### PR TITLE
Return SG IDs from get sg_ids endpoint, not sample IDs

### DIFF
--- a/db/python/tables/participant.py
+++ b/db/python/tables/participant.py
@@ -298,11 +298,11 @@ RETURNING id
         self, project: ProjectId, sequencing_type: str | None = None
     ) -> list[tuple[str, int]]:
         """
-        Get a map of {external_participant_id} -> {internal_sample_id}
-        useful to matching joint-called samples in the matrix table to the participant
+        Get a map of {external_participant_id} -> {internal_sequencing_group_id}
+        useful to match joint-called sequencing groups in the matrix table to the participant
 
         Return a list not dictionary, because dict could lose
-        participants with multiple samples.
+        participants with multiple sequencing groups.
         """
         wheres = ['p.project = :project']
         values: dict[str, Any] = {'project': project}
@@ -311,7 +311,7 @@ RETURNING id
             values['sequencing_type'] = sequencing_type
 
         _query = f"""
-SELECT p.external_id, s.id
+SELECT p.external_id, sg.id
 FROM participant p
 INNER JOIN sample s ON p.id = s.participant_id
 INNER JOIN sequencing_group sg ON sg.sample_id = s.id


### PR DESCRIPTION
Following the sequencing groups migration, there was a degree of synchronisation between each sample ID and sequencing group ID, they tended to only differ by the checksum value because they used different offset values, but internally the ID was the same. 

However, in more recent ingestions, the sequencing group IDs and the sample IDs have diverged and no longer align, so this query has been causing issues when retrieving the `participant_external_id : sequencing_group_id` mapping since it was returning `sample_ids` instead.