### PR TITLE
Fix pedigree query 

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -233,9 +233,6 @@ class GraphQLProject:
         if not root.id:
             raise ValueError('Project must have an id')
 
-        if not internal_family_ids:
-            return []
-
         pedigree_dicts = await family_layer.get_pedigree(
             project=root.id,
             family_ids=internal_family_ids,


### PR DESCRIPTION
Fixes https://github.com/populationgenomics/metamist/issues/762 

Currently, if family_ids are not specify the pedigree will return an empty list. However, this field is optional, so this behaviour isn't ideal. 