### PR TITLE
Update fix_pbmc_sample_participant.py script for multiple external ids

### DIFF
--- a/scripts/fix_pbmc_sample_participant.py
+++ b/scripts/fix_pbmc_sample_participant.py
@@ -19,12 +19,12 @@ def main():
         )
     )
 
-    sample_map_by_external_id = {s['external_id']: s for s in all_samples}
+    sample_map_by_external_id = {eid: s for s in all_samples for eid in s['external_ids'].values()}
 
-    pbmc_samples = [s for s in all_samples if '-PBMC' in s['external_id']]
+    pbmc_samples = [s for s in all_samples if any('-PBMC' in eid for eid in s['external_ids'].values())]
 
     for sample in pbmc_samples:
-        external_id = sample['external_id']
+        external_id = next(eid for eid in sample['external_ids'].values() if '-PBMC' in eid)
         non_pbmc_id = external_id.strip('-PBMC')
         non_pbmc_sample = sample_map_by_external_id.get(non_pbmc_id)
         pbmc_sample = sample_map_by_external_id.get(external_id)


### PR DESCRIPTION
I didn't previously audit the ad-hoc scripts directory too carefully… having now done so, alongside _create_test_subset.py_ I think this is the only one needing adjustments.

Expand `sample_map_by_external_id` to hold all the external_ids for all the samples. For samples with an external_id containing '-PBMC', use `next(...)` to pick the first such external_id — generally there'll surely only be one anyway.