### PR TITLE
Added a filter option for querying analysis by ids

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -362,11 +362,13 @@ class GraphQLProject:
         active: GraphQLFilter[bool] | None = None,
         meta: GraphQLMetaFilter | None = None,
         timestamp_completed: GraphQLFilter[datetime.datetime] | None = None,
+        ids: GraphQLFilter[int] | None = None,
     ) -> list['GraphQLAnalysis']:
         connection = info.context['connection']
         connection.project = root.id
         internal_analysis = await AnalysisLayer(connection).query(
             AnalysisFilter(
+                id=ids.to_internal_filter() if ids else None,
                 type=type.to_internal_filter() if type else None,
                 status=(
                     status.to_internal_filter()


### PR DESCRIPTION
Quick fix that closes #701 

Analyses can now be queried like:

```
query MyQuery {
  project(name: "your-project") {
    analyses(ids: {in_: [1,2,3,4,5]}) {
      id
      status
      type
      meta
    }
  }
}
```

OR

```
query MyQuery {
  project(name: "your-project") {
    analyses(ids: {eq: 1}) {
      id
      status
      type
      meta
    }
  }
}
```