### PR TITLE
:bug: Fix Billing Cost By Analysis page, cost records are not cleared between various cromwell jobs.

### DIFF
--- a/web/src/pages/billing/components/BatchGrid.tsx
+++ b/web/src/pages/billing/components/BatchGrid.tsx
@@ -98,7 +98,7 @@ const AnalysisRunnerRecordCard: React.FC<{ data: AnalysisCostRecord }> = ({ data
                             return (
                                 <DisplayRow
                                     label={_.startCase(tcat.category)}
-                                    key={`ar-guid-${arGuid}-category-${tcat}`}
+                                    key={`ar-guid-${arGuid}-category-${tcat.category}`}
                                 >
                                     {formatMoney(tcat.cost, 2)} {workflows}
                                 </DisplayRow>


### PR DESCRIPTION
This PR is fixing weird issue on Billing Cost By Analysis page with not clearing up the category costs between searches for different cromwell jobs. 
It is related to the key warning showing in the console, where key category was only showing up as [object] and not a category value.
Have tested locally and issue went away.