### PR TITLE
Fix GenericFilter creating conditional with empty list

### DIFF
--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -61,6 +61,9 @@ class SequencingGroupTable(DbBase):
         self, filter_: SequencingGroupFilter
     ) -> tuple[set[ProjectId], list[SequencingGroupInternal]]:
         """Query samples"""
+        if filter_.is_false():
+            return set(), []
+
         sql_overrides = {
             'project': 's.project',
             'sample_id': 'sg.sample_id',
@@ -166,9 +169,9 @@ class SequencingGroupTable(DbBase):
         WHERE project = :project
         """
         rows = await self.connection.fetch_all(_query, {'project': self.project})
-        sequencing_group_ids_by_sample_ids_by_type: dict[
-            int, dict[str, list[int]]
-        ] = defaultdict(lambda: defaultdict(list))
+        sequencing_group_ids_by_sample_ids_by_type: dict[int, dict[str, list[int]]] = (
+            defaultdict(lambda: defaultdict(list))
+        )
         for row in rows:
             sample_id = row['sid']
             sg_id = row['sgid']

--- a/db/python/utils.py
+++ b/db/python/utils.py
@@ -147,6 +147,9 @@ class GenericFilter(Generic[T]):
         return NONFIELD_CHARS_REGEX.sub('_', name)
 
     def is_false(self) -> bool:
+        """
+        The filter will resolve to False (usually because the in_ is an empty list)
+        """
         return self.in_ is not None and len(self.in_) == 0
 
     def to_sql(

--- a/db/python/utils.py
+++ b/db/python/utils.py
@@ -237,18 +237,16 @@ class GenericFilterModel:
         """
         Returns False if any of the internal filters is FALSE
         """
-        return any(
-            (
-                getattr(self, field.name).is_false()
-                if isinstance(getattr(self, field.name), GenericFilter)
-                else any(
-                    getattr(self, field.name).is_false()
-                    for field in dataclasses.fields(getattr(self, field.name))
-                )
-            )
-            for field in dataclasses.fields(self)
-            if getattr(self, field.name) is not None
-        )
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if isinstance(value, GenericFilter) and value.is_false():
+                return True
+
+            if isinstance(value, dict):
+                if any(f.is_false() for f in value.values()):
+                    return True
+
+        return False
 
     def __post_init__(self):
         for field in dataclasses.fields(self):

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -96,6 +96,14 @@ class TestAnalysis(DbIsolatedTest):
         self.assertEqual(AnalysisStatus.COMPLETED, analysis.status)
 
     @run_as_sync
+    async def test_empty_query(self):
+        """
+        Test empty IDs to see the query construction
+        """
+        analyses = await self.al.query(AnalysisFilter(id=GenericFilter(in_=[])))
+        self.assertEqual(len(analyses), 0)
+
+    @run_as_sync
     async def test_add_cram(self):
         """
         Test adding an analysis of type CRAM

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -53,6 +53,14 @@ class TestSequencingGroup(DbIsolatedTest):
         self.slayer = SampleLayer(self.connection)
 
     @run_as_sync
+    async def test_empty_query(self):
+        """
+        Test empty IDs to see the query construction
+        """
+        sgs = await self.sglayer.query(SequencingGroupFilter(id=GenericFilter(in_=[])))
+        self.assertEqual(len(sgs), 0)
+
+    @run_as_sync
     async def test_insert_sequencing_group(self):
         """Test inserting and fetching a sequencing group"""
         sample_to_insert = get_sample_model()


### PR DESCRIPTION
Closes https://github.com/populationgenomics/metamist/issues/743

Adds a specific check to the GenericFilter for the value for `in` being empty, which means the rest of the query should resolve to False. Also allow a handy way to check if this is the case, and then you can just return no results (eg: implemented in the sequencing group query method.