### PR TITLE
fix for analysis runner entries that don't have a config path

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -890,7 +890,7 @@ class GraphQLAnalysisRunner:
     script: str
     description: str
     driver_image: str
-    config_path: str
+    config_path: str | None
     cwd: str | None
     environment: str
     hail_version: str | None

--- a/models/models/analysis_runner.py
+++ b/models/models/analysis_runner.py
@@ -20,7 +20,7 @@ class AnalysisRunnerInternal(SMBase):
     script: str
     description: str
     driver_image: str
-    config_path: str
+    config_path: str | None
     cwd: str | None
     environment: str
     hail_version: str | None

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "metamist",
-    "version": "6.8.0",
+    "version": "6.10.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "metamist",
-            "version": "6.8.0",
+            "version": "6.10.2",
             "dependencies": {
                 "@apollo/client": "^3.7.3",
                 "@artsy/fresnel": "^6.2.1",


### PR DESCRIPTION
this was breaking the api/ui when trying to display analysis runner entries for projects where the config path was not set.