### PR TITLE
Refactor to allow local settings for generating test data

### DIFF
--- a/api/utils/db.py
+++ b/api/utils/db.py
@@ -53,7 +53,7 @@ def authenticate(
             x_goog_iap_jwt_assertion, audience=EXPECTED_AUDIENCE
         )
 
-    if token:
+    if token and (getenv('SM_ENVIRONMENT').lower() != 'local'):
         return email_from_id_token(token.credentials)
 
     if default_user := get_default_user():

--- a/metamist/graphql/__init__.py
+++ b/metamist/graphql/__init__.py
@@ -147,7 +147,8 @@ async def query_async(
         variables = {}
 
     if not client:
-        client = await configure_async_client()
+        env = os.getenv('SM_ENVIRONMENT')
+        client = await configure_async_client(auth_token="FAKE" if env == 'local' else None)
 
     response = await client.execute_async(
         _query if isinstance(_query, DocumentNode) else gql(_query),


### PR DESCRIPTION
Just done slight refactoring where needed to get the `test/data/generate_data.py` code working. Running as is according to `README.md` was raising GCPClient errors so I had to supply `"FAKE"` auth token in a config to all types of `Api` instances. Original functionality should still be maintained :)