### PR TITLE
Fixes to seqr sync

### DIFF
--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -765,13 +765,14 @@ class ParticipantLayer(BaseLayer):
             set_headers.update(set(row.keys()))
 
         rows = [{h: r.get(h) for h in set_headers if h in r} for r in rows]
+        headers = []  # get ordered headers if we have data for it
+        for h in SeqrMetadataKeys.get_ordered_headers():
+            if header := lheader_to_json.get(h.value.lower()) in set_headers:
+                headers.append(header)
 
         return {
             'rows': rows,
-            # get ordered headers if we have data for it
-            'headers': [
-                h for h in SeqrMetadataKeys.get_ordered_headers() if h in set_headers
-            ],
+            'headers': headers,
             'header_map': json_header_map,
         }
 

--- a/db/python/layers/seqr.py
+++ b/db/python/layers/seqr.py
@@ -11,6 +11,7 @@ from typing import Iterable, Iterator, TypeVar
 import aiohttp
 import slack_sdk
 import slack_sdk.errors
+from backoff import expo, on_exception
 from cloudpathlib import AnyPath
 
 from cpg_utils.cloud import get_google_identity_token
@@ -498,6 +499,7 @@ class SeqrLayer(BaseLayer):
         messages.extend(await asyncio.gather(*requests))
         return messages
 
+    @on_exception(expo, aiohttp.ClientResponseError, max_tries=3)
     async def update_saved_variants(
         self,
         session: aiohttp.ClientSession,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # requirements are for running the server
 # fix boto3/core version to prevent pip downloading all the versions caused by cloudpathlib
+backoff>=2.2.1
 boto3==1.28.56
 botocore==1.31.56
 cpg-utils>=5.0.5


### PR DESCRIPTION
Attempt to resolve https://github.com/populationgenomics/metamist/issues/760

The API endpoint "Get individual metadata template for Seqr" has not been working properly, since the `headers` value returned by the db participant layer `get_seqr_individual_template` is returning an empty list. This is because the `set_headers` contains the snake_case header names, like `'family_id'` and `'individual_id'`, while the values from `SeqrMetadataKeys.get_ordered_headers()` are the human readable header names, like `'Family ID'` and `'Individual ID'`. 

This change utilises the `lheader_to_json` dictionary constructed earlier in the function to get the snake_case header names from the human readable header names. This way, the `headers` returned will not be empty, but a list of the snake_case headers that are keys in the dicts in `rows`. 

As mentioned in the issue linked above, it's unclear why this has become a problem now, seeing as the code looks to be unchanged for years. I may be totally misunderstanding something but it definitely looks like the `headers` should be a list of snake case headers as they appear in `rows`. 

---

There is a second change I'm sneaking in here, which is adding `@backoff` to the seqr sync API call to update saved variants. This call often succeeds and the Seqr VM logs show a 200 response, however Metamist frequently receives a 502 error response and outputs an error when reporting the sync results. By adding the backoff and retry, these transient 502 errors should mostly go away. 

I'm seeing that the `@backoff` library is not found and causing the unit tests / linting to fail. Why is this? It also gets imported and used [here](https://github.com/populationgenomics/metamist/blob/dev/metamist/graphql/__init__.py#L12) without issue.