### PR TITLE
Fix individual metadata for seqr layer headers

### DIFF
--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -767,7 +767,8 @@ class ParticipantLayer(BaseLayer):
         rows = [{h: r.get(h) for h in set_headers if h in r} for r in rows]
         headers = []  # get ordered headers if we have data for it
         for h in SeqrMetadataKeys.get_ordered_headers():
-            if (header := lheader_to_json.get(h.value.lower())) in set_headers:
+            header = lheader_to_json.get(h.value.lower())
+            if header in set_headers:
                 headers.append(header)
 
         return {

--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -767,7 +767,7 @@ class ParticipantLayer(BaseLayer):
         rows = [{h: r.get(h) for h in set_headers if h in r} for r in rows]
         headers = []  # get ordered headers if we have data for it
         for h in SeqrMetadataKeys.get_ordered_headers():
-            if header := lheader_to_json.get(h.value.lower()) in set_headers:
+            if (header := lheader_to_json.get(h.value.lower())) in set_headers:
                 headers.append(header)
 
         return {


### PR DESCRIPTION
OK really silly bug that I missed when I changed the code to use walrus at the last minute before submitting my previous PR.

Basically we need an extra set of parentheses to define the `header` variable in the loop, or else the `headers` list is just full of `True`.

```python
list1 = ['a','b','c']
list2 = ['a','c','d']

# header defined as "item in list2"
# if condition evaluates `header=True`
for item in list1:
  if header := item in list2:
    print(header)
>True
>True

# header defined as "item"
# if condition evaluates `header in list2`
for item in list1:
  if (header := item) in list2:
    print(header)
>a
>c
```