### PR TITLE
Billing Enums & Filter fixes

### DIFF
--- a/api/routes/billing.py
+++ b/api/routes/billing.py
@@ -7,11 +7,11 @@ from fastapi import APIRouter
 from api.settings import BILLING_CACHE_RESPONSE_TTL, BQ_AGGREG_VIEW
 from api.utils.db import BqConnection, get_author
 from db.python.layers.billing import BillingLayer
+from models.enums import BillingSource
 from models.models import (
     BillingColumn,
     BillingCostBudgetRecord,
     BillingHailBatchCostRecord,
-    BillingSource,
     BillingTotalCostQueryModel,
     BillingTotalCostRecord,
 )

--- a/db/python/layers/billing.py
+++ b/db/python/layers/billing.py
@@ -4,13 +4,11 @@ from db.python.tables.bq.billing_daily import BillingDailyTable
 from db.python.tables.bq.billing_daily_extended import BillingDailyExtendedTable
 from db.python.tables.bq.billing_gcp_daily import BillingGcpDailyTable
 from db.python.tables.bq.billing_raw import BillingRawTable
+from models.enums import BillingSource, BillingTimeColumn, BillingTimePeriods
 from models.models import (
     BillingColumn,
     BillingCostBudgetRecord,
     BillingHailBatchCostRecord,
-    BillingSource,
-    BillingTimeColumn,
-    BillingTimePeriods,
     BillingTotalCostQueryModel,
 )
 

--- a/db/python/tables/bq/billing_base.py
+++ b/db/python/tables/bq/billing_base.py
@@ -12,11 +12,11 @@ from db.python.gcp_connect import BqDbBase
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.function_bq_filter import FunctionBQFilter
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
+from models.enums import BillingTimePeriods
 from models.models import (
     BillingColumn,
     BillingCostBudgetRecord,
     BillingCostDetailsRecord,
-    BillingTimePeriods,
     BillingTotalCostQueryModel,
 )
 

--- a/db/python/tables/bq/billing_gcp_daily.py
+++ b/db/python/tables/bq/billing_gcp_daily.py
@@ -42,6 +42,15 @@ class BillingGcpDailyTable(BillingBaseTable):
             if query.end_date
             else None,
         )
+        # add day filter after partition filter is applied
+        billing_filter.day = GenericBQFilter[datetime](
+            gte=datetime.strptime(query.start_date, '%Y-%m-%d')
+            if query.start_date
+            else None,
+            lte=datetime.strptime(query.end_date, '%Y-%m-%d')
+            if query.end_date
+            else None,
+        )
         return billing_filter
 
     async def _last_loaded_day(self):

--- a/models/enums/__init__.py
+++ b/models/enums/__init__.py
@@ -1,3 +1,4 @@
 from models.enums.analysis import AnalysisStatus
+from models.enums.billing import BillingSource, BillingTimeColumn, BillingTimePeriods
 from models.enums.search import SearchResponseType
 from models.enums.web import MetaSearchEntityPrefix

--- a/models/models/__init__.py
+++ b/models/models/__init__.py
@@ -17,9 +17,6 @@ from models.models.billing import (
     BillingCostDetailsRecord,
     BillingHailBatchCostRecord,
     BillingInternal,
-    BillingSource,
-    BillingTimeColumn,
-    BillingTimePeriods,
     BillingTotalCostQueryModel,
     BillingTotalCostRecord,
 )


### PR DESCRIPTION
When we refactor Billing models and extracted Billing enums to enum folder, the imports were not updated. 
When running locally it was still working properly. A bit of annoying as linting did not report this as an issue either.
Bug only discovered when deployed to production.

The other fix is related to showing more than selected days on the chart. Issue is related to the way gcp billing records are digested and partitioned. GCP BQ table is partition by datetime it was loaded, however we need to display data based on usage_end_time, which could be off by a few days. To address it two filters needs to be used (one for usage_end_time and one for _PARTITIONTIME) when selecting from gcp table.