### PR TITLE
Unpin requests

### DIFF
--- a/compile_requirements.sh
+++ b/compile_requirements.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# To avoid pip-compile deciding requirements on your specific machine,
+# we use a docker container to compile the requirements, which should match
+# the architecture of the dev environment.
+
+docker run --platform linux/amd64 -v $(pwd):/opt/metamist python:3.11 /bin/bash -c '
+    cd /opt/metamist;
+    pip install pip-tools;
+    pip-compile requirements.in > requirements.txt;
+    pip-compile --output-file=requirements-dev.txt requirements-dev.in requirements.in
+'

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,7 +8,7 @@ flake8-bugbear
 nest-asyncio
 pre-commit
 pylint
-testcontainers[mysql]>=4.4.1
+testcontainers[mysql]>=4.5.0
 types-PyMySQL
 # some strawberry dependency
 strawberry-graphql[debug-server]==0.229.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -177,6 +177,8 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 graphql-core==3.2.3
     # via strawberry-graphql
+greenlet==3.0.3
+    # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via
     #   google-cloud-logging

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -83,9 +83,7 @@ cryptography==42.0.7
     #   azure-storage-blob
     #   pymysql
 databases[mysql]==0.9.0
-    # via
-    #   -r requirements.in
-    #   databases
+    # via -r requirements.in
 deprecated==1.2.14
     # via cpg-utils
 deprecation==2.1.0
@@ -96,14 +94,13 @@ distlib==0.3.8
     # via virtualenv
 dnspython==2.6.1
     # via email-validator
-docker==7.0.0
+docker==7.1.0
     # via testcontainers
 email-validator==2.1.1
     # via fastapi
 fastapi[all]==0.110.2
     # via
     #   -r requirements.in
-    #   fastapi
     #   strawberry-graphql
 filelock==3.14.0
     # via virtualenv
@@ -125,7 +122,6 @@ functions-framework==3.5.0
     # via -r requirements-dev.in
 google-api-core[grpc]==2.19.0
     # via
-    #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-bigquery
     #   google-cloud-core
@@ -181,8 +177,6 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 graphql-core==3.2.3
     # via strawberry-graphql
-greenlet==3.0.3
-    # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via
     #   google-cloud-logging
@@ -267,7 +261,6 @@ packaging==24.0
     # via
     #   black
     #   deprecation
-    #   docker
     #   google-cloud-bigquery
     #   gunicorn
 pathspec==0.12.1
@@ -355,7 +348,7 @@ pyyaml==6.0.1
     #   libcst
     #   pre-commit
     #   uvicorn
-requests==2.31.0
+requests==2.32.2
     # via
     #   -r requirements.in
     #   azure-core
@@ -398,13 +391,10 @@ strawberry-graphql[debug-server,fastapi]==0.229.0
     # via
     #   -r requirements-dev.in
     #   -r requirements.in
-    #   strawberry-graphql
 tabulate==0.9.0
     # via cpg-utils
-testcontainers[mysql]==4.4.1
-    # via
-    #   -r requirements-dev.in
-    #   testcontainers
+testcontainers[mysql]==4.5.0
+    # via -r requirements-dev.in
 toml==0.10.2
     # via cpg-utils
 tomlkit==0.12.5

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ cpg-utils>=5.0.5
 aiohttp
 async_lru
 cloudpathlib
-requests==2.31.0
+requests
 google-auth>=2.19.0
 google-cloud-bigquery==3.11.4
 google-cloud-logging==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,9 +62,7 @@ cryptography==42.0.7
     #   -r requirements.in
     #   azure-storage-blob
 databases[mysql]==0.9.0
-    # via
-    #   -r requirements.in
-    #   databases
+    # via -r requirements.in
 deprecated==1.2.14
     # via cpg-utils
 dnspython==2.6.1
@@ -74,7 +72,6 @@ email-validator==2.1.1
 fastapi[all]==0.110.2
     # via
     #   -r requirements.in
-    #   fastapi
     #   strawberry-graphql
 frozendict==2.4.4
     # via cpg-utils
@@ -84,7 +81,6 @@ frozenlist==1.4.1
     #   aiosignal
 google-api-core[grpc]==2.19.0
     # via
-    #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-bigquery
     #   google-cloud-core
@@ -136,8 +132,6 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 graphql-core==3.2.3
     # via strawberry-graphql
-greenlet==3.0.3
-    # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via
     #   google-cloud-logging
@@ -252,7 +246,7 @@ pyyaml==6.0.1
     # via
     #   fastapi
     #   uvicorn
-requests==2.31.0
+requests==2.32.2
     # via
     #   -r requirements.in
     #   azure-core
@@ -281,9 +275,7 @@ sqlalchemy==2.0.30
 starlette==0.37.2
     # via fastapi
 strawberry-graphql[fastapi]==0.229.0
-    # via
-    #   -r requirements.in
-    #   strawberry-graphql
+    # via -r requirements.in
 tabulate==0.9.0
     # via cpg-utils
 toml==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.4.0
     # via
     #   httpx
     #   starlette
@@ -27,12 +27,12 @@ azure-storage-blob==12.20.0
     # via cloudpathlib
 backoff==2.2.1
     # via -r requirements.in
-boto3==1.34.111
+boto3==1.34.115
     # via
     #   -r requirements.in
     #   cloudpathlib
     #   cpg-utils
-botocore==1.34.111
+botocore==1.34.115
     # via
     #   -r requirements.in
     #   boto3
@@ -132,6 +132,8 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 graphql-core==3.2.3
     # via strawberry-graphql
+greenlet==3.0.3
+    # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via
     #   google-cloud-logging
@@ -215,12 +217,12 @@ pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==2.7.1
+pydantic==2.7.2
     # via
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.18.2
+pydantic-core==2.18.3
     # via pydantic
 pydantic-extra-types==2.7.0
     # via fastapi
@@ -246,7 +248,7 @@ pyyaml==6.0.1
     # via
     #   fastapi
     #   uvicorn
-requests==2.32.2
+requests==2.32.3
     # via
     #   -r requirements.in
     #   azure-core
@@ -280,7 +282,7 @@ tabulate==0.9.0
     # via cpg-utils
 toml==0.10.2
     # via cpg-utils
-typing-extensions==4.11.0
+typing-extensions==4.12.0
     # via
     #   azure-core
     #   azure-storage-blob
@@ -301,7 +303,7 @@ uvicorn[standard]==0.29.0
     #   fastapi
 uvloop==0.19.0
     # via uvicorn
-watchfiles==0.21.0
+watchfiles==0.22.0
     # via uvicorn
 websockets==12.0
     # via uvicorn


### PR DESCRIPTION
With the release of https://github.com/docker/docker-py/pull/3257 we no longer need to have our `requests` package pinned in the deps, so just unpinning it here and also upgrading `docker` and `testcontainers` while we're at it.

Also add a script to compile requirements with Docker to avoid Apple Silicon (M1) architecture differences.