### PR TITLE
Auditor filter analyses

### DIFF
--- a/metamist/audit/generic_auditor.py
+++ b/metamist/audit/generic_auditor.py
@@ -10,9 +10,9 @@ from metamist.graphql import query_async, gql
 
 ANALYSIS_TYPES_QUERY = gql(
     """
-    query seqTypes {
+    query analysisTypes {
         enum {
-            sequencingType
+            analysisType
         }
     }
     """

--- a/metamist/audit/generic_auditor.py
+++ b/metamist/audit/generic_auditor.py
@@ -72,6 +72,7 @@ AssayReportEntry = namedtuple(
     'sg_id assay_id assay_file_path analysis_id filesize',
 )
 
+
 @cache
 async def get_analysis_types():
     """Return the list of analysis types from the enum table."""

--- a/metamist/audit/generic_auditor.py
+++ b/metamist/audit/generic_auditor.py
@@ -17,17 +17,6 @@ ANALYSIS_TYPES_QUERY = gql(
     }
     """
 )
-ANALYSIS_TYPES = [
-    'QC',
-    'JOINT-CALLING',
-    'GVCF',
-    'CRAM',
-    'CUSTOM',
-    'ES-INDEX',
-    'SV',
-    'WEB',
-    'ANALYSIS-RUNNER',
-]
 
 QUERY_PARTICIPANTS_SAMPLES_SGS_ASSAYS = gql(
     """

--- a/test/test_generic_auditor.py
+++ b/test/test_generic_auditor.py
@@ -537,7 +537,25 @@ class TestGenericAuditor(unittest.TestCase):
             'CPGaaa',
         ]
 
-        mock_query.return_value = {
+        mock_analysis_types_query_result = {
+            'enum': {
+                'analysisType': [
+                    'analysis-runner',
+                    'cram',
+                    'custom',
+                    'es-index',
+                    'gvcf',
+                    'joint-calling',
+                    'mito-cram',
+                    'mito_cram',
+                    'qc',
+                    'sv',
+                    'web',
+                ]
+            }
+        }
+
+        mock_sg_analyses_query_result = {
             'sequencingGroups': [
                 {
                     'id': 'CPGaaa',
@@ -553,6 +571,11 @@ class TestGenericAuditor(unittest.TestCase):
                 }
             ]
         }
+
+        mock_query.side_effect = [
+            mock_analysis_types_query_result,
+            mock_sg_analyses_query_result,
+        ]
 
         with self.assertLogs(level='WARNING') as log:
             # catch the warning logs from here and check below


### PR DESCRIPTION
Not sure if I've set these PR's up correctly but this builds on #572, filtering the analyses returned based on their project so that analysis runner submissions for a specific dataset don't break if they find an analysis outside of that dataset.

Also replaces the fixed analysis types with a query to the enum table.