### PR TITLE
Fix Existing Cohort Parser Sequencing Type Param

### DIFF
--- a/scripts/parse_existing_cohort.py
+++ b/scripts/parse_existing_cohort.py
@@ -240,7 +240,7 @@ async def main(
     project: str,
     search_locations: List[str],
     batch_number: Optional[str],
-    sequencing_type:str,
+    sequencing_type: str,
     confirm=True,
     dry_run=False,
     include_participant_column=False,

--- a/scripts/parse_existing_cohort.py
+++ b/scripts/parse_existing_cohort.py
@@ -216,6 +216,7 @@ class ExistingCohortParser(GenericMetadataParser):
     '--sequencing-type',
     type=click.Choice(['genome', 'exome']),
     help='Sequencing type: genome or exome',
+    default='genome',
 )
 @click.option('--search-location', 'search_locations', multiple=True)
 @click.option(
@@ -239,11 +240,11 @@ async def main(
     project: str,
     search_locations: List[str],
     batch_number: Optional[str],
+    sequencing_type:str,
     confirm=True,
     dry_run=False,
     include_participant_column=False,
     allow_missing_files=False,
-    sequencing_type: str = 'genome',
 ):
     """Run script from CLI arguments"""
 


### PR DESCRIPTION
 When running the EC parser without a default sequencing type specified the following error was produced 
```
   File "/Users/.../lib/python3.11/site-packages/metamist/parser/generic_metadata_parser.py", line 200, in get_sequencing_type
    value = value.lower()
            ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```

Despite the default value being set in the function declaration. It appears that Click was overwriting this value and setting it to None. 

This PR sets the default value within the click param, resolving the issue. 
