### PR TITLE
Extended bq looks back time to 300 days as we do not have much data loaded in dev table

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -40,7 +40,7 @@ SEQUENCING_GROUP_CHECKSUM_OFFSET = int(os.getenv('SM_SEQUENCINGGROUPCHECKOFFSET'
 BQ_GCP_BILLING_PROJECT = os.getenv('SM_GCP_BILLING_PROJECT')
 # This is to optimise BQ queries, DEV table has data only for Mar 2023
 # TODO change to 7 days or similar before merging into DEV
-BQ_DAYS_BACK_OPTIMAL = 210
+BQ_DAYS_BACK_OPTIMAL = 300
 BILLING_CACHE_RESPONSE_TTL = 1800  # 30 minutes
 
 


### PR DESCRIPTION
This "BQ_DAYS_BACK_OPTIMAL" settings is there to minimise cost of BQ queries, once we go to production it can be changed to something like 7 or 30 days, there is no point look for all projects/topics in more than that.
For our development we have data for March loaded.