### PR TITLE
Add pseudo contributor role w/o readonly reqs, but write access

### DIFF
--- a/api/routes/cohort.py
+++ b/api/routes/cohort.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from api.utils.db import Connection, get_project_readonly_connection
+from api.utils.db import Connection, HACK_get_project_contributor_connection
 from db.python.layers.cohort import CohortLayer
 from db.python.tables.project import ProjectPermissionsTable
 from models.models.cohort import CohortBody, CohortCriteria, CohortTemplate, NewCohort
@@ -17,7 +17,7 @@ router = APIRouter(prefix='/cohort', tags=['cohort'])
 async def create_cohort_from_criteria(
     cohort_spec: CohortBody,
     cohort_criteria: CohortCriteria | None = None,
-    connection: Connection = get_project_readonly_connection,
+    connection: Connection = HACK_get_project_contributor_connection,
     dry_run: bool = False,
 ) -> NewCohort:
     """
@@ -70,7 +70,7 @@ async def create_cohort_from_criteria(
 @router.post('/{project}/cohort_template', operation_id='createCohortTemplate')
 async def create_cohort_template(
     template: CohortTemplate,
-    connection: Connection = get_project_readonly_connection,
+    connection: Connection = HACK_get_project_contributor_connection,
 ) -> str:
     """
     Create a cohort template with the given name and sample/sequencing group IDs.

--- a/api/utils/db.py
+++ b/api/utils/db.py
@@ -120,7 +120,7 @@ async def HACK_dependable_contributor_project_connection(
     connection = await ProjectPermissionsTable.get_project_connection(
         project_name=project,
         author=author,
-        readonly=False,
+        readonly=True,
         on_behalf_of=None,
         ar_guid=ar_guid,
         meta=meta,

--- a/api/utils/db.py
+++ b/api/utils/db.py
@@ -114,7 +114,7 @@ async def HACK_dependable_contributor_project_connection(
     if extra_values:
         meta.update(extra_values)
 
-    meta = {'role': 'contributor'}
+    meta['role'] = 'contributor'
 
     # hack by making it appear readonly
     connection = await ProjectPermissionsTable.get_project_connection(

--- a/api/utils/db.py
+++ b/api/utils/db.py
@@ -103,6 +103,35 @@ async def dependable_get_write_project_connection(
     )
 
 
+async def HACK_dependable_contributor_project_connection(
+    project: str,
+    author: str = Depends(authenticate),
+    ar_guid: str = Depends(get_ar_guid),
+    extra_values: dict | None = Depends(get_extra_audit_log_values),
+) -> Connection:
+    """FastAPI handler for getting connection WITH project"""
+    meta = {}
+    if extra_values:
+        meta.update(extra_values)
+
+    meta = {'role': 'contributor'}
+
+    # hack by making it appear readonly
+    connection = await ProjectPermissionsTable.get_project_connection(
+        project_name=project,
+        author=author,
+        readonly=False,
+        on_behalf_of=None,
+        ar_guid=ar_guid,
+        meta=meta,
+    )
+
+    # then hack it so
+    connection.readonly = False
+
+    return connection
+
+
 async def dependable_get_readonly_project_connection(
     project: str,
     author: str = Depends(authenticate),
@@ -179,6 +208,9 @@ def validate_iap_jwt_and_get_email(iap_jwt, audience):
 
 get_author = Depends(authenticate)
 get_project_readonly_connection = Depends(dependable_get_readonly_project_connection)
+HACK_get_project_contributor_connection = Depends(
+    HACK_dependable_contributor_project_connection
+)
 get_project_write_connection = Depends(dependable_get_write_project_connection)
 get_projectless_db_connection = Depends(dependable_get_connection)
 get_projectless_bq_connection = Depends(dependable_get_bq_connection)

--- a/db/python/tables/family.py
+++ b/db/python/tables/family.py
@@ -65,6 +65,7 @@ class FamilyTable(DbBase):
         if not filter_.project and not filter_.id:
             raise ValueError('Project or ID filter is required for family queries')
 
+        has_participant_join = False
         field_overrides = {'id': 'f.id', 'external_id': 'f.external_id'}
 
         if filter_.participant_id:


### PR DESCRIPTION
Short term hack for: https://github.com/populationgenomics/metamist/pull/703

1. Check readonly
2. Then update the connection to make it non-readonly. 

Though this gently points out that someone could update the connection.readonly attribute to False anywhere in the code, maybe this should be frozen.