### PR TITLE
Update sequencing group 'project:' filter to parse names, not ids

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -633,15 +633,11 @@ class Query:
         # we list project names, but internally we want project ids
         project_id_map = {}
         if project:
-            print(project)
             project_names = project.all_values()
-            print(project_names)
             projects = await ptable.get_and_check_access_to_projects_for_names(
                 user=connection.author, project_names=project_names, readonly=True
             )
-            print(projects)
             project_id_map = {p.name: p.id for p in projects}
-            print(project_id_map)
 
         filter_ = SequencingGroupFilter(
             project=project.to_internal_filter(lambda val: project_id_map[val])

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -589,9 +589,9 @@ class Query:
 
         project_name_map: dict[str, int] = {}
         if project:
-            project_ids = project.all_values()
-            projects = await ptable.get_and_check_access_to_projects_for_ids(
-                user=connection.author, project_ids=project_ids, readonly=True
+            project_names = project.all_values()
+            projects = await ptable.get_and_check_access_to_projects_for_names(
+                user=connection.author, project_names=project_names, readonly=True
             )
             project_name_map = {p.name: p.id for p in projects}
 

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -633,11 +633,15 @@ class Query:
         # we list project names, but internally we want project ids
         project_id_map = {}
         if project:
-            project_ids = project.all_values()
-            projects = await ptable.get_and_check_access_to_projects_for_ids(
-                user=connection.author, project_ids=project_ids, readonly=True
+            print(project)
+            project_names = project.all_values()
+            print(project_names)
+            projects = await ptable.get_and_check_access_to_projects_for_names(
+                user=connection.author, project_names=project_names, readonly=True
             )
+            print(projects)
             project_id_map = {p.name: p.id for p in projects}
+            print(project_id_map)
 
         filter_ = SequencingGroupFilter(
             project=project.to_internal_filter(lambda val: project_id_map[val])

--- a/test/test_graphql.py
+++ b/test/test_graphql.py
@@ -209,7 +209,7 @@ query MyQuery($project: String!) {
 
         q = """
 query MyQuery($sg_id: String!, $project: String!) {
-  sequencingGroups(id: {in_: [$sg_id]}) {
+  sequencingGroups(id: {in_: [$sg_id]}, project: {eq: $project}) {
     analyses(project: {eq: $project}) {
       id
       meta


### PR DESCRIPTION
Having some issues with my queries because the GraphQL `project:` filter seems to be expecting project IDs, however it only accepts string input so I can't get it to parse anything. I tried these changes in dev environment and they got my queries working again, however I'm not sure if this might impact anything else.

Understand there were a lot of changes to the project table recently, the speed improvements have been amazing 🏎️
