### PR TITLE
Add rename_embedded_ids.py script that updates `@RG SM:{id}` values

### DIFF
--- a/scripts/rename_embedded_ids.py
+++ b/scripts/rename_embedded_ids.py
@@ -52,9 +52,15 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         print(__doc__)
 
+    old_urls = []
     for arg in sys.argv[1:]:
         field = arg.split(',')
         if len(field) >= 3:
             reheader_cram(field[0], field[1], field[2])
         else:
             reheader_cram(field[0], 'CPG[0-9]*', field[1])
+        old_urls.append(field[0])
+        old_urls.append(f'{field[0]}.crai')
+
+    logger.info(f'Check output, then manually remove {len(old_urls)} outdated files:')
+    logger.info(f'gcloud storage rm {" ".join(old_urls)}')

--- a/scripts/rename_embedded_ids.py
+++ b/scripts/rename_embedded_ids.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Copies CRAM files and associated .crai index files to URLs based on new IDs,
+also replacing SM:{id} values on the CRAM files' @RG header lines.
+Each command-line argument is
+
+    OLDURL[,OLDID],NEWID
+
+If OLDID is not specified, a pattern matching /CPGdd...dd/ is used instead
+to match CPG-style IDs in the URL and @RG SM fields.
+
+This script should usually be run via analysis-runner. It requires an image
+that contains samtools.
+"""
+
+import logging
+import re
+import subprocess
+import sys
+
+logger = logging.getLogger(__file__)
+logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
+logger.setLevel(logging.INFO)
+
+
+def reheader_cram(old_url: str, old_id: str, new_id: str):
+    """
+    Rewrites @RG headers to include SM:{new_id} and writes the resulting CRAM output
+    to {old_url} with ids within the URL similarly replaced by {new_id}. Also writes
+    a corresponding .crai index file alongside the CRAM output.
+    """
+    new_url = re.sub(old_id, new_id, old_url)
+    if new_url == old_url:
+        raise ValueError(f'Existing url {old_url} does not contain {old_id}')
+
+    # Because we're streaming we don't use in-place reheadering so we need to regenerate
+    # the .crai index file, not just copy it. Do this via process substitution so we don't
+    # need to reread the CRAM data from the bucket.
+    new_index_url = f'{new_url}.crai'
+    command = f"""
+        gcloud storage cat {old_url!r} |
+        samtools reheader --no-PG -c 'sed /^@RG/s/SM:{old_id}/SM:{new_id}/g' /dev/stdin |
+        tee >(samtools index -o - - | gcloud storage cp - {new_index_url!r}) |
+        gcloud storage cp - {new_url!r}
+        """
+    logger.info(command.replace('\n', ' '))
+    subprocess.run(command, shell=True, executable='/bin/bash', check=True)
+    logger.info(f'Rewrote {old_url} to {new_url}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(__doc__)
+
+    for arg in sys.argv[1:]:
+        field = arg.split(',')
+        if len(field) >= 3:
+            reheader_cram(field[0], field[1], field[2])
+        else:
+            reheader_cram(field[0], 'CPG[0-9]*', field[1])


### PR DESCRIPTION
Add a fairly simpleminded script that reads CRAM files from a `gs://…` URL, applies `samtools reheader` to update the `@RG SM:{id}` headers as instructed, and writes the CRAM file and associated index file back to new `gs://…` URLs constructed from the old one by updating the `{id}` similarly.

Fortunately the samtools bug I ran into (samtools/samtools#1866) only affects CRAM v2.1 files, which were superseded by v3.0 in 2015 so we surely don't have any — so this streaming method will work after all. (It was just bad luck that I grabbed one when I was testing this locally!)

It's invoked as
```
Copies CRAM files and associated .crai index files to URLs based on new IDs,
also replacing SM:{id} values on the CRAM files' @RG header lines.
Each command-line argument is

    OLDURL[,OLDID],NEWID

If OLDID is not specified, a pattern matching /CPGdd...dd/ is used instead
to match CPG-style IDs in the URL and @RG SM fields.

This script should usually be run via analysis-runner. It requires an image
that contains samtools.
```

