### PR TITLE
Get OpenAPI Spec without spinning up server

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,16 +71,6 @@ jobs:
               --new-version $(cat deploy/python/version.txt)dev$(echo $(git rev-parse HEAD) | cut -c1-7)
           fi
 
-      # we have to build the image first without the web files to
-      # generate the openapi file to then generate the documentation
-      - name: "build image"
-        run: |
-          docker build \
-            --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
-            --tag $SM_DOCKER \
-            -f deploy/api/Dockerfile \
-            .
-
       - name: "build deployable API"
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"
@@ -97,10 +87,13 @@ jobs:
           npm run build
           popd
 
-      # rebuild docker image now that front-end files are in the right place
-      - name: "build image II"
+      - name: "build image"
         run: |
-          docker build --tag $SM_DOCKER -f deploy/api/Dockerfile .
+          docker build \
+            --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
+            --tag $SM_DOCKER \
+            -f deploy/api/Dockerfile \
+            .
 
       - name: Build python package
         run: python setup.py sdist

--- a/api/utils/openapi.py
+++ b/api/utils/openapi.py
@@ -81,6 +81,7 @@ def get_openapi_schema_func(app, version):
             # openapi_version='3.1.0'
         )
 
+        # follow-up PR, upgrade swagger and use 3.1 directly
         convert_3_dot_1_to_3_dot_0_inplace(openapi_schema)
 
         openapi_schema['servers'] = [{'url': url} for url in URLS]
@@ -89,3 +90,25 @@ def get_openapi_schema_func(app, version):
         return openapi_schema
 
     return openapi
+
+
+def get_openapi_3_0_schema(app, version):
+    """
+    Uncouple the openapi schema of the server, for the OpenAPI generator
+    (Because we use an old version that only supports 3.0 schema)
+
+    """
+    openapi_schema = get_openapi(
+        title='Sample metadata API',
+        version=version,
+        routes=app.routes,
+        # update when FastAPI + swagger supports 3.1.0
+        # openapi_version='3.1.0'
+        )
+
+    convert_3_dot_1_to_3_dot_0_inplace(openapi_schema)
+
+    openapi_schema['servers'] = [{'url': url} for url in URLS]
+
+    app.openapi_schema = openapi_schema
+    return openapi_schema


### PR DESCRIPTION
Great shout @dancoates .

This technically allows us to unbundle our 3.1 -> 3.0 OpenAPI schema version hack, and code has been set-up to support that, we basically just need to check that the Swagger pages (both FastAPI / node version) support 3.1 before doing this.

If you hide whitespace changes, this is mostly just deletes.