### PR TITLE
Fixing custom audience attribute for cloud run service.

### DIFF
--- a/metamist_infrastructure/driver.py
+++ b/metamist_infrastructure/driver.py
@@ -607,7 +607,7 @@ class MetamistInfrastructure(CpgInfrastructurePlugin):
         f_name: str,
         docker_image_url: str,
         sa: gcp.serviceaccount.Account,
-        custom_audiences: list[str] | None
+        custom_audiences: list[str] | None,
     ):
         """
         Create External Function with custom audiences
@@ -629,13 +629,14 @@ class MetamistInfrastructure(CpgInfrastructurePlugin):
                             limits={
                                 'cpu': '1',
                                 'memory': '2Gi',
-                            }
+                            },
                         ),
                         envs=[
                             gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
                                 name=k,
                                 value=v,
-                            ) for k, v in self._etl_get_env().items()
+                            )
+                            for k, v in self._etl_get_env().items()
                         ],
                     )
                 ],
@@ -731,7 +732,9 @@ class MetamistInfrastructure(CpgInfrastructurePlugin):
             self.config.metamist.etl.custom_audience_list
             and self.config.metamist.etl.custom_audience_list.get(f_name)
         ):
-            custom_audience_list = self.config.metamist.etl.custom_audience_list.get(f_name)
+            custom_audience_list = self.config.metamist.etl.custom_audience_list.get(
+                f_name
+            )
 
         fxn = gcp.cloudfunctionsv2.Function(
             f'metamist-etl-{f_name}',


### PR DESCRIPTION
Background notes:
To be able to have custom domain linked to a cloud run, property 'custom_audiences' needs to be set.
However there is an issue with pulumi and gcp.
After trial and error I have found they don't support this field when cloud function gets created via gcp.cloudfunctionsv2.Function and gcp.cloudfunctionsv2.FunctionServiceConfigArg.

Solution is to create cloud service separately via gcp.cloudrunv2.Service, which has property 'custom_audiences'.
The only ugly bit is cloud function creates cloud run service by default and there seems to be no way to skip it.
So we would have 2 cloud runs linked to a one function, which is not a problem, just unnescessary extra cloud run service.
It would not cost anything extra as both services have cpu set to idle.

if custom_audience_list is present for the function in the etl configuration, it creates a new custom service with postfix '-external'.