### PR TITLE
Replaced json with orjson for large size loads

### DIFF
--- a/db/python/layers/web.py
+++ b/db/python/layers/web.py
@@ -1,10 +1,11 @@
 # pylint: disable=too-many-locals, too-many-instance-attributes
 import asyncio
 import itertools
-import json
 import re
 from collections import defaultdict
 from datetime import date
+
+import orjson
 
 from api.utils import group_by
 from db.python.layers.base import BaseLayer
@@ -15,15 +16,10 @@ from db.python.tables.assay import AssayTable
 from db.python.tables.base import DbBase
 from db.python.tables.project import ProjectPermissionsTable
 from db.python.tables.sequencing_group import SequencingGroupTable
-from models.models import (
-    AssayInternal,
-    FamilySimpleInternal,
-    NestedParticipantInternal,
-    NestedSampleInternal,
-    NestedSequencingGroupInternal,
-    SearchItem,
-    parse_sql_bool,
-)
+from models.models import (AssayInternal, FamilySimpleInternal,
+                           NestedParticipantInternal, NestedSampleInternal,
+                           NestedSequencingGroupInternal, SearchItem,
+                           parse_sql_bool)
 from models.models.web import ProjectSummaryInternal, WebProject
 
 
@@ -109,7 +105,7 @@ class WebDb(DbBase):
             AssayInternal(
                 id=seq['id'],
                 type=seq['type'],
-                meta=json.loads(seq['meta']),
+                meta=orjson.loads(seq['meta']),  # pylint: disable=maybe-no-member
                 sample_id=seq['sample_id'],
             )
             for seq in assay_rows
@@ -148,7 +144,7 @@ class WebDb(DbBase):
             sg_id_to_sample_id[sg_id] = row['sample_id']
             sg_by_id[sg_id] = NestedSequencingGroupInternal(
                 id=sg_id,
-                meta=json.loads(row['meta']),
+                meta=orjson.loads(row['meta']),  # pylint: disable=maybe-no-member
                 type=row['type'],
                 technology=row['technology'],
                 platform=row['platform'],
@@ -186,7 +182,7 @@ class WebDb(DbBase):
                 id=s['id'],
                 external_id=s['external_id'],
                 type=s['type'],
-                meta=json.loads(s['meta']) or {},
+                meta=orjson.loads(s['meta']) or {},  # pylint: disable=maybe-no-member
                 created_date=str(sample_id_start_times.get(s['id'], '')),
                 sequencing_groups=sg_models_by_sample_id.get(s['id'], []),
                 non_sequencing_assays=filtered_assay_models_by_sid.get(s['id'], []),
@@ -443,7 +439,7 @@ WHERE fp.participant_id in :pids
                     NestedParticipantInternal(
                         id=p['id'],
                         external_id=p['external_id'],
-                        meta=json.loads(p['meta']),
+                        meta=orjson.loads(p['meta']),  # pylint: disable=maybe-no-member
                         families=pid_to_families.get(p['id'], []),
                         samples=list(smodels_by_pid.get(p['id'])),
                         reported_sex=p['reported_sex'],

--- a/db/python/layers/web.py
+++ b/db/python/layers/web.py
@@ -16,10 +16,15 @@ from db.python.tables.assay import AssayTable
 from db.python.tables.base import DbBase
 from db.python.tables.project import ProjectPermissionsTable
 from db.python.tables.sequencing_group import SequencingGroupTable
-from models.models import (AssayInternal, FamilySimpleInternal,
-                           NestedParticipantInternal, NestedSampleInternal,
-                           NestedSequencingGroupInternal, SearchItem,
-                           parse_sql_bool)
+from models.models import (
+    AssayInternal,
+    FamilySimpleInternal,
+    NestedParticipantInternal,
+    NestedSampleInternal,
+    NestedSequencingGroupInternal,
+    SearchItem,
+    parse_sql_bool,
+)
 from models.models.web import ProjectSummaryInternal, WebProject
 
 

--- a/models/models/analysis.py
+++ b/models/models/analysis.py
@@ -1,9 +1,9 @@
 import enum
-import json
 from datetime import date, datetime
 from typing import Any
 
 from pydantic import BaseModel
+import orjson
 
 from models.base import SMBase
 from models.enums import AnalysisStatus
@@ -38,7 +38,7 @@ class AnalysisInternal(SMBase):
         meta = kwargs.get('meta')
 
         if meta and isinstance(meta, str):
-            meta = json.loads(meta)
+            meta = orjson.loads(meta)  # pylint: disable=maybe-no-member
 
         if timestamp_completed and isinstance(timestamp_completed, str):
             timestamp_completed = datetime.fromisoformat(timestamp_completed)

--- a/models/models/assay.py
+++ b/models/models/assay.py
@@ -1,5 +1,6 @@
-import json
 from typing import Any
+
+import orjson
 
 from models.base import OpenApiGenNoneType, SMBase
 from models.utils.sample_id_format import sample_id_format, sample_id_transform_to_raw
@@ -31,7 +32,7 @@ class AssayInternal(SMBase):
             if isinstance(meta, bytes):
                 meta = meta.decode()
             if isinstance(meta, str):
-                meta = json.loads(meta)
+                meta = orjson.loads(meta)  # pylint: disable=maybe-no-member
         return AssayInternal(meta=meta, **d)
 
     def to_external(self):

--- a/models/models/audit_log.py
+++ b/models/models/audit_log.py
@@ -1,5 +1,6 @@
 import datetime
-import json
+
+import orjson
 
 from models.base import SMBase
 from models.models.project import ProjectId
@@ -26,6 +27,6 @@ class AuditLogInternal(SMBase):
         """Take DB mapping object, and return SampleSequencing"""
         meta = {}
         if 'meta' in d:
-            meta = json.loads(d.pop('meta'))
+            meta = orjson.loads(d.pop('meta'))  # pylint: disable=maybe-no-member
 
         return AuditLogInternal(meta=meta, **d)

--- a/models/models/participant.py
+++ b/models/models/participant.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from models.base import OpenApiGenNoneType, SMBase
 from models.models.family import FamilySimple, FamilySimpleInternal
@@ -28,7 +28,7 @@ class ParticipantInternal(SMBase):
     def from_db(cls, data: dict):
         """Convert from db keys, mainly converting parsing meta"""
         if 'meta' in data and isinstance(data['meta'], str):
-            data['meta'] = json.loads(data['meta'])
+            data['meta'] = orjson.loads(data['meta'])  # pylint: disable=maybe-no-member
 
         return ParticipantInternal(**data)
 

--- a/models/models/project.py
+++ b/models/models/project.py
@@ -1,5 +1,6 @@
-import json
 from typing import Optional
+
+import orjson
 
 from models.base import SMBase
 
@@ -20,5 +21,5 @@ class Project(SMBase):
     def from_db(kwargs):
         """From DB row, with db keys"""
         kwargs = dict(kwargs)
-        kwargs['meta'] = json.loads(kwargs['meta']) if kwargs.get('meta') else {}
+        kwargs['meta'] = orjson.loads(kwargs['meta']) if kwargs.get('meta') else {}  # pylint: disable=maybe-no-member
         return Project(**kwargs)

--- a/models/models/sample.py
+++ b/models/models/sample.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from models.base import OpenApiGenNoneType, SMBase, parse_sql_bool
 from models.models.assay import Assay, AssayInternal, AssayUpsert, AssayUpsertInternal
@@ -37,7 +37,7 @@ class SampleInternal(SMBase):
             if isinstance(meta, bytes):
                 meta = meta.decode()
             if isinstance(meta, str):
-                meta = json.loads(meta)
+                meta = orjson.loads(meta)  # pylint: disable=maybe-no-member
 
         return SampleInternal(id=_id, type=str(type_), meta=meta, active=active, **d)
 

--- a/models/models/sequencing_group.py
+++ b/models/models/sequencing_group.py
@@ -1,4 +1,4 @@
-import json
+import orjson
 
 from models.base import OpenApiGenNoneType, SMBase
 from models.models.assay import Assay, AssayInternal, AssayUpsert, AssayUpsertInternal
@@ -49,7 +49,7 @@ class SequencingGroupInternal(SMBase):
         """From database model"""
         meta = kwargs.pop('meta')
         if meta and isinstance(meta, str):
-            meta = json.loads(meta)
+            meta = orjson.loads(meta)  # pylint: disable=maybe-no-member
 
         _archived = kwargs.pop('archived', None)
         if _archived is not None:

--- a/openapi-templates/api_client.mustache
+++ b/openapi-templates/api_client.mustache
@@ -1,6 +1,6 @@
 {{>partial_header}}
 
-import json
+import orjson
 import atexit
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -333,7 +333,7 @@ class ApiClient(object):
 
         # fetch data from response object
         try:
-            received_data = json.loads(response.data)
+            received_data = orjson.loads(response.data)  # pylint: disable=maybe-no-member
         except ValueError:
             received_data = response.data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ SQLAlchemy==1.4.41
 cryptography>=41.0.0
 python-dateutil==2.8.2
 slack-sdk==3.20.2
+orjson==3.9.12

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         # for get id-token
         'cpg-utils >= 4.9.4',
         'gql[aiohttp,requests]',
+        'orjson==3.9.12',
     ],
     entry_points={
         'metamist_parser': [


### PR DESCRIPTION
## Description
This is based off #658 which proposes to switch to `orjson` in place of the standard `json` library, for deserialising values that might be large. This switch should offer a significant cut in loading times, without introducing any code complexity.

## Changes Made
- Replaced `json.loads` calls with `orjson.loads` where deemed appropriate. This replacement has not been done on low-impact calls that deserialise small objects.

## Notes
- We should probably use `orjson` when introducing any new features/fixes that involving deserialising of large objects.

## Closes
- [x] Closes #658  
