### PR TITLE
Fix broken OurDNA Dashboard

### DIFF
--- a/models/models/ourdna.py
+++ b/models/models/ourdna.py
@@ -7,19 +7,19 @@ class OurDNALostSample(BaseModel):
     """Model for OurDNA Lost Sample"""
 
     sample_id: str
-    time_to_process_start: int
+    time_to_process_start: int | None
     collection_time: str
     process_start_time: str
     process_end_time: str
     received_time: str
-    received_by: str
+    received_by: str | None
     collection_lab: str
-    courier: str
-    courier_tracking_number: str
-    courier_scheduled_pickup_time: str
-    courier_actual_pickup_time: str
-    courier_scheduled_dropoff_time: str
-    courier_actual_dropoff_time: str
+    courier: str | None
+    courier_tracking_number: str | None
+    courier_scheduled_pickup_time: str | None
+    courier_actual_pickup_time: str | None
+    courier_scheduled_dropoff_time: str | None
+    courier_actual_dropoff_time: str | None
 
 
 class OurDNADashboard(BaseModel):


### PR DESCRIPTION
It seems like there are some fields that are missing in some of the data, which we did not expect to be missing. This has caused the UI to not load any data with the graphql endpoint returning errors.

I have added an initial set of fields to be checked for `None` so we will test this out as the errors are being returned from this set for now. 