### PR TITLE
Etl load trials

### DIFF
--- a/etl/load/main.py
+++ b/etl/load/main.py
@@ -227,7 +227,9 @@ def etl_load(request: flask.Request):
 def process_request(
     request_id: str, delivery_attempt: int | None = None
 ) -> tuple[dict, int]:
-
+    """
+    Process request_id, delivery_attempt and return result
+    """
     # locate the request_id in bq
     query = f"""
         SELECT * FROM `{BIGQUERY_TABLE}` WHERE request_id = @request_id

--- a/etl/test/test_etl_load.py
+++ b/etl/test/test_etl_load.py
@@ -200,13 +200,15 @@ class TestEtlLoad(TestCase):
         """Test get_parser_instance success"""
 
         mock_get_accessor_config.return_value = {
-            'user@test.com': [
-                {
-                    'name': 'test/v1',
-                    'default_parameters': {},
-                    # 'parser_name': 'test',
-                }
-            ]
+            'user@test.com': {
+                'parsers': [
+                    {
+                        'name': 'test/v1',
+                        'default_parameters': {},
+                        # 'parser_name': 'test',
+                    }
+                ]
+            }
         }
 
         mock_prepare_parser_map.return_value = {
@@ -234,13 +236,15 @@ class TestEtlLoad(TestCase):
         """Test get_parser_instance success"""
 
         mock_get_accessor_config.return_value = {
-            'user@test.com': [
-                {
-                    'name': 'test/v1',
-                    'default_parameters': {'project': 'test'},
-                    'parser_name': 'different_parser/name',
-                }
-            ]
+            'user@test.com': {
+                'parsers': [
+                    {
+                        'name': 'test/v1',
+                        'default_parameters': {'project': 'test'},
+                        'parser_name': 'different_parser/name',
+                    }
+                ]
+            }
         }
 
         mock_prepare_parser_map.return_value = {
@@ -284,12 +288,14 @@ class TestEtlLoad(TestCase):
         """Test get_parser_instance success"""
 
         mock_get_accessor_config.return_value = {
-            'user@test.com': [
-                {
-                    'name': 'test/v1',
-                    'default_parameters': {'project': 'test'},
-                }
-            ]
+            'user@test.com': {
+                'parsers': [
+                    {
+                        'name': 'test/v1',
+                        'default_parameters': {'project': 'test'},
+                    }
+                ]
+            }
         }
 
         # this doesn't need to be mocked as it fails before here
@@ -316,12 +322,14 @@ class TestEtlLoad(TestCase):
         """Test get_parser_instance success"""
 
         mock_get_accessor_config.return_value = {
-            'user@test.com': [
-                {
-                    'name': 'a/b',
-                    'default_parameters': {'project': 'test'},
-                }
-            ]
+            'user@test.com': {
+                'parsers': [
+                    {
+                        'name': 'a/b',
+                        'default_parameters': {'project': 'test'},
+                    }
+                ]
+            }
         }
 
         mock_prepare_parser_map.return_value = {

--- a/metamist/parser/generic_parser.py
+++ b/metamist/parser/generic_parser.py
@@ -536,7 +536,7 @@ class GenericParser(
         """
         if not isinstance(rows, list):
             rows = [rows]
-            
+
         await self.validate_rows(rows)
 
         # one participant with no value

--- a/metamist/parser/generic_parser.py
+++ b/metamist/parser/generic_parser.py
@@ -534,6 +534,9 @@ class GenericParser(
         If no participants are present, groups samples by their IDs.
         For each sample, gets its sequencing groups by their keys. For each sequencing group, groups assays and analyses.
         """
+        if not isinstance(rows, list):
+            rows = [rows]
+            
         await self.validate_rows(rows)
 
         # one participant with no value


### PR DESCRIPTION
- Fix parser config format
- Pass row as received: [Don't pre-convert to list as a downstream convert in the BBV parser fails]
- Add a fallback to ^ in the generic_parser
- Convert from pkg_resource to importlib.metadata due to deprecation in py3.10 (we use py311 for the functions).