### PR TITLE
Handle multiple participant external_ids in create_test_subset.py

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -703,8 +703,9 @@ def transfer_participants(
     )
 
     target_project_pid_map = {
-        participant['external_id']: participant['id']
+        external_id: participant['id']
         for participant in existing_participants
+        for external_id in participant['external_ids'].values()
     }
 
     participants_to_transfer = []
@@ -715,7 +716,7 @@ def transfer_participants(
         else:
             del participant['id']
         transfer_participant = {
-            'external_id': participant['externalId'],
+            'external_ids': {PRIMARY_EXTERNAL_ORG: participant['externalId']},
             'meta': participant.get('meta') or {},
             'karyotype': participant.get('karyotype'),
             'reported_gender': participant.get('reportedGender'),
@@ -733,9 +734,9 @@ def transfer_participants(
     external_to_internal_participant_id_map: dict[str, int] = {}
 
     for participant in upserted_participants:
-        external_to_internal_participant_id_map[participant['external_id']] = (
-            participant['id']
-        )
+        for external_id in participant['external_ids'].values():
+            external_to_internal_participant_id_map[external_id] = participant['id']
+
     return external_to_internal_participant_id_map
 
 


### PR DESCRIPTION
Fix oversight in PR #659's late changes to _create_test_subset.py_: `transfer_participants()` also needs adjustment as Participant and ParticipantUpsert now have an `external_ids` field instead of an `external_id` field. We future-proof the two maps being built by adding all external ids, even though at present only the primary one is returned by the GraphQL queries.

In future we will represent the extra external ids in GraphQLParticipant too and revisit the initialisation of transfer_participant's `external_ids` field.

Context: https://centrepopgen.slack.com/archives/C020PDNH3N0/p1718340238722549?thread_ts=1718317460.582949&cid=C020PDNH3N0