### PR TITLE
Add script to clear test project metadata from Metamist

### DIFF
--- a/scripts/clear_project_test_metadata.py
+++ b/scripts/clear_project_test_metadata.py
@@ -1,10 +1,22 @@
-from metamist.apis import ProjectApi
 import click
+
+from metamist.apis import ProjectApi
 
 
 @click.command()
 @click.option('--project', required=True, help='Project to delete data from')
 def main(project: str):
+    """
+    Deletes all data from a specified project in Metamist.
+
+    This function uses the Metamist API to delete all data associated with a given project.
+
+    Args:
+        project (str): The name of the project from which to delete data.
+
+    Returns:
+        None
+    """
     papi = ProjectApi()
 
     # Delete Project Data
@@ -14,4 +26,5 @@ def main(project: str):
 
 
 if __name__ == '__main__':
+    # pylint: disable=no-value-for-parameter
     main()

--- a/scripts/clear_project_test_metadata.py
+++ b/scripts/clear_project_test_metadata.py
@@ -1,0 +1,17 @@
+from metamist.apis import ProjectApi
+import click
+
+
+@click.command()
+@click.option('--project', required=True, help='Project to delete data from')
+def main(project: str):
+    papi = ProjectApi()
+
+    # Delete Project Data
+    papi_response = papi.delete_project_data(project=project)
+
+    print(papi_response)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit introduces a new script that uses the ProjectApi to delete all data from a specified project. It does not delete the project itself, just the data within it. 

If users run in to permission issues with deleting data from a test project, then this script is available.