### PR TITLE
Multiple external IDs in GraphQL and other front-end code

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -657,6 +657,7 @@ class GraphQLParticipant:
 
     id: int
     external_id: str
+    external_ids: strawberry.scalars.JSON
     meta: strawberry.scalars.JSON
 
     reported_sex: int | None
@@ -671,6 +672,7 @@ class GraphQLParticipant:
         return GraphQLParticipant(
             id=internal.id,
             external_id=internal.external_ids[PRIMARY_EXTERNAL_ORG],
+            external_ids=internal.external_ids or {},
             meta=internal.meta,
             reported_sex=internal.reported_sex,
             reported_gender=internal.reported_gender,
@@ -752,6 +754,7 @@ class GraphQLSample:
 
     id: str
     external_id: str
+    external_ids: strawberry.scalars.JSON
     active: bool
     meta: strawberry.scalars.JSON
     type: str
@@ -766,6 +769,7 @@ class GraphQLSample:
         return GraphQLSample(
             id=sample_id_format(sample.id),
             external_id=sample.external_ids[PRIMARY_EXTERNAL_ORG],
+            external_ids=sample.external_ids or {},
             active=sample.active,
             meta=sample.meta,
             type=sample.type,

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -45,8 +45,6 @@ papi = ParticipantApi()
 
 DEFAULT_SAMPLES_N = 10
 
-PRIMARY_EXTERNAL_ORG = ''
-
 QUERY_ALL_DATA = gql(
     """
     query getAllData($project: String!, $sids: [String!]) {
@@ -56,8 +54,10 @@ QUERY_ALL_DATA = gql(
                 meta
                 type
                 externalId
+                externalIds
                 participant {
                     externalId
+                    externalIds
                     id
                     karyotype
                     meta
@@ -330,7 +330,7 @@ def transfer_samples_sgs_assays(
             existing_pid = upserted_participant_map[s['participant']['externalId']]
 
         sample_upsert = SampleUpsert(
-            external_ids={PRIMARY_EXTERNAL_ORG: s['externalId']},
+            external_ids=s['externalIds'],
             type=sample_type or None,
             meta=(copy_files_in_dict(s['meta'], project) or {}),
             participant_id=existing_pid,
@@ -768,7 +768,7 @@ def transfer_participants(
         else:
             del participant['id']
         transfer_participant = {
-            'external_ids': {PRIMARY_EXTERNAL_ORG: participant['externalId']},
+            'external_ids': participant['externalIds'],
             'meta': participant.get('meta') or {},
             'karyotype': participant.get('karyotype'),
             'reported_gender': participant.get('reportedGender'),

--- a/scripts/fix_pbmc_sample_participant.py
+++ b/scripts/fix_pbmc_sample_participant.py
@@ -19,12 +19,12 @@ def main():
         )
     )
 
-    sample_map_by_external_id = {s['external_id']: s for s in all_samples}
+    sample_map_by_external_id = {eid: s for s in all_samples for eid in s['external_ids'].values()}
 
-    pbmc_samples = [s for s in all_samples if '-PBMC' in s['external_id']]
+    pbmc_samples = [s for s in all_samples if any('-PBMC' in eid for eid in s['external_ids'].values())]
 
     for sample in pbmc_samples:
-        external_id = sample['external_id']
+        external_id = next(eid for eid in sample['external_ids'].values() if '-PBMC' in eid)
         non_pbmc_id = external_id.strip('-PBMC')
         non_pbmc_sample = sample_map_by_external_id.get(non_pbmc_id)
         pbmc_sample = sample_map_by_external_id.get(external_id)


### PR DESCRIPTION
Leaves the `externalId` field as is, for existing queries and those who just want to query the primary one.