### PR TITLE
Update css for project grid table layout

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -371,7 +371,7 @@ html[data-theme='dark-mode'] .ui.table {
 }
 
 .ui.table {
-    table-layout: fixed;
+    table-layout: auto;
 }
 
 .ui.table .table-cell {


### PR DESCRIPTION
In the project insights PR #533 a piece of css was added which impacted semantic-ui Table components. The css set `table-layout: fixed`, meaning all Table columns are rendered to fit on the users screen, compressing all the data cells too. 

This fix sets the layout to `auto`, allowing the columns to relax and use the width they need so the grid can actually be read.