### PR TITLE
Billing small fix to show hail batches which have no ar_guid available.

### DIFF
--- a/db/python/tables/bq/billing_ar_batch.py
+++ b/db/python/tables/bq/billing_ar_batch.py
@@ -17,7 +17,7 @@ class BillingArBatchTable(BillingBaseTable):
 
     async def get_batches_by_ar_guid(
         self, ar_guid: str
-    ) -> tuple[datetime, datetime, list[str]]:
+    ) -> tuple[datetime | None, datetime | None, list[str]]:
         """
         Get batches for given ar_guid
         """
@@ -46,15 +46,24 @@ class BillingArBatchTable(BillingBaseTable):
         # return empty list if no record found
         return None, None, []
 
-    async def get_ar_guid_by_batch_id(self, batch_id: str) -> str:
+    async def get_ar_guid_by_batch_id(
+        self, batch_id: str | None
+    ) -> tuple[datetime | None, datetime | None, str | None]:
         """
-        Get ar_guid for given batch_id
+        Get ar_guid for given batch_id,
+        if batch_id is found, but not ar_guid, then return batch_id back
         """
+        if batch_id is None:
+            return None, None, None
+
         _query = f"""
-        SELECT ar_guid
+        SELECT ar_guid,
+            MIN(min_day) as start_day,
+            MAX(max_day) as end_day
         FROM `{self.table_name}`
         WHERE batch_id = @batch_id
-        AND ar_guid IS NOT NULL
+        GROUP BY ar_guid
+        ORDER BY ar_guid DESC
         LIMIT 1;
         """
 
@@ -63,7 +72,14 @@ class BillingArBatchTable(BillingBaseTable):
         ]
         query_job_result = self._execute_query(_query, query_parameters)
         if query_job_result:
-            return query_job_result[0]['ar_guid']
+            ar_guid = query_job_result[0]['ar_guid']
+            start_day = query_job_result[0]['start_day']
+            end_day = query_job_result[0]['end_day'] + timedelta(days=1)
+            if ar_guid:
+                return start_day, end_day, ar_guid
+
+            # if ar_guid not found but batch_id exists
+            return start_day, end_day, batch_id
 
         # return None if no ar_guid found
-        return None
+        return None, None, None

--- a/db/python/tables/bq/billing_ar_batch.py
+++ b/db/python/tables/bq/billing_ar_batch.py
@@ -63,8 +63,7 @@ class BillingArBatchTable(BillingBaseTable):
         FROM `{self.table_name}`
         WHERE batch_id = @batch_id
         GROUP BY ar_guid
-        ORDER BY ar_guid DESC
-        LIMIT 1;
+        ORDER BY ar_guid DESC;  -- make NULL values appear last
         """
 
         query_parameters = [
@@ -72,6 +71,9 @@ class BillingArBatchTable(BillingBaseTable):
         ]
         query_job_result = self._execute_query(_query, query_parameters)
         if query_job_result:
+            if len(query_job_result) > 1 and query_job_result[1]['ar_guid'] is not None:
+                raise ValueError(f'Multiple ARs found for batch_id: {batch_id}')
+
             ar_guid = query_job_result[0]['ar_guid']
             start_day = query_job_result[0]['start_day']
             end_day = query_job_result[0]['end_day'] + timedelta(days=1)

--- a/db/python/tables/bq/billing_daily_extended.py
+++ b/db/python/tables/bq/billing_daily_extended.py
@@ -212,7 +212,7 @@ class BillingDailyExtendedTable(BillingBaseTable):
                     sum(d.cost) AS cost,
                     MIN(d.usage_start_time) AS usage_start_time,
                     max(d.usage_end_time) AS usage_end_time,
-                    COUNT(DISTINCT d.job_id) as jobs_cnt
+                    MAX(d.job_id) as jobs_cnt
                 FROM d
                 WHERE d.batch_id IS NOT NULL
                 GROUP BY batch_id, batch_name
@@ -253,7 +253,7 @@ class BillingDailyExtendedTable(BillingBaseTable):
                     sum(d.cost) AS cost,
                     MIN(d.usage_start_time) AS usage_start_time,
                     max(d.usage_end_time) AS usage_end_time,
-                    COUNT(DISTINCT d.job_id) as jobs_cnt
+                    MAX(d.job_id) as jobs_cnt
                 FROM d
                 WHERE d.wdl_task_name IS NOT NULL
                 GROUP BY wdl_task_name
@@ -283,7 +283,7 @@ class BillingDailyExtendedTable(BillingBaseTable):
                     sum(d.cost) AS cost,
                     MIN(d.usage_start_time) AS usage_start_time,
                     max(d.usage_end_time) AS usage_end_time,
-                    COUNT(DISTINCT d.job_id) as jobs_cnt
+                    MAX(d.job_id) as jobs_cnt
                 FROM d
                 WHERE d.cromwell_workflow_id IS NOT NULL
                 GROUP BY cromwell_workflow_id
@@ -313,7 +313,7 @@ class BillingDailyExtendedTable(BillingBaseTable):
                     sum(d.cost) AS cost,
                     MIN(d.usage_start_time) AS usage_start_time,
                     max(d.usage_end_time) AS usage_end_time,
-                    COUNT(DISTINCT d.job_id) as jobs_cnt
+                    MAX(d.job_id) as jobs_cnt
                 FROM d
                 WHERE d.cromwell_sub_workflow_name IS NOT NULL
                 GROUP BY cromwell_sub_workflow_name

--- a/test/test_bq_billing_ar_batch.py
+++ b/test/test_bq_billing_ar_batch.py
@@ -168,7 +168,7 @@ class TestBillingArBatchTable(BqTest):
         self.bq_result.result.return_value = []
 
         # test get_ar_guid_by_batch_id function
-        _st, _ed, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
+        _, _, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 
         self.assertEqual(None, ar_guid)
 
@@ -189,6 +189,6 @@ class TestBillingArBatchTable(BqTest):
         ]
 
         # test get_ar_guid_by_batch_id function
-        _st, _ed, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
+        _, _, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 
         self.assertEqual(expected_ar_guid, ar_guid)

--- a/test/test_bq_billing_ar_batch.py
+++ b/test/test_bq_billing_ar_batch.py
@@ -168,7 +168,7 @@ class TestBillingArBatchTable(BqTest):
         self.bq_result.result.return_value = []
 
         # test get_ar_guid_by_batch_id function
-        ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
+        _st, _ed, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 
         self.assertEqual(None, ar_guid)
 
@@ -180,9 +180,15 @@ class TestBillingArBatchTable(BqTest):
         expected_ar_guid = 'AR_GUID_1234'
 
         # mock BigQuery result
-        self.bq_result.result.return_value = [{'ar_guid': expected_ar_guid}]
+        self.bq_result.result.return_value = [
+            {
+                'ar_guid': expected_ar_guid,
+                'start_day': datetime.datetime(2024, 1, 1, 0, 0),
+                'end_day': datetime.datetime(2024, 1, 2, 0, 0),
+            }
+        ]
 
         # test get_ar_guid_by_batch_id function
-        ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
+        _st, _ed, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 
         self.assertEqual(expected_ar_guid, ar_guid)

--- a/test/test_layers_billing.py
+++ b/test/test_layers_billing.py
@@ -448,8 +448,6 @@ class TestBillingLayer(BqTest):
                 batch_id=dummy_batch_id,
                 start_day=given_start_day,
                 end_day=given_end_day,
-                # mockup __getitem__ to return dummy_ar_guid
-                __getitem__=mock.MagicMock(return_value=dummy_ar_guid),
             ),
         ]
         self.bq_result.result.return_value = mock_rows

--- a/web/src/pages/billing/components/BatchGrid.tsx
+++ b/web/src/pages/billing/components/BatchGrid.tsx
@@ -260,7 +260,7 @@ const BatchCard: React.FC<{ item: AnalysisCostRecordBatch }> = ({ item }) => {
 
                     <DisplayRow label="Cost">
                         {formatMoney(item.cost, 4)}{' '}
-                        {item.jobs?.length > 0 && <em>- across {item.jobs.length} job(s)</em>}
+                        {(item?.jobs_cnt || 0) > 0 && <em>- across {item.jobs_cnt} job(s)</em>}
                     </DisplayRow>
 
                     <DisplayRow label="Start" isVisible={isOpen}>


### PR DESCRIPTION
This PR contains:
1. small fix to show batches where ar_guid is not present. We have a few of them in Feb 2024 and before.
2. Preparation for very large batches, where jobs billing data gets aggregated, to get number of jobs instead of COUNT(jobs), we look at MAX(JobID).
