### PR TITLE
Create md5s script

### DIFF
--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -54,10 +54,7 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
     job.command(
         f"""\
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
-    spaces='  '
-    md5_command="printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5"
-    eval $md5_command
+    gsutil cat {file} | md5sum | cut -d " " -f1  > /tmp/uploaded.md5"
     gsutil cp /tmp/uploaded.md5 {md5}
     """
     )

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -43,7 +43,8 @@ def validate_all_objects_in_directory(gs_dir):
 
 def create_md5(job: hb.batch.job, file) -> hb.batch.job:
     """
-    Streams the file with gsutil and calculates the md5 checksum, 
+    Streams the file with gsutil and calculates the md5 checksum,
+    then uploads the checksum to the same path as filename.md5.
     """
 
     # Calculate md5 checksum.
@@ -55,7 +56,8 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
     spaces='  '
-    printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5
+    md5_command="printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5"
+    eval $md5_command
     gsutil cp /tmp/uploaded.md5 {md5}
     """
     )

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -6,7 +6,7 @@ from cpg_utils.hail_batch import get_config, remote_tmpdir, copy_common_env
 import hailtop.batch as hb
 from google.cloud import storage
 
-DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:8cc869505251c8396fefef01c42225a7b7930a97-hail-0.2.73.devc6f6f09cec08'
+DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest'
 
 
 def validate_all_objects_in_directory(gs_dir):
@@ -35,7 +35,7 @@ def validate_all_objects_in_directory(gs_dir):
 
         job = b.new_job(f'validate_{os.path.basename(obj)}')
         copy_common_env(job)
-        job.image('ubuntu:22.04')
+        job.image(DRIVER_IMAGE)
         create_md5(job, obj)
 
     b.run(wait=False)
@@ -48,6 +48,7 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
 
     # Calculate md5 checksum.
     md5 = f'{file}.md5'
+    job.command('set -euxo pipefail')
     job.env('GOOGLE_APPLICATION_CREDENTIALS', '/gsa-key/key.json')
     job.command(
         f"""\

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -54,7 +54,7 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
         f"""\
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
-    md5_command="echo '${{md5_hash}}  {file}' > /tmp/uploaded.md5"
+    md5_command="printf '%s  %s' '${{md5_hash}}' '{os.path.basename(file)}' > /tmp/uploaded.md5"
     eval $md5_command
     gsutil cp /tmp/uploaded.md5 {md5}
     """

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -8,17 +8,17 @@ from google.cloud import storage
 DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest'
 
 
-def create_md5s_for_files_in_directory(skip_filetypes: list[str], billing_project: str | None, gs_dir):
+def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], billing_project: str | None, gs_dir):
     """Validate files with MD5s in the provided gs directory"""
     b = get_batch(f'Create md5 checksums for files in {gs_dir}')
-    
+
     if not gs_dir.startswith('gs://'):
         raise ValueError(f'Expected GS directory, got: {gs_dir}')
 
     config = get_config()
     if not billing_project:
         billing_project = config['hail']['billing_project']
-    
+
     bucket_name, *components = gs_dir[5:].split('/')
 
     client = storage.Client()
@@ -58,13 +58,13 @@ def create_md5(job, file, billing_project=None):
 
 
 @click.command()
-@click.option('--skip-filetypes', '-s', default=['.crai', '.tbi'], multiple=True)
+@click.option('--skip-filetypes', '-s', default=('.crai', '.tbi'), multiple=True)
 @click.option('--billing-project', '-b', help='Billing project to use for gsutil cp, required for requester pays buckets')
 @click.argument('gs_dir')
-def main(skip_filetypes: list[str], billing_project: str | None, gs_dir: str):
+def main(skip_filetypes: tuple[str, str], billing_project: str | None, gs_dir: str):
     """Scans the directory for files and creates md5 checksums for them."""
     create_md5s_for_files_in_directory(skip_filetypes, billing_project, gs_dir=gs_dir)
-    
+
 
 if __name__ == '__main__':
     # pylint: disable=no-value-for-parameter

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -55,7 +55,7 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
     spaces='  '
-    printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5"
+    printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5
     gsutil cp /tmp/uploaded.md5 {md5}
     """
     )

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -2,7 +2,7 @@ import os
 from typing import Set
 
 import click
-from cpg_utils.hail_batch import get_batch, copy_common_env
+from cpg_utils.hail_batch import get_batch, get_config, copy_common_env
 from google.cloud import storage
 
 DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest'
@@ -15,6 +15,10 @@ def create_md5s_for_files_in_directory(skip_filetypes: list[str], gs_dir):
     if not gs_dir.startswith('gs://'):
         raise ValueError(f'Expected GS directory, got: {gs_dir}')
 
+    config = get_config()
+    if not billing_project:
+        billing_project = config['hail']['billing_project']
+    
     bucket_name, *components = gs_dir[5:].split('/')
 
     client = storage.Client()
@@ -29,12 +33,12 @@ def create_md5s_for_files_in_directory(skip_filetypes: list[str], gs_dir):
         job = b.new_job(f'Create {os.path.basename(obj)}.md5')
         copy_common_env(job)
         job.image(DRIVER_IMAGE)
-        create_md5(job, obj)
+        create_md5(job, obj, billing_project)
 
     b.run(wait=False)
 
 
-def create_md5(job, file):
+def create_md5(job, file, billing_project=None):
     """
     Streams the file with gsutil and calculates the md5 checksum,
     then uploads the checksum to the same path as filename.md5.
@@ -46,7 +50,7 @@ def create_md5(job, file):
         f"""\
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     gsutil cat {file} | md5sum | cut -d " " -f1  > /tmp/uploaded.md5
-    gsutil cp /tmp/uploaded.md5 {md5}
+    gsutil -u {billing_project} cp /tmp/uploaded.md5 {md5}
     """
     )
 
@@ -55,10 +59,11 @@ def create_md5(job, file):
 
 @click.command()
 @click.option('--skip-filetypes', '-s', default=['.crai', '.tbi'], multiple=True)
+@click.option('--billing-project', '-b', help='Billing project to use for gsutil cp, required for requester pays buckets')
 @click.argument('gs_dir')
-def main(skip_filetypes: tuple[str, str], gs_dir):
+def main(skip_filetypes: tuple[str, str], billing_project: str, gs_dir: str):
     """Scans the directory for files and creates md5 checksums for them."""
-    create_md5s_for_files_in_directory(skip_filetypes, gs_dir=gs_dir)
+    create_md5s_for_files_in_directory(skip_filetypes, billing_project, gs_dir=gs_dir)
     
 
 if __name__ == '__main__':

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -16,7 +16,7 @@ def validate_all_objects_in_directory(gs_dir):
         billing_project=get_config()['hail']['billing_project'],
         remote_tmpdir=remote_tmpdir()
     )
-    b = hb.Batch('validate_md5s', backend=backend)
+    b = hb.Batch(f'Create md5 checksums for files in {gs_dir}', backend=backend)
     client = storage.Client()
 
     if not gs_dir.startswith('gs://'):
@@ -54,7 +54,7 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
         f"""\
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
-    md5_command="printf '%s  %s' '${{md5_hash}}' '{os.path.basename(file)}' > /tmp/uploaded.md5"
+    md5_command="spaces='  '; printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5"
     eval $md5_command
     gsutil cp /tmp/uploaded.md5 {md5}
     """

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -54,7 +54,7 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
     job.command(
         f"""\
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    gsutil cat {file} | md5sum | cut -d " " -f1  > /tmp/uploaded.md5"
+    gsutil cat {file} | md5sum | cut -d " " -f1  > /tmp/uploaded.md5
     gsutil cp /tmp/uploaded.md5 {md5}
     """
     )

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -1,14 +1,11 @@
 import os
-from typing import Set
 
 import click
 from cpg_utils.hail_batch import get_batch, get_config, copy_common_env
 from google.cloud import storage
 
-DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest'
 
-
-def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], gs_dir):
+def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], force_recreate: bool, gs_dir):
     """Validate files with MD5s in the provided gs directory"""
     b = get_batch(f'Create md5 checksums for files in {gs_dir}')
 
@@ -16,36 +13,38 @@ def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], gs_dir):
         raise ValueError(f'Expected GS directory, got: {gs_dir}')
 
     billing_project = get_config()['hail']['billing_project']
+    driver_image = get_config()['workflow']['driver_image']
 
     bucket_name, *components = gs_dir[5:].split('/')
 
     client = storage.Client()
     blobs = client.list_blobs(bucket_name, prefix='/'.join(components))
-    files: Set[str] = {f'gs://{bucket_name}/{blob.name}' for blob in blobs}
+    files: set[str] = {f'gs://{bucket_name}/{blob.name}' for blob in blobs}
     for obj in files:
         if obj.endswith('.md5') or obj.endswith(skip_filetypes):
             continue
-        if f'{obj}.md5' not in files:
-            print('Creating md5 for', obj)
+        if f'{obj}.md5' in files and not force_recreate:
+            print(f'{obj}.md5 already exists, skipping')
+            continue
 
+        print('Creating md5 for', obj)
         job = b.new_job(f'Create {os.path.basename(obj)}.md5')
-        copy_common_env(job)
-        job.image(DRIVER_IMAGE)
-        create_md5(job, obj, billing_project)
+        create_md5(job, obj, billing_project, driver_image)
 
     b.run(wait=False)
 
 
-def create_md5(job, file, billing_project):
+def create_md5(job, file, billing_project, driver_image):
     """
     Streams the file with gsutil and calculates the md5 checksum,
     then uploads the checksum to the same path as filename.md5.
     """
+    copy_common_env(job)
+    job.image(driver_image)
     md5 = f'{file}.md5'
-    job.command('set -euxo pipefail')
-    job.env('GOOGLE_APPLICATION_CREDENTIALS', '/gsa-key/key.json')
     job.command(
         f"""\
+    set -euxo pipefail
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     gsutil cat {file} | md5sum | cut -d " " -f1  > /tmp/uploaded.md5
     gsutil -u {billing_project} cp /tmp/uploaded.md5 {md5}
@@ -57,10 +56,11 @@ def create_md5(job, file, billing_project):
 
 @click.command()
 @click.option('--skip-filetypes', '-s', default=('.crai', '.tbi'), multiple=True)
+@click.option('--force-recreate', '-f', is_flag=True, default=False)
 @click.argument('gs_dir')
-def main(skip_filetypes: tuple[str, str], gs_dir: str):
+def main(skip_filetypes: tuple[str, str], force_recreate: bool, gs_dir: str):
     """Scans the directory for files and creates md5 checksums for them."""
-    create_md5s_for_files_in_directory(skip_filetypes, gs_dir=gs_dir)
+    create_md5s_for_files_in_directory(skip_filetypes, force_recreate, gs_dir=gs_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -8,7 +8,7 @@ from google.cloud import storage
 DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest'
 
 
-def create_md5s_for_files_in_directory(skip_filetypes: list[str], gs_dir):
+def create_md5s_for_files_in_directory(skip_filetypes: list[str], billing_project: str | None, gs_dir):
     """Validate files with MD5s in the provided gs directory"""
     b = get_batch(f'Create md5 checksums for files in {gs_dir}')
     

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -54,8 +54,8 @@ def create_md5(job: hb.batch.job, file) -> hb.batch.job:
         f"""\
     gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
-    md5_command="spaces='  '; printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5"
-    eval $md5_command
+    spaces='  '
+    printf '%s%s%s' '${{md5_hash}}' \"${{spaces}}\" '{os.path.basename(file)}' > /tmp/uploaded.md5"
     gsutil cp /tmp/uploaded.md5 {md5}
     """
     )

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -1,0 +1,74 @@
+import os
+from typing import Set
+
+import click
+from cpg_utils.hail_batch import get_config, remote_tmpdir, copy_common_env
+import hailtop.batch as hb
+from google.cloud import storage
+
+DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:8cc869505251c8396fefef01c42225a7b7930a97-hail-0.2.73.devc6f6f09cec08'
+
+
+def validate_all_objects_in_directory(gs_dir):
+    """Validate files with MD5s in the provided gs directory"""
+    
+    backend = hb.ServiceBackend(
+        billing_project=get_config()['hail']['billing_project'],
+        remote_tmpdir=remote_tmpdir()
+    )
+    b = hb.Batch('validate_md5s', backend=backend)
+    client = storage.Client()
+
+    if not gs_dir.startswith('gs://'):
+        raise ValueError(f'Expected GS directory, got: {gs_dir}')
+
+    bucket_name, *components = gs_dir[5:].split('/')
+
+    blobs = client.list_blobs(bucket_name, prefix='/'.join(components))
+    files: Set[str] = {f'gs://{bucket_name}/{blob.name}' for blob in blobs}
+    for obj in files:
+        if obj.endswith('.md5'):
+            continue
+        if f'{obj}.md5' not in files:
+            #continue
+            print('No md5 for', obj)
+
+        job = b.new_job(f'validate_{os.path.basename(obj)}')
+        copy_common_env(job)
+        job.image('ubuntu:22.04')
+        create_md5(job, obj)
+
+    b.run(wait=False)
+
+
+def create_md5(job: hb.batch.job, file) -> hb.batch.job:
+    """
+    Streams the file with gsutil and calculates the md5 checksum, 
+    """
+
+    # Calculate md5 checksum.
+    md5 = f'{file}.md5'
+    job.env('GOOGLE_APPLICATION_CREDENTIALS', '/gsa-key/key.json')
+    job.command(
+        f"""\
+    gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+    md5_hash=$(gsutil cat {file} | md5sum | cut -d " " -f1) 
+    md5_command="echo '${{md5_hash}}  {file}' > /tmp/uploaded.md5"
+    eval $md5_command
+    gsutil cp /tmp/uploaded.md5 {md5}
+    """
+    )
+
+    return job
+
+
+@click.command()
+@click.argument('gs_dir')
+def main(gs_dir):
+    """Main from CLI"""
+    validate_all_objects_in_directory(gs_dir=gs_dir)
+
+
+if __name__ == '__main__':
+    # pylint: disable=no-value-for-parameter
+    main()

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -8,16 +8,14 @@ from google.cloud import storage
 DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest'
 
 
-def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], billing_project: str | None, gs_dir):
+def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], gs_dir):
     """Validate files with MD5s in the provided gs directory"""
     b = get_batch(f'Create md5 checksums for files in {gs_dir}')
 
     if not gs_dir.startswith('gs://'):
         raise ValueError(f'Expected GS directory, got: {gs_dir}')
 
-    config = get_config()
-    if not billing_project:
-        billing_project = config['hail']['billing_project']
+    billing_project = get_config()['hail']['billing_project']
 
     bucket_name, *components = gs_dir[5:].split('/')
 
@@ -38,7 +36,7 @@ def create_md5s_for_files_in_directory(skip_filetypes: tuple[str, str], billing_
     b.run(wait=False)
 
 
-def create_md5(job, file, billing_project=None):
+def create_md5(job, file, billing_project):
     """
     Streams the file with gsutil and calculates the md5 checksum,
     then uploads the checksum to the same path as filename.md5.
@@ -59,11 +57,10 @@ def create_md5(job, file, billing_project=None):
 
 @click.command()
 @click.option('--skip-filetypes', '-s', default=('.crai', '.tbi'), multiple=True)
-@click.option('--billing-project', '-b', help='Billing project to use for gsutil cp, required for requester pays buckets')
 @click.argument('gs_dir')
-def main(skip_filetypes: tuple[str, str], billing_project: str | None, gs_dir: str):
+def main(skip_filetypes: tuple[str, str], gs_dir: str):
     """Scans the directory for files and creates md5 checksums for them."""
-    create_md5s_for_files_in_directory(skip_filetypes, billing_project, gs_dir=gs_dir)
+    create_md5s_for_files_in_directory(skip_filetypes, gs_dir=gs_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/create_md5s.py
+++ b/scripts/create_md5s.py
@@ -61,7 +61,7 @@ def create_md5(job, file, billing_project=None):
 @click.option('--skip-filetypes', '-s', default=['.crai', '.tbi'], multiple=True)
 @click.option('--billing-project', '-b', help='Billing project to use for gsutil cp, required for requester pays buckets')
 @click.argument('gs_dir')
-def main(skip_filetypes: tuple[str, str], billing_project: str, gs_dir: str):
+def main(skip_filetypes: list[str], billing_project: str | None, gs_dir: str):
     """Scans the directory for files and creates md5 checksums for them."""
     create_md5s_for_files_in_directory(skip_filetypes, billing_project, gs_dir=gs_dir)
     


### PR DESCRIPTION
Iterates through a gs directory and creates .md5 checksum files for each file in the directory. Useful for composite objects since GCP does not provide md5 checksums for these by default. Skips `.crai` and `.tbi` files as this will mostly be used on directories containing CRAM / gVCFs and their indexes - and the latter do not need checksums. 