### PR TITLE
Pin requests to 2.31.0 due to breaking change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cpg-utils>=5.0.5
 aiohttp
 async_lru
 cloudpathlib
-requests
+requests==2.31.0
 google-auth>=2.19.0
 google-cloud-secret-manager==2.8.0
 google-cloud-bigquery==3.11.4


### PR DESCRIPTION
## Description
Unit tests are failing due to the latest release of `requests==2.32.0` which isn't compatible with `docker-py`. This pins the package to `2.31.0`.


## Notes
- The unit tests pass on this branch, unsure if we should pin in the `setup.py` file too?
