### PR TITLE
Update es-index types for seqr sync API and UI

### DIFF
--- a/api/routes/web.py
+++ b/api/routes/web.py
@@ -102,6 +102,7 @@ async def search_by_keyword(keyword: str, connection=get_projectless_db_connecti
 )
 async def sync_seqr_project(
     sequencing_type: str,
+    es_index_type: str,
     sync_families: bool = True,
     sync_individual_metadata: bool = True,
     sync_individuals: bool = True,
@@ -113,6 +114,7 @@ async def sync_seqr_project(
 ):
     """
     Sync a metamist project with its seqr project (for a specific sequence type)
+    es_index_types: Haplotypecaller, SV_Caller, Mitochondria_Caller
     """
     seqr = SeqrLayer(connection)
     try:
@@ -122,6 +124,7 @@ async def sync_seqr_project(
             sync_individual_metadata=sync_individual_metadata,
             sync_individuals=sync_individuals,
             sync_es_index=sync_es_index,
+            es_index_type=es_index_type,
             sync_saved_variants=sync_saved_variants,
             sync_cram_map=sync_cram_map,
             post_slack_notification=post_slack_notification,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "metamist",
-    "version": "6.4.0",
+    "version": "6.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "metamist",
-            "version": "6.4.0",
+            "version": "6.8.0",
             "dependencies": {
                 "@apollo/client": "^3.7.3",
                 "@artsy/fresnel": "^6.2.1",

--- a/web/src/pages/project/SeqrSync.tsx
+++ b/web/src/pages/project/SeqrSync.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import _ from 'lodash'
-import { Button, CheckboxProps, Form, Message, Modal } from 'semantic-ui-react'
+import { Button, CheckboxProps, DropdownProps, Form, Message, Modal } from 'semantic-ui-react'
 import { WebApi } from '../../sm-api'
 import MuckTheDuck from '../../shared/components/MuckTheDuck'
 
@@ -14,6 +14,7 @@ interface SeqrSyncFormOptions {
     syncIndividualMetadata?: boolean
     syncIndividuals?: boolean
     syncEsIndex?: boolean
+    esIndexType: string
     syncSavedVariants?: boolean
     syncCramMap?: boolean
     postSlackNotification?: boolean
@@ -30,6 +31,7 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
         syncIndividualMetadata: true,
         syncIndividuals: true,
         syncEsIndex: true,
+        esIndexType: 'Haplotypecaller',
         syncSavedVariants: true,
         syncCramMap: true,
         postSlackNotification: true,
@@ -45,6 +47,7 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
             .syncSeqrProject(
                 seqType,
                 project,
+                syncOptions.esIndexType,
                 syncOptions.syncFamilies,
                 syncOptions.syncIndividualMetadata,
                 syncOptions.syncIndividuals,
@@ -73,8 +76,18 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
             })
     }
 
-    const updateStateFromForm = (e: React.FormEvent<HTMLInputElement>, data: CheckboxProps) =>
-        setSyncOptions({ ...syncOptions, [data.id || '']: data.checked })
+    const updateStateFromCheckbox = (e: React.FormEvent<HTMLInputElement>, data: CheckboxProps) => {
+        const value = data.checked
+        setSyncOptions({ ...syncOptions, [data.id || '']: value })
+    }
+
+    const updateStateFromDropdown = (
+        e: React.SyntheticEvent<HTMLElement, Event>,
+        data: DropdownProps
+    ) => {
+        const value = (data as any).value
+        setSyncOptions({ ...syncOptions, [data.id || '']: value })
+    }
 
     return (
         <>
@@ -101,38 +114,57 @@ const SeqrSync: React.FunctionComponent<SeqrSyncProps> = ({ syncTypes, project }
                         <Form.Checkbox
                             id="syncIndividuals"
                             checked={syncOptions.syncIndividuals}
-                            onChange={updateStateFromForm}
+                            onChange={updateStateFromCheckbox}
                             label="Sync pedigree"
                         />
                         <Form.Checkbox
                             id="syncFamilies"
                             checked={syncOptions.syncFamilies}
-                            onChange={updateStateFromForm}
+                            onChange={updateStateFromCheckbox}
                             label="Sync families"
                         />
                         <Form.Checkbox
                             id="syncIndividualMetadata"
                             checked={syncOptions.syncIndividualMetadata}
-                            onChange={updateStateFromForm}
+                            onChange={updateStateFromCheckbox}
                             label="Sync individuals metadata"
                         />
                         <Form.Checkbox
                             id="syncEsIndex"
                             checked={syncOptions.syncEsIndex}
-                            onChange={updateStateFromForm}
+                            onChange={updateStateFromCheckbox}
                             label="Sync elastic-search index"
+                        />
+                        <Form.Dropdown
+                            id="esIndexType"
+                            options={[
+                                {
+                                    key: 'Haplotypecaller',
+                                    text: 'Haplotypecaller',
+                                    value: 'Haplotypecaller',
+                                },
+                                { key: 'SV_Caller', text: 'SV_Caller', value: 'SV_Caller' },
+                                {
+                                    key: 'Mitochondria_Caller',
+                                    text: 'Mitochondria_Caller',
+                                    value: 'Mitochondria_Caller',
+                                },
+                            ]}
+                            value={syncOptions.esIndexType}
+                            onChange={updateStateFromDropdown}
+                            label="ES index type"
                         />
                         <Form.Checkbox
                             id="syncCramMap"
                             checked={syncOptions.syncCramMap}
-                            onChange={updateStateFromForm}
+                            onChange={updateStateFromCheckbox}
                             label="Sync CRAMs"
                         />
                         <br />
                         <Form.Checkbox
                             id="postSlackNotification"
                             checked={syncOptions.postSlackNotification}
-                            onChange={updateStateFromForm}
+                            onChange={updateStateFromCheckbox}
                             label="Post slack notification"
                         />
 


### PR DESCRIPTION
This PR updates the seqr syncing layer to allow for input of an ES-Index "Type". This is useful since we are now creating multiple types of ES-Indexes in metamist analysis records, with analysis type `es-index`. Additionally, In a recent seqr update, the [`datasetType` option for SNV (Haplotypecaller) ES-Indexes was updated](https://github.com/populationgenomics/seqr/blob/main/ui/shared/utils/constants.js#L114). It was previously `"VARIANTS"` and has been updated to `"SNV_INDEL"`. 

The `web` API endpoint has been updated to allow entering a string field for ES-Index type. The available options are from those [displayed by the seqr UI](https://github.com/populationgenomics/seqr/blob/main/ui/pages/Project/components/EditDatasetsButton.jsx#L67). `"Haplotypecaller"` for `"SNV_Indel"` indexes, `"SV_Caller"` for `"SV"` indexes, and `"Mitochondria_Caller"` for `"Mito"` indexes.

To find the latest index for each type in Metamist, we can search for analyses and filter by the `"stage"` field in the analysis `meta`. 
```
SNV_INDEX:  "meta": {"stage": "MtToEs"    }
SV_INDEX:   "meta": {"stage": "MtToEsSv"  }
MITO_INDEX: "meta": {"stage": "MtToEsMito"}  # currently not supported
```
This is done by updating the `AnalysisFilter` passed to the analysis layer query in the `seqr.py` layer with the `"stage"` label corresponding to the input ES-Index type. The types are mapped like above using dictionary mappings added to `layers/seqr.py`
```python
DATASET_TYPE_SNV_INDEL_CALLS = 'SNV_INDEL'
DATASET_TYPE_SV_CALLS = 'SV'
DATASET_TYPE_MITO_CALLS = 'MITO'

ES_INDEX_DATASET_TYPES = {
    'Haplotypecaller': DATASET_TYPE_SNV_INDEL_CALLS,
    'SV_Caller': DATASET_TYPE_SV_CALLS,
    'Mitochondria_Caller': DATASET_TYPE_MITO_CALLS,
}

ES_INDEX_STAGES = {
    DATASET_TYPE_SNV_INDEL_CALLS: 'MtToEs',
    DATASET_TYPE_SV_CALLS: 'MtToEsSv',
    DATASET_TYPE_MITO_CALLS: 'MtToEsMito',
}
...
class SeqrLayer(BaseLayer):
  ...
  async def update_es_index(project, connection, es_index_type, sequencing_type, ...):
    ...
    alayer = AnalysisLayer(connection=self.connection)
    es_index_analyses = await alayer.query(
      AnalysisFilter(
         project=GenericFilter(eq=self.connection.project),
         type=GenericFilter(eq='es-index'),
         status=GenericFilter(eq=AnalysisStatus.COMPLETED),
         meta={'sequencing_type': GenericFilter(eq=sequencing_type),
               'stage': GenericFilter(eq=ES_INDEX_STAGES[ES_INDEX_DATASET_TYPES[es_index_type]])},
         )
    )
```

The UI update adds a dropdown selection to the Seqr Sync options, to select from the ES-Index types. It also meant that the `updateStateFromForm` function had to be split into two, `updateStateFromCheckbox` to handle the existing boolean checkboxes, and a new function `updateStateFromDropdown` to handle the new string options in the drop down menu.
![image](https://github.com/populationgenomics/metamist/assets/34049565/33d129b6-200e-42b4-a73e-406b2262dfee)

<img width="179" alt="image" src="https://github.com/populationgenomics/metamist/assets/34049565/bc90d55e-4924-427b-a5ba-a70921903396">



One final change was in `web/package_lock.json`, the Metamist module was updated to 6.8.0. Not sure if this was necessary to change or commit, it was updated by the install step:
```
python regenerate_api.py \
    && pip install .
```