### PR TITLE
Pinning boto3/botocore versions 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 # requirements are for running the server
+# fix boto3/core version to prevent pip downloading all the versions caused by cloudpathlib
+boto3==1.28.56
+botocore==1.31.56
 cpg-utils
 aiohttp
 async_lru


### PR DESCRIPTION
Pinning boto3/botocore versions to prevent downloading all the boto3 versions when installing cloudpathlib.
This is going to prevent env build to run over 20 mins and eventually run out of space.