### PR TITLE
Getting gcp_project data from gcp_billing view instead of aggregate v…

### DIFF
--- a/api/routes/billing.py
+++ b/api/routes/billing.py
@@ -235,7 +235,8 @@ async def get_total_cost(
             "fields": ["topic"],
             "start_date": "2023-03-01",
             "end_date": "2023-03-31",
-            "order_by": {"cost": true}
+            "order_by": {"cost": true},
+            "source": "aggregate"
         }
 
     2. Get total cost by day and topic for March 2023, order by day ASC and topic DESC:
@@ -320,6 +321,16 @@ async def get_total_cost(
             "order_by": {"cost": true}
         }
 
+    10. Get total gcp_project for month of March 2023, ordered by cost DESC:
+
+        {
+            "fields": ["gcp_project"],
+            "start_date": "2023-03-01",
+            "end_date": "2023-03-31",
+            "order_by": {"cost": true},
+            "source": "gcp_billing"
+        }
+
     """
 
     connection = BqConnection(author)
@@ -337,11 +348,12 @@ async def get_total_cost(
 async def get_running_costs(
     field: BillingColumn,
     invoice_month: str | None = None,
+    source: str | None = None,
     author: str = get_author,
 ) -> list[BillingCostBudgetRecord]:
     """
     Get running cost for specified fields in database
-    e.g. fields = ['dataset', 'project', 'topic']
+    e.g. fields = ['gcp_project', 'topic']
     """
 
     # TODO replace alru_cache with async-cache?
@@ -351,5 +363,5 @@ async def get_running_costs(
 
     connection = BqConnection(author)
     billing_layer = BillingLayer(connection)
-    records = await billing_layer.get_running_cost(field, invoice_month)
+    records = await billing_layer.get_running_cost(field, invoice_month, source)
     return records

--- a/api/settings.py
+++ b/api/settings.py
@@ -41,6 +41,7 @@ BQ_AGGREG_VIEW = os.getenv('SM_GCP_BQ_AGGREG_VIEW')
 BQ_AGGREG_RAW = os.getenv('SM_GCP_BQ_AGGREG_RAW')
 BQ_AGGREG_EXT_VIEW = os.getenv('SM_GCP_BQ_AGGREG_EXT_VIEW')
 BQ_BUDGET_VIEW = os.getenv('SM_GCP_BQ_BUDGET_VIEW')
+BQ_GCP_BILLING_VIEW = os.getenv('SM_GCP_BQ_BILLING_VIEW')
 
 # This is to optimise BQ queries, DEV table has data only for Mar 2023
 BQ_DAYS_BACK_OPTIMAL = 30   # Look back 30 days for optimal query

--- a/models/models/billing.py
+++ b/models/models/billing.py
@@ -171,6 +171,8 @@ class BillingTotalCostQueryModel(SMBase):
     fields: list[BillingColumn]
     start_date: str
     end_date: str
+    # optional, can be aggregate or gcp_billing
+    source: str | None = None
 
     # optional
     filters: dict[BillingColumn, str] | None = None
@@ -189,6 +191,7 @@ class BillingTotalCostRecord(SMBase):
 
     day: datetime.date | None
     topic: str | None
+    gcp_project: str | None
     cost_category: str | None
     sku: str | None
     ar_guid: str | None
@@ -208,6 +211,7 @@ class BillingTotalCostRecord(SMBase):
         return BillingTotalCostRecord(
             day=record.get('day'),
             topic=record.get('topic'),
+            gcp_project=record.get('gcp_project'),
             cost_category=record.get('cost_category'),
             sku=record.get('sku'),
             ar_guid=record.get('ar_guid'),

--- a/web/src/pages/billing/BillingCostByTime.tsx
+++ b/web/src/pages/billing/BillingCostByTime.tsx
@@ -180,12 +180,17 @@ const BillingCostByTime: React.FunctionComponent = () => {
     // on first load
     React.useEffect(() => {
         if (selectedData !== undefined && selectedData !== '' && selectedData !== null) {
+            let source = 'aggregate'
+            if (groupBy === BillingColumn.GcpProject) {
+                source = 'gcp_billing'
+            }
             if (selectedData.startsWith('All ')) {
                 getData({
                     fields: [BillingColumn.Day, BillingColumn.CostCategory],
                     start_date: start,
                     end_date: end,
                     order_by: { day: false },
+                    source: source,
                 })
             } else {
                 getData({
@@ -194,6 +199,7 @@ const BillingCostByTime: React.FunctionComponent = () => {
                     end_date: end,
                     filters: { [groupBy.replace('-', '_').toLowerCase()]: selectedData },
                     order_by: { day: false },
+                    source: source,
                 })
             }
         }

--- a/web/src/pages/billing/BillingInvoiceMonthCost.tsx
+++ b/web/src/pages/billing/BillingInvoiceMonthCost.tsx
@@ -59,8 +59,12 @@ const BillingCurrentCost = () => {
         updateNav(groupBy, invoiceMth)
         setIsLoading(true)
         setError(undefined)
+        let source = 'aggregate'
+        if (grp === BillingColumn.GcpProject) {
+            source = 'gcp_billing'
+        }
         new BillingApi()
-            .getRunningCost(grp, invoiceMth)
+            .getRunningCost(grp, invoiceMth, source)
             .then((response) => {
                 setIsLoading(false)
                 setCosts(response.data)


### PR DESCRIPTION
SM_GCP_BQ_BILLING_VIEW is the new env variable.
There is a bit of challenge to create materialised view on top of gcp_billing_export.
Partition can only be the same as the base table or its subset, we want to use different field, so I am keeping the existing part_time field in the view, partition by it, so when we run query we add extra filter based on part_time.
As well part_time is off by 4-5 days, basically when GCP load data there is a few days delay so I had hardcoded to be 7 days.