### PR TITLE
Fix get sequencing groups by analysis IDs

### DIFF
--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -370,7 +370,7 @@ class SequencingGroupTable(DbBase):
         FROM analysis_sequencing_group asg
         INNER JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
         INNER JOIN sample s ON s.id = sg.sample_id
-        INNER JOIN sequencing_group_external_id sgexid ON sg.id = sgexid.sequencing_group_id
+        LEFT JOIN sequencing_group_external_id sgexid ON sg.id = sgexid.sequencing_group_id
         WHERE asg.analysis_id IN :aids
         GROUP BY sg.id, asg.analysis_id
         """


### PR DESCRIPTION
- Add test to model failure case
- Change inner to left join to catch (most common) case where sequencing groups doesn't have any external ID.