### PR TITLE
Update seqr sync options with new SV ES Index sync type

### DIFF
--- a/api/routes/web.py
+++ b/api/routes/web.py
@@ -90,7 +90,9 @@ async def search_by_keyword(keyword: str, connection=get_projectless_db_connecti
     return SearchResponseModel(responses=responses)
 
 
-@router.post('/{project}/{sequencing_type}/sync-dataset', operation_id='syncSeqrProject')
+@router.post(
+    '/{project}/{sequencing_type}/sync-dataset', operation_id='syncSeqrProject'
+)
 async def sync_seqr_project(
     sequencing_type: str,
     sync_families: bool = True,
@@ -99,6 +101,7 @@ async def sync_seqr_project(
     sync_es_index: bool = True,
     sync_saved_variants: bool = True,
     sync_cram_map: bool = True,
+    sync_sv_es_index: bool = True,
     post_slack_notification: bool = True,
     connection=get_project_write_connection,
 ):
@@ -115,6 +118,7 @@ async def sync_seqr_project(
             sync_es_index=sync_es_index,
             sync_saved_variants=sync_saved_variants,
             sync_cram_map=sync_cram_map,
+            sync_sv_es_index=sync_sv_es_index,
             post_slack_notification=post_slack_notification,
         )
         return {'success': 'errors' not in data, **data}

--- a/web/src/pages/project/SeqrSync.tsx
+++ b/web/src/pages/project/SeqrSync.tsx
@@ -16,6 +16,7 @@ interface SeqrSyncFormOptions {
     syncEsIndex?: boolean
     syncSavedVariants?: boolean
     syncCramMap?: boolean
+    syncSvEsIndex?: boolean
     postSlackNotification?: boolean
 }
 
@@ -32,6 +33,7 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
         syncEsIndex: true,
         syncSavedVariants: true,
         syncCramMap: true,
+        syncSvEsIndex: true,
         postSlackNotification: true,
     })
 
@@ -51,6 +53,7 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
                 syncOptions.syncEsIndex,
                 syncOptions.syncEsIndex, // tie syncSavedVariants, to syncing es-index
                 syncOptions.syncCramMap,
+                syncOptions.syncSvEsIndex,
                 syncOptions.postSlackNotification
             )
             .then((resp) => {
@@ -127,6 +130,12 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
                             checked={syncOptions.syncCramMap}
                             onChange={updateStateFromForm}
                             label="Sync CRAMs"
+                        />
+                        <Form.Checkbox
+                            id="syncSvEsIndex"
+                            checked={syncOptions.syncSvEsIndex}
+                            onChange={updateStateFromForm}
+                            label="Sync SV elastic-search index"
                         />
                         <br />
                         <Form.Checkbox


### PR DESCRIPTION
Changing the ES-Index sync behaviour to account for new types of indices.

Finding the latest ES-Index will now filter analyses by the meta field `'stage'` to differentiate the types of indices stored. Filtering for SV indices will also change the `datasetType` field in the POST to seqr, as this field must be `'SV'` for SV indices.

The code that writes the `{sg_id : participant_eid}` tsv mapping file has been moved into its own function, and the result will be cached so it can be reused when syncing multiple types of es-index.

WebUI has been updated as well with a new checkbox to sync the latest SV ES-Index.