### PR TITLE
Squash GQL Transport Logs

### DIFF
--- a/metamist/graphql/__init__.py
+++ b/metamist/graphql/__init__.py
@@ -5,7 +5,7 @@ GraphQL utilities for Metamist, allows you to:
     - validate queries with metamist schema (by fetching the schema)
 """
 import os
-from typing import Dict, Any, Bool
+from typing import Dict, Any
 
 from gql import Client, gql as gql_constructor
 from gql.transport.aiohttp import AIOHTTPTransport
@@ -138,7 +138,7 @@ def validate(doc: DocumentNode, client=None, use_local_schema=False):
 
 # use older style typing to broaden supported Python versions
 def query(
-    _query: str | DocumentNode, variables: Dict = None, client: Client = None, log_response: Bool = False
+    _query: str | DocumentNode, variables: Dict = None, client: Client = None, log_response: bool = False
 ) -> Dict[str, Any]:
     """Query the metamist GraphQL API"""
     if variables is None:
@@ -160,7 +160,7 @@ def query(
 
 
 async def query_async(
-    _query: str | DocumentNode, variables: Dict = None, client: Client = None, log_response: Bool = False
+    _query: str | DocumentNode, variables: Dict = None, client: Client = None, log_response: bool = False
 ) -> Dict[str, Any]:
     """Asynchronously query the Metamist GraphQL API"""
     if variables is None:


### PR DESCRIPTION
## Description
This addresses #540 and allows suppressing `gql` logging to a less verbose level  of `WARNING` instead of `INFO`.

## Changes Made
- As per @MattWellie 's suggestion, introduced a `log_response` argument to `query` and `query_async`  methods in `metamist/graphql/__init__.py`,  that can be toggled to set the level to `WARNING` jut for that query execution before setting it to the original level.

## Notes
- I was not able to replicate this locally despite trialing with the `logger` from `gql.transport.[requests | aiohttp]` and the `logging` libraries. Would be nice to test this somehow to see if it works as expected. This should maintain the same functionality as @MattWellie 's fix in theory. 

## Closes
- [x] Closes #540 
