### PR TITLE
Fix group-member-missing-check

### DIFF
--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -551,14 +551,15 @@ class GroupTable:
             return set()
 
         _query = """
-            SELECT g.group_id
+            SELECT gm.group_id as gid
             FROM group_member gm
-            WHERE gm.member = member AND gm.group_id IN :group_ids
+            WHERE gm.member = :member AND gm.group_id IN :group_ids
         """
-        membered_group_ids = await self.connection.fetch_all(
+        results = await self.connection.fetch_all(
             _query, {'group_ids': group_ids, 'member': member}
         )
-        return set(group_ids) - set(membered_group_ids)
+        membered_group_ids = set(r['gid'] for r in results)
+        return set(group_ids) - membered_group_ids
 
     async def create_group(self, name: str) -> int:
         """Create a new group"""

--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -551,7 +551,7 @@ class GroupTable:
         Check which groups a member has
         """
         if self.allow_full_access:
-            return set()
+            return group_ids
 
         _query = """
             SELECT gm.group_id as gid

--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -559,7 +559,7 @@ class GroupTable:
             _query, {'group_ids': group_ids, 'member': member}
         )
         membered_group_ids = set(r['gid'] for r in results)
-        return set(group_ids) - membered_group_ids
+        return group_ids - membered_group_ids
 
     async def create_group(self, name: str) -> int:
         """Create a new group"""

--- a/test/test_project_groups.py
+++ b/test/test_project_groups.py
@@ -101,7 +101,7 @@ class TestGroupAccess(DbIsolatedTest):
         group = str(uuid.uuid4())
         gid = await self.pttable.gtable.create_group(group)
         missing_gids = await self.pttable.gtable.check_which_groups_member_is_missing(
-            [gid], self.author
+            {gid}, self.author
         )
 
         self.assertEqual(1, len(missing_gids))
@@ -116,7 +116,7 @@ class TestGroupAccess(DbIsolatedTest):
         gid = await self.pttable.gtable.create_group(group)
         await self.pttable.gtable.set_group_members(gid, [self.author], self.author)
         missing_gids = await self.pttable.gtable.check_which_groups_member_is_missing(
-            [gid], self.author
+            {gid}, self.author
         )
 
         self.assertEqual(0, len(missing_gids))

--- a/test/test_project_groups.py
+++ b/test/test_project_groups.py
@@ -95,29 +95,30 @@ class TestGroupAccess(DbIsolatedTest):
 
     @run_as_sync
     async def test_check_which_groups_member_is_missing(self):
-        """Test the check_which_groups_member_is_missing function"""
+        """Test the check_which_groups_member_has function"""
         await self._add_group_member_direct(GROUP_NAME_MEMBERS_ADMIN)
 
         group = str(uuid.uuid4())
         gid = await self.pttable.gtable.create_group(group)
-        missing_gids = await self.pttable.gtable.check_which_groups_member_is_missing(
+        present_gids = await self.pttable.gtable.check_which_groups_member_has(
             {gid}, self.author
         )
-
+        missing_gids = {gid} - present_gids
         self.assertEqual(1, len(missing_gids))
         self.assertEqual(gid, missing_gids.pop())
 
     @run_as_sync
     async def test_check_which_groups_member_is_missing_none(self):
-        """Test the check_which_groups_member_is_missing function"""
+        """Test the check_which_groups_member_has function"""
         await self._add_group_member_direct(GROUP_NAME_MEMBERS_ADMIN)
 
         group = str(uuid.uuid4())
         gid = await self.pttable.gtable.create_group(group)
         await self.pttable.gtable.set_group_members(gid, [self.author], self.author)
-        missing_gids = await self.pttable.gtable.check_which_groups_member_is_missing(
+        present_gids = await self.pttable.gtable.check_which_groups_member_has(
             {gid}, self.author
         )
+        missing_gids = {gid} - present_gids
 
         self.assertEqual(0, len(missing_gids))
 

--- a/test/test_project_groups.py
+++ b/test/test_project_groups.py
@@ -94,6 +94,34 @@ class TestGroupAccess(DbIsolatedTest):
         )
 
     @run_as_sync
+    async def test_check_which_groups_member_is_missing(self):
+        """Test the check_which_groups_member_is_missing function"""
+        await self._add_group_member_direct(GROUP_NAME_MEMBERS_ADMIN)
+
+        group = str(uuid.uuid4())
+        gid = await self.pttable.gtable.create_group(group)
+        missing_gids = await self.pttable.gtable.check_which_groups_member_is_missing(
+            [gid], self.author
+        )
+
+        self.assertEqual(1, len(missing_gids))
+        self.assertEqual(gid, missing_gids.pop())
+
+    @run_as_sync
+    async def test_check_which_groups_member_is_missing_none(self):
+        """Test the check_which_groups_member_is_missing function"""
+        await self._add_group_member_direct(GROUP_NAME_MEMBERS_ADMIN)
+
+        group = str(uuid.uuid4())
+        gid = await self.pttable.gtable.create_group(group)
+        await self.pttable.gtable.set_group_members(gid, [self.author], self.author)
+        missing_gids = await self.pttable.gtable.check_which_groups_member_is_missing(
+            [gid], self.author
+        )
+
+        self.assertEqual(0, len(missing_gids))
+
+    @run_as_sync
     async def test_project_creators_failed(self):
         """
         Test that a user without permission cannot create a project


### PR DESCRIPTION
This method should definitely have been tested, codecov would probably have caught it.
Would be awesome to have some way to annotate a function to require it to be completely tested.