### PR TITLE
Forbid fields other than those defined by each model class

### DIFF
--- a/db/python/tables/assay.py
+++ b/db/python/tables/assay.py
@@ -549,6 +549,7 @@ class AssayTable(DbBase):
                 drow['external_ids'] = {drow.pop('name'): external_id}
             else:
                 drow['external_ids'] = {}
+                del drow['name']
 
             sequencing_group_id = drow.pop('sequencing_group_id')
             projects.add(drow.pop('project'))

--- a/db/python/tables/sample.py
+++ b/db/python/tables/sample.py
@@ -49,7 +49,6 @@ class SampleTable(DbBase):
         'active',
         'type',
         'project',
-        'audit_log_id',
     ]
 
     # region GETS

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -59,7 +59,6 @@ class SequencingGroupTable(DbBase):
         'sg.technology',
         'sg.platform',
         'sg.meta',
-        'sg.author',
         'sg.archived',
     ]
     common_get_keys_str = ', '.join(common_get_keys)

--- a/models/base.py
+++ b/models/base.py
@@ -1,4 +1,4 @@
-from pydantic.main import BaseModel
+from pydantic.main import BaseModel, Extra
 
 # annotate any external objects that must be instantiated with this
 # type to force openapi generator to allow for Nones (it will actually allow Any)
@@ -7,6 +7,10 @@ OpenApiGenNoneType = bytes | None
 
 class SMBase(BaseModel):
     """Base object for all models"""
+
+    class Config:
+        """Allow only the fields defined in each model class"""
+        extra = Extra.forbid
 
     @classmethod
     def from_dict(cls, d: dict):

--- a/models/models/sequencing_group.py
+++ b/models/models/sequencing_group.py
@@ -38,6 +38,7 @@ class SequencingGroupInternal(SMBase):
     sample_id: int | None = None
     external_ids: dict[str, str] | None = {}
     archived: bool | None = None
+    author: str | None = None
 
     project: int | None = None
 

--- a/models/models/sequencing_group.py
+++ b/models/models/sequencing_group.py
@@ -38,7 +38,6 @@ class SequencingGroupInternal(SMBase):
     sample_id: int | None = None
     external_ids: dict[str, str] | None = {}
     archived: bool | None = None
-    author: str | None = None
 
     project: int | None = None
 

--- a/models/models/web.py
+++ b/models/models/web.py
@@ -117,8 +117,3 @@ class ProjectSummary(SMBase):
     seqr_sync_types: list[str]
 
     links: PagingLinks | None
-
-    class Config:
-        """Config for ProjectSummaryResponse"""
-
-        fields = {'links': '_links'}


### PR DESCRIPTION
This PR activates field strictness, as identified in #746. This may or may not be a good idea, but it identifies a few existing problems hence so far I like it… :smile:

This would have detected the `sample_type`/`sample_types` problem (https://github.com/populationgenomics/metamist/pull/615#issuecomment-2071594382) that took a bit of debugging at the end of custom-cohorts.

~~It identifies where we've left a real-world field that exists in the database out of `SequencingGroupInternal` though apparently we don't use it at present (as the omission went unnoticed)~~[Resolved a different way — see below]. It also identifies that `ProjectSummary.links` was probably never being set.

The second commit's fixes are enough to make the tests pass again. There may possibly be other models needing adjustments that have been missed because they are not exercised by tests…