### PR TITLE
Improving error handling for ETL notifications

### DIFF
--- a/etl/notification/main.py
+++ b/etl/notification/main.py
@@ -51,8 +51,16 @@ def etl_notify(request: flask.Request):
             'message': f'Missing or empty message: {jbody_str}',
         }, 400
 
-    # TODO: format message to slack message
-    message_blocks = format_slack(message)
+    # format message to slack message
+    try:
+        message_blocks = format_slack(message)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logging.error(f'Failed to format message: {e}, message: {message}')
+        return {
+            'success': False,
+            'message': f'Failed to format message: {e}',
+        }, 500
+
     success = None
     try:
         client = WebClient(token=SLACK_BOT_TOKEN)


### PR DESCRIPTION
This PR is fixing issue when failed ETL load was not passed to slack alert channel. 
Reason was the message contained the whole stacktrace and failed during message formatting.
To prevent this reason for failure has been shortened to only first 100 chars, BQ table still contain the whole message useful for debugging.