### PR TITLE
Bumping to actions to latest versions that use Node 20.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,13 +16,13 @@ jobs:
       run:
         shell: bash -eo pipefail -l {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: "temurin" # See 'Supported distributions' for available options
           java-version: "17"


### PR DESCRIPTION
# Description
Node 16.x has reached end of life, and some of the actions are now deprecated. Just bumping them here.

## Changes
Bumped all `actions` to the latest release. 

## Reference
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 