### PR TITLE
Environment Lock

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
@@ -30,7 +31,7 @@ jobs:
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v2"
         with:
-          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/gh-deploy-pool/providers/gh-provider"
+          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
 
       - id: "google-cloud-sdk-setup"

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build-image:
     runs-on: ubuntu-latest
-
+    environment: production
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -25,7 +25,7 @@ jobs:
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v2"
         with:
-          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/gh-deploy-pool/providers/gh-provider"
+          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
 
       - id: "google-cloud-sdk-setup"

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -33,7 +33,7 @@ jobs:
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v2"
         with:
-          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/gh-deploy-pool/providers/gh-provider"
+          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
 
       - id: "google-cloud-sdk-setup"

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   invoke-cloud-run:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
In a bid to introduce better security permissions, we have replaced the use of SA keys to workload identity providers. This change will also implement the use of environments to ensure deployments are going through the right channels.

## Changes
- [x]  Updated the workflow to use WIP over SA keys
- [x]  Added `environment` attribute in the `deploy.yaml` and `*_schema_updater.yaml` files