### PR TITLE
Bump pre-commit versions for the new year

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
         exclude: '\.*conda/.*'
@@ -14,13 +14,13 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.38.0
     hooks:
       - id: markdownlint
         args: ["--config", ".markdownlint.json"]
 
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 23.12.1
     hooks:
       - id: black
         args: [.]
@@ -29,7 +29,7 @@ repos:
         exclude: ^metamist/
 
   - repo: https://github.com/PyCQA/flake8
-    rev: "6.0.0"
+    rev: "6.1.0"
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear, flake8-quotes]
@@ -45,7 +45,7 @@ repos:
 
   # mypy
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         args: [


### PR DESCRIPTION
We should add isort soon, maybe after the billing PR + audit log to avoid lots of conflicts