### PR TITLE
Load frozen metamist python api client from frozen branch

### DIFF
--- a/.github/actions/get_frozen_client/action.yaml
+++ b/.github/actions/get_frozen_client/action.yaml
@@ -1,0 +1,9 @@
+name: Get frozen OpenAPI client files
+
+runs:
+  using: composite
+  steps:
+    - name: "Copy python api files"
+      run: |
+        python scripts/get_frozen_api_files.py f0a0e546c73202e3c90f152d8861448e1f4203f4
+      shell: bash -eo pipefail -l {0}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -81,6 +81,9 @@ jobs:
             -f deploy/api/Dockerfile \
             .
 
+      - name: Get frozen client files
+        uses: ./.github/actions/get_frozen_client
+
       - name: "build deployable API"
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,6 +43,9 @@ jobs:
             -f deploy/api/Dockerfile \
             .
 
+      - name: Get frozen client files
+        uses: ./.github/actions/get_frozen_client
+
       - name: Build + install packages
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,9 @@ jobs:
             -f deploy/api/Dockerfile \
             .
 
+      - name: Get frozen client files
+        uses: ./.github/actions/get_frozen_client
+
       - name: "build deployable API"
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It comprises three key components:
    - Storing frequently used queries.
    - Providing a GraphQL/HTTP API for efficient querying of the database.
 
-3. **Installable Python Library**: Wraps the Python Web API using the OpenAPI generator, facilitating easier interaction with the system.
+3. **Installable Python Library**: Wraps the Python Web API using the OpenAPI generator, facilitating easier interaction with the system. This is deprecated and will soon be replaced with a installable python library generated from the graphql schema.
 
 ### Schema
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -347,11 +347,31 @@ You can now place breakpoints anywhere and debug the API with "Run API" under th
 
 ![Run and Debug](../resources/debug-api.png)
 
-### Generate and install the python installable API
+
+## Using OpenAPI
+
+As of March 2024 we are deprecating the generation of apis using OpenAPI due to ongoing issues with dependency and version conflicts caused by the openapi generator. As such, no changes should be made to OpenAPI routes unless absolutely necessary. A frozen version of the generated API has been stored in the `metamist-legacy-api` branch and can be downloaded as described below.
+
+### Downloading the Python installable API
+
+To get the python installable API you can run the `scripts/get_frozen_api_files.py` script:
+
+```bash
+python scripts/get_frozen_api_files.py <ref>
+```
+
+where `<ref>` is the ref that you want to download the frozen api files from, in most cases this will be the most recent commit on the `metamist-legacy-api` branch.
+
+This will fetch an archive of the frozen API and copy the necessary files into the correct locations.
+
+
+### Generate the typescript API client
+
+Despite the deprecation of the OpenAPI generation, the generator should still work to generate the typescript API.
 
 After making any changes to the logic, it is worth regenerating the API with the OpenAPI Generator.
 
-Generating the installable APIs (Python + Typescript) involves running the server, getting the `/openapi.json`, and running `openapi-generator`.
+Generating the Typescript API involves running the server, getting the `/openapi.json`, and running `openapi-generator`.
 
 The `regenerate_api.py` script does this for us in a few ways:
 
@@ -363,8 +383,7 @@ You can simply run:
 
 ```bash
 # this will start the api.server, so make sure you have the dependencies installed,
-python regenerate_api.py \
-    && pip install .
+python regenerate_api.py
 ```
 
 or if you prefer the Docker approach (eg: for CI), this command will build the docker container and supply it to `regenerate_api.py`:
@@ -375,6 +394,10 @@ export SM_DOCKER="cpg/metamist-server:dev"
 docker build --build-arg SM_ENVIRONMENT=local -t $SM_DOCKER -f deploy/api/Dockerfile .
 python regenerate_api.py
 ```
+
+
+
+
 
 ### Developing the UI
 

--- a/regenerate_api.py
+++ b/regenerate_api.py
@@ -344,13 +344,6 @@ def main():
     try:
         assert_server_is_accessible()
 
-        # Generate the installable Python API
-        generate_api_and_copy(
-            'python',
-            copy_python_files_from,
-            ['--template-dir', 'openapi-templates'],
-        )
-
         # Generate the Typescript API for React application
         generate_api_and_copy(
             'typescript-axios',

--- a/scripts/get_frozen_api_files.py
+++ b/scripts/get_frozen_api_files.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# pylint: disable=no-member,consider-using-with
+
+"""
+Download frozen api client files from the metamist-legacy-client branch where they are
+committed
+
+usage:
+
+    python scripts/get_frozen_api_files.py <ref>
+
+"""
+import argparse
+import glob
+import os
+import shutil
+import tempfile
+from io import BytesIO
+from urllib.request import urlopen
+from zipfile import ZipFile
+
+FILE_GLOBS = [
+    'metamist/api/*.py',
+    'metamist/apis/*.py',
+    'metamist/model/*.py',
+    'metamist/models/*.py',
+    'metamist/*.py',
+    'web/src/static/sm_docs/*.md',
+]
+
+
+def main(args=None):
+    """Main function, parses sys.argv"""
+
+    parser = argparse.ArgumentParser('Get frozen api client files')
+
+    parser.add_argument('ref')
+    parsed_args = parser.parse_args(args)
+
+    ref = parsed_args.ref
+    url = f'https://github.com/populationgenomics/metamist/archive/{ref}.zip'
+
+    tmpdir = tempfile.mkdtemp()
+
+    with urlopen(url) as zipresp:
+        with ZipFile(BytesIO(zipresp.read())) as zfile:
+            zfile.extractall(tmpdir)
+
+    unzipped_folder = os.listdir(tmpdir)[0]
+    frozen_metamist = os.path.join(tmpdir, unzipped_folder)
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+
+    for glob_path in FILE_GLOBS:
+        # remove existing files
+        for file in glob.glob(os.path.abspath(os.path.join(this_dir, '..', glob_path))):
+            print(f'removing existing {file}')
+            os.remove(file)
+
+        for file in glob.glob(os.path.join(frozen_metamist, glob_path)):
+            dest_rel = os.path.relpath(file, frozen_metamist)
+            dest = os.path.abspath(os.path.join(this_dir, '..', dest_rel))
+            print(f'copying {dest_rel}')
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            shutil.copy(file, dest)
+
+    shutil.rmtree(tmpdir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Context

We've had a lot of problems with the openapi generator that metamist uses. It is currently stopping us from updating pydantic and switching to using graphql to generate our API client. 

We need to continue supporting existing users of the python openapi client, so it is important that the current version of the python client remains usable. 

### Solution

The best workaround for this is to commit the generated python code to a branch of metamist [metamist-legacy-client](https://github.com/populationgenomics/metamist/tree/metamist-legacy-client) and pull that generated code in instead of attempting to generate it.

### Notes/Caveats

Doing this means that we essentially have a code-freeze on any updates to the REST routes that are read by the OpenAPI generator. If necessary we can update the [metamist-legacy-client](https://github.com/populationgenomics/metamist/tree/metamist-legacy-client) branch with new changes but this will be a slow and highly manual process so is best to avoid. 

Any new routes should be implemented in graphql, and if major changes are needed to existing routes, they should be ported over to graphql endpoints instead. 