### PR TITLE
Participant grid hot fixes

### DIFF
--- a/models/models/sequencing_group.py
+++ b/models/models/sequencing_group.py
@@ -49,8 +49,11 @@ class SequencingGroupInternal(SMBase):
         meta = parse_sql_dict(kwargs.pop('meta'))
 
         _archived = parse_sql_bool(kwargs.pop('archived', None))
+        external_ids = parse_sql_dict(kwargs.pop('external_ids', None)) or {}
 
-        return SequencingGroupInternal(**kwargs, archived=_archived, meta=meta)
+        return SequencingGroupInternal(
+            **kwargs, archived=_archived, meta=meta, external_ids=external_ids
+        )
 
     def to_external(self):
         """Convert to transport model"""

--- a/models/models/web.py
+++ b/models/models/web.py
@@ -1,7 +1,7 @@
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes,too-many-locals
 import dataclasses
 from enum import Enum
-from typing import Sequence
+from typing import Any, Sequence
 
 from db.python.filters.web import ProjectParticipantGridFilter
 from models.base import SMBase
@@ -105,6 +105,18 @@ class ProjectParticipantGridField(SMBase):
     filter_types: list[ProjectParticipantGridFilterType] | None = None
 
 
+def has_value_worth_displaying(value: Any) -> bool:
+    """
+    Check if the value is worth displaying on the UI, otherwise hide the column
+    """
+    if value is None:
+        return False
+    if isinstance(value, (bool, int)):
+        return True
+
+    return bool(value)
+
+
 class ProjectParticipantGridResponse(SMBase):
     """
     Web GridResponse including keys
@@ -154,47 +166,63 @@ class ProjectParticipantGridResponse(SMBase):
         }
         hidden_sg_meta_keys: set[str] = set()
 
-        family_meta_keys: set[str] = set()
-        participant_meta_keys: set[str] = set()
-        sample_meta_keys: set[str] = set()
-        sg_meta_keys: set[str] = set()
-        assay_meta_keys: set[str] = set()
+        # we should put the field in the list, but hide it if there's no actual value
+        # dict[key, has_any_value]
+        family_meta_keys: dict[str, bool] = {}
+        participant_meta_keys: dict[str, bool] = {}
+        sample_meta_keys: dict[str, bool] = {}
+        sg_meta_keys: dict[str, bool] = {}
+        assay_meta_keys: dict[str, bool] = {}
+        has_nested_samples = False
 
         if filter_fields.family and filter_fields.family.meta:
-            family_meta_keys.update(filter_fields.family.meta.keys())
+            family_meta_keys.update({k: True for k in filter_fields.family.meta.keys()})
         if filter_fields.participant and filter_fields.participant.meta:
-            participant_meta_keys.update(filter_fields.participant.meta.keys())
+            participant_meta_keys.update(
+                {k: True for k in filter_fields.participant.meta.keys()}
+            )
             hidden_participant_meta_keys -= set(filter_fields.participant.meta.keys())
         if filter_fields.sample and filter_fields.sample.meta:
-            sample_meta_keys.update(filter_fields.sample.meta.keys())
+            sample_meta_keys.update({k: True for k in filter_fields.sample.meta.keys()})
             hidden_participant_meta_keys -= set(filter_fields.sample.meta.keys())
         if filter_fields.sequencing_group and filter_fields.sequencing_group.meta:
-            sg_meta_keys.update(filter_fields.sequencing_group.meta.keys())
+            # sg_meta_keys.update(filter_fields.sequencing_group.meta.keys())
+            sg_meta_keys.update(
+                {k: True for k in filter_fields.sequencing_group.meta.keys()}
+            )
             hidden_sg_meta_keys -= set(filter_fields.sequencing_group.meta.keys())
         if filter_fields.assay and filter_fields.assay.meta:
-            assay_meta_keys.update(filter_fields.assay.meta.keys())
+            assay_meta_keys.update({k: True for k in filter_fields.assay.meta.keys()})
             hidden_assay_meta_keys -= set(filter_fields.assay.meta.keys())
+
+        def update_d_from_meta(d: dict[str, bool], meta: dict[str, Any]):
+            for k, v in meta.items():
+                worth_displaying = has_value_worth_displaying(v)
+                if k in d:
+                    d[k] |= worth_displaying
+                else:
+                    d[k] = worth_displaying
 
         for p in participants:
             if p.meta:
-                participant_meta_keys.update(p.meta.keys())
+                update_d_from_meta(participant_meta_keys, p.meta)
             if not p.samples:
                 continue
             for s in p.samples:
                 if s.meta:
-                    sample_meta_keys.update(s.meta.keys())
+                    update_d_from_meta(sample_meta_keys, s.meta)
                 if not s.sequencing_groups:
                     continue
 
                 for sg in s.sequencing_groups or []:
                     if sg.meta:
-                        sg_meta_keys.update(sg.meta.keys())
+                        update_d_from_meta(sg_meta_keys, sg.meta)
 
                     if not sg.assays:
                         continue
                     for a in sg.assays:
                         if a.meta:
-                            assay_meta_keys.update(a.meta.keys())
+                            update_d_from_meta(assay_meta_keys, a.meta)
 
         has_reported_sex = any(p.reported_sex is not None for p in participants)
         has_reported_gender = any(p.reported_gender is not None for p in participants)
@@ -212,8 +240,10 @@ class ProjectParticipantGridResponse(SMBase):
             )
         ]
         family_fields.extend(
-            Field(key='meta.' + k, label=k, is_visible=True, filter_key='meta.' + k)
-            for k in family_meta_keys
+            Field(
+                key='meta.' + k, label=k, is_visible=has_value, filter_key='meta.' + k
+            )
+            for k, has_value in family_meta_keys.items()
         )
         participant_fields = [
             Field(
@@ -245,10 +275,10 @@ class ProjectParticipantGridResponse(SMBase):
             Field(
                 key='meta.' + k,
                 label=k,
-                is_visible=k not in hidden_participant_meta_keys,
+                is_visible=has_value and k not in hidden_participant_meta_keys,
                 filter_key='meta.' + k,
             )
-            for k in participant_meta_keys
+            for k, has_value in participant_meta_keys.items()
         )
 
         sample_fields = [
@@ -279,10 +309,10 @@ class ProjectParticipantGridResponse(SMBase):
             Field(
                 key='meta.' + k,
                 label=k,
-                is_visible=k not in hidden_sample_meta_keys,
+                is_visible=has_value and k not in hidden_sample_meta_keys,
                 filter_key='meta.' + k,
             )
-            for k in sample_meta_keys
+            for k, has_value in sample_meta_keys.items()
         )
         assay_fields = [
             Field(
@@ -296,10 +326,10 @@ class ProjectParticipantGridResponse(SMBase):
             Field(
                 key='meta.' + k,
                 label=k,
-                is_visible=k not in hidden_assay_meta_keys,
+                is_visible=has_value and k not in hidden_assay_meta_keys,
                 filter_key='meta.' + k,
             )
-            for k in assay_meta_keys
+            for k, has_value in assay_meta_keys.items()
         )
 
         sequencing_group_fields = [
@@ -337,10 +367,10 @@ class ProjectParticipantGridResponse(SMBase):
             Field(
                 key='meta.' + k,
                 label=k,
-                is_visible=k not in hidden_sg_meta_keys,
+                is_visible=has_value and k not in hidden_sg_meta_keys,
                 filter_key='meta.' + k,
             )
-            for k in sg_meta_keys
+            for k, has_value in sg_meta_keys.items()
         )
 
         return {

--- a/models/models/web.py
+++ b/models/models/web.py
@@ -173,7 +173,6 @@ class ProjectParticipantGridResponse(SMBase):
         sample_meta_keys: dict[str, bool] = {}
         sg_meta_keys: dict[str, bool] = {}
         assay_meta_keys: dict[str, bool] = {}
-        has_nested_samples = False
 
         if filter_fields.family and filter_fields.family.meta:
             family_meta_keys.update({k: True for k in filter_fields.family.meta.keys()})

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -30,7 +30,7 @@ def get_sample_model():
                 meta={
                     'meta-key': 'meta-value',
                 },
-                external_ids={},
+                external_ids={'ext': 'some-ext-id'},
                 assays=[
                     AssayUpsertInternal(
                         type='sequencing',

--- a/web/src/pages/project/ParticipantGridRow.tsx
+++ b/web/src/pages/project/ParticipantGridRow.tsx
@@ -77,7 +77,11 @@ const FamilyCells: React.FC<{
             >
                 {field.key == 'external_id'
                     ? participant.families.map((f) => (
-                          <FamilyLink id={`${f.id ?? ''}`} projectName={projectName}>
+                          <FamilyLink
+                              key={`family-${participant.id}-${f.id}`}
+                              id={`${f.id ?? ''}`}
+                              projectName={projectName}
+                          >
                               {f.external_id}
                           </FamilyLink>
                       ))

--- a/web/src/pages/project/ParticipantGridRow.tsx
+++ b/web/src/pages/project/ParticipantGridRow.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 
+import _ from 'lodash'
 import { TableCell, TableRow } from 'semantic-ui-react'
 import FamilyLink from '../../shared/components/links/FamilyLink'
 import SampleLink from '../../shared/components/links/SampleLink'
@@ -7,7 +8,6 @@ import SequencingGroupLink from '../../shared/components/links/SequencingGroupLi
 import sanitiseValue from '../../shared/utilities/sanitiseValue'
 import {
     Assay,
-    FamilySimple,
     NestedParticipant,
     NestedSample,
     NestedSequencingGroup,
@@ -75,18 +75,15 @@ const FamilyCells: React.FC<{
                 }}
                 rowSpan={participantRowSpan}
             >
-                {field.key == 'external_id' ? (
-                    <FamilyLink
-                        id={`${participant.families.map((f) => f.id)[0]}`}
-                        projectName={projectName}
-                    >
-                        {participant.families.map((f) => f.external_id).join(', ')}
-                    </FamilyLink>
-                ) : (
-                    participant.families
-                        .map((fam) => sanitiseValue(fam[field.key as keyof FamilySimple]))
-                        .join(', ')
-                )}
+                {field.key == 'external_id'
+                    ? participant.families.map((f) => (
+                          <FamilyLink id={`${f.id ?? ''}`} projectName={projectName}>
+                              {f.external_id}
+                          </FamilyLink>
+                      ))
+                    : participant.families
+                          .map((fam) => sanitiseValue(_.get(fam, field.key)))
+                          .join(', ')}
             </TableCell>
         ))}
     </>
@@ -111,7 +108,7 @@ const ParticipantCells: React.FC<{
             >
                 {field.key == 'external_ids'
                     ? prepareExternalIds(participant.external_ids || {})
-                    : sanitiseValue(participant[field.key as keyof NestedParticipant])}
+                    : sanitiseValue(_.get(participant, field.key))}
             </TableCell>
         ))}
     </>
@@ -186,7 +183,7 @@ export const ProjectGridParticipantRows: React.FC<IProjectGridParticipantRowProp
                                                 : s.id}
                                         </SampleLink>
                                     ) : (
-                                        sanitiseValue(s[field.key as keyof NestedSample])
+                                        sanitiseValue(_.get(s, field.key))
                                     )}
                                 </TableCell>
                             ))}
@@ -197,7 +194,7 @@ export const ProjectGridParticipantRows: React.FC<IProjectGridParticipantRowProp
                                         ...getBorderStyles(i),
                                         backgroundColor,
                                     }}
-                                    key={`${s.id}sequencing_group.${field.key}`}
+                                    key={`${sg.id}-sequencing_group.${field.key}`}
                                     rowSpan={sg.assays?.length || undefined}
                                 >
                                     {field.key === 'id' ? (
@@ -209,7 +206,7 @@ export const ProjectGridParticipantRows: React.FC<IProjectGridParticipantRowProp
                                             {sanitiseValue(sg.id)}
                                         </SequencingGroupLink>
                                     ) : (
-                                        sanitiseValue(sg[field.key as keyof NestedSequencingGroup])
+                                        sanitiseValue(_.get(sg, field.key))
                                     )}
                                 </TableCell>
                             ))}
@@ -221,7 +218,7 @@ export const ProjectGridParticipantRows: React.FC<IProjectGridParticipantRowProp
                                 }}
                                 key={`${s.id}-assay.${field.key || field.label}`}
                             >
-                                {sanitiseValue(assay[field.key as keyof Assay])}
+                                {sanitiseValue(_.get(assay, field.key))}
                             </TableCell>
                         ))}
                     </TableRow>

--- a/web/src/pages/project/ProjectGridContainer.tsx
+++ b/web/src/pages/project/ProjectGridContainer.tsx
@@ -82,7 +82,8 @@ export const ProjectGridContainer: React.FunctionComponent<IProjectGridContainer
         }
         const q = new URLSearchParams(qParams).toString()
 
-        const pageSuffix = pageNumber ? `/${pageNumber}` : ''
+        const newPageNumber = options.pageNumber || pageNumber
+        const pageSuffix = newPageNumber ? `/${newPageNumber}` : ''
         navigate(`/project/${projectName}${pageSuffix}?${q}`)
     }
 
@@ -227,7 +228,9 @@ export const ProjectGridContainer: React.FunctionComponent<IProjectGridContainer
             >
                 <Dropdown
                     selection
-                    onChange={(_, data) => setPageOptions({ pageSize: data.value as number })}
+                    onChange={(_, data) =>
+                        setPageOptions({ pageSize: data.value as number, pageNumber: 1 })
+                    }
                     value={pageSize}
                     options={PAGE_SIZES.map((s) => ({
                         key: s,


### PR DESCRIPTION
- An issue with parsing sequencing group external IDs [context](https://centrepopgen.slack.com/archives/C030X7WGFCL/p1719444477368069)
- Pagination was not working when selected manually
- Swapping lodash broke column values from meta
- Better logic for hiding empty (but present) columns by default
- Fixed an issue for family links showing undefined for no families