### PR TITLE
Custom Cohorts Fixes

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -117,7 +117,19 @@ class GraphQLCohort:
             cohort_id_transform_to_raw(root.id)
         )
 
-        return GraphQLCohortTemplate.from_internal(template)
+        ptable = ProjectPermissionsTable(connection)
+        projects = await ptable.get_and_check_access_to_projects_for_ids(
+            user=connection.author,
+            project_ids=(
+                template.criteria.projects if template.criteria.projects else []
+            ),
+            readonly=True,
+        )
+        project_names = [p.name for p in projects if p.name]
+
+        return GraphQLCohortTemplate.from_internal(
+            template, project_names=project_names
+        )
 
     @strawberry.field()
     async def sequencing_groups(
@@ -164,13 +176,15 @@ class GraphQLCohortTemplate:
     criteria: strawberry.scalars.JSON
 
     @staticmethod
-    def from_internal(internal: CohortTemplateInternal) -> 'GraphQLCohortTemplate':
+    def from_internal(
+        internal: CohortTemplateInternal, project_names: list[str]
+    ) -> 'GraphQLCohortTemplate':
         # At this point, the object that comes in doesn't have an ID field.
         return GraphQLCohortTemplate(
             id=cohort_template_id_format(internal.id),
             name=internal.name,
             description=internal.description,
-            criteria=internal.criteria.to_external(),
+            criteria=internal.criteria.to_external(project_names=project_names),
         )
 
 
@@ -959,10 +973,21 @@ class Query:  # entry point to graphql.
         )
 
         cohort_templates = await cohort_layer.query_cohort_templates(filter_)
-        return [
-            GraphQLCohortTemplate.from_internal(cohort_template)
-            for cohort_template in cohort_templates
-        ]
+
+        external_templates = []
+
+        for template in cohort_templates:
+            template_projects = await ptable.get_and_check_access_to_projects_for_ids(
+                user=connection.author,
+                project_ids=template.criteria.projects or [],
+                readonly=True,
+            )
+            template_project_names = [p.name for p in template_projects if p.name]
+            external_templates.append(
+                GraphQLCohortTemplate.from_internal(template, template_project_names)
+            )
+
+        return external_templates
 
     @strawberry.field()
     async def cohorts(

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -170,7 +170,7 @@ class GraphQLCohortTemplate:
             id=cohort_template_id_format(internal.id),
             name=internal.name,
             description=internal.description,
-            criteria=internal.criteria,
+            criteria=internal.criteria.to_external(),
         )
 
 
@@ -383,6 +383,7 @@ class GraphQLProject:
                 else None
             ),
             timestamp=timestamp.to_internal_filter() if timestamp else None,
+            project=GenericFilter(eq=root.id),
         )
 
         cohorts = await CohortLayer(connection).query(c_filter)

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -184,7 +184,7 @@ class GraphQLCohortTemplate:
             id=cohort_template_id_format(internal.id),
             name=internal.name,
             description=internal.description,
-            criteria=internal.criteria.to_external(project_names=project_names),
+            criteria=internal.criteria.to_external(project_names=project_names).dict(),
         )
 
 

--- a/api/routes/cohort.py
+++ b/api/routes/cohort.py
@@ -93,7 +93,9 @@ async def create_cohort_template(
             criteria_project_ids = [p.id for p in projects_for_criteria if p.id]
 
     cohort_raw_id = await cohort_layer.create_cohort_template(
-        cohort_template=template.to_internal(criteria_projects=criteria_project_ids),
+        cohort_template=template.to_internal(
+            criteria_projects=criteria_project_ids, template_project=connection.project
+        ),
         project=connection.project,
     )
 

--- a/db/python/layers/cohort.py
+++ b/db/python/layers/cohort.py
@@ -229,6 +229,7 @@ class CohortLayer(BaseLayer):
                 name=cohort_name,
                 description=description,
                 criteria=cohort_criteria,
+                project=project_to_write,
             )
             template_id = await self.create_cohort_template(
                 cohort_template=cohort_template, project=project_to_write

--- a/models/models/cohort.py
+++ b/models/models/cohort.py
@@ -52,6 +52,28 @@ class CohortCriteriaInternal(SMBase):
     sg_type: list[str] | None = None
     sample_type: list[str] | None = None
 
+    def to_external(self) -> dict:
+        """
+        Convert to external model
+        """
+        return {
+            'projects': [str(p) for p in self.projects] if self.projects else [],
+            'sg_ids_internal': (
+                sequencing_group_id_format_list(self.sg_ids_internal_raw)
+                if self.sg_ids_internal_raw
+                else []
+            ),
+            'excluded_sgs_internal': (
+                sequencing_group_id_format_list(self.excluded_sgs_internal_raw)
+                if self.excluded_sgs_internal_raw
+                else []
+            ),
+            'sg_technology': self.sg_technology if self.sg_technology else [],
+            'sg_platform': self.sg_platform if self.sg_platform else [],
+            'sg_type': self.sg_type if self.sg_type else [],
+            'sample_type': self.sample_type if self.sample_type else [],
+        }
+
 
 class CohortTemplateInternal(SMBase):
     """Model for CohortTemplate"""
@@ -60,6 +82,7 @@ class CohortTemplateInternal(SMBase):
     name: str
     description: str
     criteria: CohortCriteriaInternal
+    project: ProjectId
 
     @staticmethod
     def from_db(d: dict):
@@ -72,12 +95,14 @@ class CohortTemplateInternal(SMBase):
         criteria = d.pop('criteria', None)
         if criteria and isinstance(criteria, str):
             criteria = json.loads(criteria)
+        project = d.pop('project', None)
 
         return CohortTemplateInternal(
             id=_id,
             name=name,
             description=description,
             criteria=criteria,
+            project=project,
         )
 
 
@@ -136,7 +161,9 @@ class CohortTemplate(SMBase):
     description: str
     criteria: CohortCriteria
 
-    def to_internal(self, criteria_projects: list[ProjectId]) -> CohortTemplateInternal:
+    def to_internal(
+        self, criteria_projects: list[ProjectId], template_project: ProjectId
+    ) -> CohortTemplateInternal:
         """
         Convert to internal model
         """
@@ -145,6 +172,7 @@ class CohortTemplate(SMBase):
             name=self.name,
             description=self.description,
             criteria=self.criteria.to_internal(criteria_projects),
+            project=template_project,
         )
 
 

--- a/models/models/cohort.py
+++ b/models/models/cohort.py
@@ -52,12 +52,12 @@ class CohortCriteriaInternal(SMBase):
     sg_type: list[str] | None = None
     sample_type: list[str] | None = None
 
-    def to_external(self) -> dict:
+    def to_external(self, project_names: list[str]) -> dict:
         """
         Convert to external model
         """
         return {
-            'projects': [str(p) for p in self.projects] if self.projects else [],
+            'projects': project_names,
             'sg_ids_internal': (
                 sequencing_group_id_format_list(self.sg_ids_internal_raw)
                 if self.sg_ids_internal_raw

--- a/models/models/cohort.py
+++ b/models/models/cohort.py
@@ -52,27 +52,27 @@ class CohortCriteriaInternal(SMBase):
     sg_type: list[str] | None = None
     sample_type: list[str] | None = None
 
-    def to_external(self, project_names: list[str]) -> dict:
+    def to_external(self, project_names: list[str]) -> 'CohortCriteria':
         """
         Convert to external model
         """
-        return {
-            'projects': project_names,
-            'sg_ids_internal': (
+        return CohortCriteria(
+            projects=project_names,
+            sg_ids_internal=(
                 sequencing_group_id_format_list(self.sg_ids_internal_raw)
                 if self.sg_ids_internal_raw
                 else []
             ),
-            'excluded_sgs_internal': (
+            excluded_sgs_internal=(
                 sequencing_group_id_format_list(self.excluded_sgs_internal_raw)
                 if self.excluded_sgs_internal_raw
                 else []
             ),
-            'sg_technology': self.sg_technology if self.sg_technology else [],
-            'sg_platform': self.sg_platform if self.sg_platform else [],
-            'sg_type': self.sg_type if self.sg_type else [],
-            'sample_type': self.sample_type if self.sample_type else [],
-        }
+            sg_technology=self.sg_technology if self.sg_technology else [],
+            sg_platform=self.sg_platform if self.sg_platform else [],
+            sg_type=self.sg_type if self.sg_type else [],
+            sample_type=self.sample_type if self.sample_type else [],
+        )
 
 
 class CohortTemplateInternal(SMBase):

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -115,6 +115,7 @@ class TestCohortBasic(DbIsolatedTest):
                 name='Empty template',
                 description='Template with no entries',
                 criteria=CohortCriteriaInternal(projects=[self.project_id]),
+                project=self.project_id,
             ),
         )
 
@@ -273,7 +274,9 @@ class TestCohortData(DbIsolatedTest):
             name='My template',
             description='Testing template',
             criteria=cc_external,
-        ).to_internal(criteria_projects=[self.project_id])
+        ).to_internal(
+            criteria_projects=[self.project_id], template_project=self.project_id
+        )
         self.assertIsInstance(ctpl_internal, CohortTemplateInternal)
         self.assertDictEqual(ctpl_internal.dict(), ctpl_internal_dict)
 
@@ -413,6 +416,7 @@ class TestCohortData(DbIsolatedTest):
                     projects=[self.project_id],
                     sample_type=['blood'],
                 ),
+                project=self.project_id,
             ),
         )
 

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -267,6 +267,7 @@ class TestCohortData(DbIsolatedTest):
             'name': 'My template',
             'description': 'Testing template',
             'criteria': cc_internal_dict,
+            'project': self.project_id,
         }
 
         ctpl_internal = CohortTemplate(

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -265,9 +265,8 @@ class TestCohortData(DbIsolatedTest):
         self.assertDictEqual(cc_internal.dict(), cc_internal_dict)
 
         cc_ext_trip = cc_internal.to_external(project_names=[self.project_name])
-        # self.assertIsInstance(cc_ext_trip, CohortCriteria)
-        # self.assertDictEqual(cc_ext_trip.dict(), cc_external_dict)
-        self.assertDictEqual(cc_ext_trip, cc_external_dict)
+        self.assertIsInstance(cc_ext_trip, CohortCriteria)
+        self.assertDictEqual(cc_ext_trip.dict(), cc_external_dict)
 
         ctpl_internal_dict = {
             'id': 496,


### PR DESCRIPTION
Fixes https://github.com/populationgenomics/metamist/issues/780 

The issues were:
1- Project was not being passed to the filter, so the query would return everything (if you enter via project)
2- The template project was not being stored on the template model 
3- Cohort criteria was being returned as the model, but needs to be in dict form to display on UI, so required a to_external method.