### PR TITLE
Updated database backup script

### DIFF
--- a/db/backup/backup.py
+++ b/db/backup/backup.py
@@ -1,9 +1,10 @@
-#!/usr/bin/python3.7
+#!/usr/bin/python3
 # pylint: disable=broad-exception-caught,broad-exception-raised
 """ Daily back up function for databases within a local
 MariaDB instance """
 
 import json
+import os
 import subprocess
 from datetime import datetime
 from typing import Literal
@@ -50,7 +51,7 @@ def perform_backup():
     tmp_dir = f'backup_{timestamp_str}'
     subprocess.run(['mkdir', tmp_dir], check=True)
     # grant permissions, so that mariadb can read ib_logfile0
-    subprocess.run(['sudo', 'chmod', '-R', '777', tmp_dir], check=True)
+    subprocess.run(['sudo', 'chmod', '-R', '770', tmp_dir], check=True)
 
     credentials = read_db_credentials()
     db_username = credentials['username']
@@ -66,10 +67,11 @@ def perform_backup():
                 '--backup',
                 f'--target-dir={tmp_dir}/',
                 f'--user={db_username}',
-                f'-p{db_password}',
             ],
             check=True,
             stderr=subprocess.DEVNULL,
+            # pass the password with stdin to avoid it being visible in the process list
+            env={'MYSQL_PWD': db_password, **os.environ},
         )
 
     except subprocess.CalledProcessError as e:
@@ -83,7 +85,7 @@ def perform_backup():
 
     # mariabackup creates awkward permissions for the output files,
     # so we'll grant appropriate permissions for tmp_dir to later remove it
-    subprocess.run(['sudo', 'chmod', '-R', '777', tmp_dir], check=True)
+    subprocess.run(['sudo', 'chmod', '-R', '770', tmp_dir], check=True)
 
     # tar the archive to make it easier to upload to GCS
     tar_archive_path = f'{tmp_dir}.tar.gz'


### PR DESCRIPTION
## Description
After a recent database upgrade, we have reviewed the process we use to execute the daily backups. This newer version of the program ensures we are not logging the password in plaintext when an error is logged. 

## Changes Made
- Pass the user's password via environment variable to the subprocess.
- Set 770 permissions on the file so that only the owner/group can read/write/execute the script instead of allowing it to everyone.