### PR TITLE
Fix mismatch between epid and esid in create_test_subset 

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -278,7 +278,7 @@ def transfer_samples_sgs_assays(
     sample_to_sg_attribute_map: dict[Tuple[str, str], SequencingGroupAttributes] = {}
     old_sid_to_new_sid: dict[str, str] = {}
     for s in samples:
-        exid_old_sid = (s['participant']['externalId'], s['id'])
+        exid_old_sid = (s['externalId'], s['id'])
         if exid_old_sid not in sample_to_sg_attribute_map:
             sample_to_sg_attribute_map[exid_old_sid] = {}
         for sg in s['sequencingGroups']:
@@ -384,7 +384,7 @@ def get_new_sg_id(
         sid (str): The sample id to search for.
         new_sg_attributes (tuple[str, str, str]): The attributes of the sequencing group to search for.
         old_sid_to_new_sid (dict[str, str]): A map from old sample ids to new sample ids.
-        sample_to_sg_attribute_map (dict[tuple, dict[tuple, str]]): A map from (peid, sid) keys to a map of sequencing group attribute keys to old sequencing group ids.
+        sample_to_sg_attribute_map (dict[tuple, dict[tuple, str]]): A map from (seid, sid) keys to a map of sequencing group attribute keys to old sequencing group ids.
         new_sg_data (dict[dict, Any]): The data containing the new samples and their sequencing groups.
 
 
@@ -415,14 +415,14 @@ def get_new_sg_id(
                 new_sample['id'] == old_sid_to_new_sid[old_sid]
             ):  # If new sample maps to old sample
                 for new_sg in new_sample['sequencingGroups']:
-                    peid_sid_key = (new_sample['externalId'], old_sid)
+                    seid_sid_key = (new_sample['externalId'], old_sid)
                     sg_attribute_key = (
                         new_sg['type'],
                         new_sg['platform'],
                         new_sg['technology'],
                     )
                     if (
-                        sample_to_sg_attribute_map[peid_sid_key].get(new_sg_attributes)
+                        sample_to_sg_attribute_map[seid_sid_key].get(new_sg_attributes)
                         and new_sg_attributes == sg_attribute_key
                     ):
                         new_sg_id = new_sg['id']


### PR DESCRIPTION
Closes https://github.com/populationgenomics/metamist/issues/814

When the sample_to_sg_attribute_map is created, the keys are created like so: 

`exid_old_sid = (s['participant']['externalId'], s['id']) `

When the code later references this map, it creates the keys like so 

`seid_sid_key = (new_sample['externalId'], old_sid)` 

Using the externalID from the participant when setting up the map, and using the externalID from the sample when accessing it later. 

We often use the same name for both, so this can go relatively unnoticed in production. 