### PR TITLE
Small typescript fixes for Safari browser.

### DIFF
--- a/web/src/pages/billing/BillingInvoiceMonthCost.tsx
+++ b/web/src/pages/billing/BillingInvoiceMonthCost.tsx
@@ -169,7 +169,7 @@ const BillingCurrentCost = () => {
         const year = invoiceMonth.substring(0, 4)
         const month = invoiceMonth.substring(4, 6)
         let nextYear = year
-        let nextMonth = (parseInt(month, 10) + 1).toString()
+        let nextMonth = (parseInt(month, 10) + 1).toString().padStart(2, '0')
         if (month === '12') {
             nextYear = (parseInt(year, 10) + 1).toString()
             nextMonth = '01'

--- a/web/src/shared/components/Graphs/DonutChart.tsx
+++ b/web/src/shared/components/Graphs/DonutChart.tsx
@@ -79,14 +79,15 @@ export const DonutChart: React.FC<IDonutChartProps> = ({ data, maxSlices, colors
     const margin = 15
     const radius = Math.min(width, height) / 2 - margin
 
-    // keep order of the slices
+    // keep order of the slices, declare custom sort function to keep order of slices as passed in
+    // by default pie function starts from index 1 and sorts by value
     const pieFnc = pie()
         .value((d) => d.value)
         .sort((a) => {
             if (typeof a === 'object' && a.type === 'inc') {
                 return 1
             }
-            return -1
+            return 0    // works both on Safari and Firefox, any other value will break one of them
         })
     const data_ready = pieFnc(data)
     const innerRadius = radius / 1.75 // inner radius of pie, in pixels (non-zero for donut)


### PR DESCRIPTION
This two small changes are fixing billing GUI for Safari Browser, originally developed and tested on Firefox.

1. It is interesting how Firefox can parse '2024-2-21' as date, however Safari fails on it and requires leading 0 for the month.

2. D3 pie function requires custom compare function to keep the order and index of passed series, returning 0 (equal) works on both Firefox and Safari, original -1 recommended on various stackoverflow blog posts seems to work only on Firefox. 