### PR TITLE
setup-gcloud@v1 needs a separate gga/auth action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,11 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: "gcloud auth"
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.GCP_SERVER_DEPLOY_KEY }}'
+
       - name: "gcloud setup"
         uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: sample-metadata
-          service_account_key: ${{ secrets.GCP_SERVER_DEPLOY_KEY }}
 
       - name: "gcloud docker auth"
         run: |


### PR DESCRIPTION
Moving from v0 to v1 in PR #520 removed the deprecated `service_account_key` option, which appears to have [broken things](https://github.com/populationgenomics/sample-metadata/actions/runs/6217894869/job/16873576573):

```
Warning: Unexpected input(s) 'service_account_key', valid inputs are ['skip_install', 'version', 'project_id', 'install_components']
Run google-github-actions/setup-gcloud@v1
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/0cab5d55-ed4d-4507-a4f2-d5285f49ee1c -f /home/runner/work/_temp/8df5102a-6ced-44a0-9f29-c8279d945214
Warning: No authentication found for gcloud, authenticate with `google-github-actions/auth`.
Successfully set default project
```

Oops!

Apparently we need to recode using a separate `google-github-actions/auth` action step. This PR does that [using service-account-key-json](https://github.com/google-github-actions/auth#authenticating-via-service-account-key-json), however it's possible that the secret is no longer in the format expected by this new option and will need to be updated.

Alternatively we could revert to `google-github-actions/setup-gcloud@v0`, though that will likely eventually cause problems.