### PR TITLE
Avoid cloudpathlib 0.18.0, which is incompatible with google-cloud-storage 1.43

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ botocore==1.31.56
 cpg-utils
 aiohttp
 async_lru
-cloudpathlib
+# later cloudpathlib versions require a more recent google-cloud-storage
+cloudpathlib==0.17.0
 requests
 google-auth>=2.19.0
 google-cloud-secret-manager==2.8.0


### PR DESCRIPTION
Cloudpathlib 0.18.0, released today, contains the following:

```python
…
from google.cloud.storage import transfer_manager
…
```

This `import` was recently added in implementing sliced downloads in `GSClient`, a new feature in this release.

For metamist, this results in

```
INFO:__main__:API: ImportError: cannot import name 'transfer_manager' from 'google.cloud.storage' 
```

because google-cloud-storage 1.43 does not provide `transfer_manager` — presumably it is new in 2.x (the current version is 2.14.0) [— ETA: added in 2.7 or so apparently]. It's possible that the cloudpathlib authors did not intentionally break compatibility with this old google-cloud-storage version, as it's not mentioned in the release notes. Or perhaps this old version has been untested / not officially supported for a while…

We pin google-cloud-storage at 1.43, presumably for good reasons. An alternative to this PR would be to do the work to update to current google-cloud-storage. This PR takes the simpler approach (for now) of maintaining the status quo.