### PR TITLE
Use the correct field name in test/data/generate_data.py

### DIFF
--- a/test/data/generate_data.py
+++ b/test/data/generate_data.py
@@ -123,7 +123,7 @@ async def main(ped_path=default_ped_location, project='greek-myth'):
                     ),
                 },
                 participant_id=pid,
-                assays=[],
+                non_sequencing_assays=[],
                 sequencing_groups=[],
             )
             samples.append(sample)


### PR DESCRIPTION
Some fallout from PR #752 — this script needs to use the right field name to avoid failing with

```
File "/Users/johnm/metamist/test/data/generate_data.py", line 115, in main
   sample = SampleUpsert(
[…]
metamist.exceptions.ApiAttributeError: SampleUpsert has no attribute 'assays' at ['assays']
```