### PR TITLE
Add dedicated seqr sync module to db layers

### DIFF
--- a/db/python/layers/seqr_sync/config.py
+++ b/db/python/layers/seqr_sync/config.py
@@ -1,0 +1,62 @@
+import os
+from enum import Enum
+
+CREDENTIALS_FILENAME = os.environ.get('SEQR_CREDS', '')
+MAP_LOCATION = 'gs://cpg-seqr-main-analysis/automation/'
+ENVIRONMENT = 'prod'  # 'staging'
+
+ENVS = {
+    'staging': (
+        'https://seqr-staging.populationgenomics.org.au',
+        '1021400127367-40kj6v68nlps6unk6bgvh08r5o4djf6b.apps.googleusercontent.com',
+    ),
+    'prod': (
+        'https://seqr.populationgenomics.org.au',
+        '1021400127367-9uc4sikfsm0vqo38q1g6rclj91mm501r.apps.googleusercontent.com',
+    ),
+    'reanalysis-dev': (
+        'https://seqr-reanalysis-dev.populationgenomics.org.au'
+        '1021400127367-4vch8s8kc9opeg4v14b2n70se55jpao4.apps.googleusercontent.com'
+    ),
+    'local': (
+        'http://127.0.0.1:8000',
+        '1021400127367-4vch8s8kc9opeg4v14b2n70se55jpao4.apps.googleusercontent.com',
+    ),
+}
+BASE, SEQR_AUDIENCE = ENVS[ENVIRONMENT]
+
+SGS_TO_IGNORE: set[str] = set()
+
+
+class SeqrDatasetType(Enum):
+    """Type of dataset (es-index) that can be POSTed to Seqr"""
+
+    SNV_INDEL = 'SNV_INDEL'  # Haplotypecaller in seqr UI
+    SV = 'SV'  # SV Caller in seqr UI (WGS projects)
+    GCNV = 'SV_WES'  # SV Caller in seqr UI (WES projects)
+    MITO = 'MITO'  # Mitochondria Caller in seqr UI
+
+
+ES_INDEX_STAGES = {
+    SeqrDatasetType.SNV_INDEL: 'MtToEs',
+    SeqrDatasetType.SV: 'MtToEsSv',
+    SeqrDatasetType.GCNV: 'MtToEsCNV',
+    SeqrDatasetType.MITO: 'MtToEsMito',
+}
+
+ES_INDICES_YAML = """
+exome:
+    test: test
+
+genome:
+    example: example
+"""
+
+# API URLs
+url_individuals_sync = '/api/project/sa/{projectGuid}/individuals/sync'
+url_individual_metadata_sync = '/api/project/sa/{projectGuid}/individuals_metadata/sync'
+url_family_sync = '/api/project/sa/{projectGuid}/families/sync'
+url_update_es_index = '/api/project/sa/{projectGuid}/add_dataset/variants'
+url_update_saved_variants = '/api/project/sa/{projectGuid}/saved_variant/update'
+url_igv_diff = '/api/project/sa/{projectGuid}/igv/diff'
+url_igv_individual_update = '/api/individual/sa/{individualGuid}/igv/update'

--- a/db/python/layers/seqr_sync/data_fetchers.py
+++ b/db/python/layers/seqr_sync/data_fetchers.py
@@ -1,0 +1,521 @@
+import json
+
+from metamist.apis import AnalysisApi, ProjectApi, SeqrApi
+from metamist.graphql import gql, query_async
+from metamist.model.export_type import ExportType
+
+from .config import ES_INDEX_STAGES, SeqrDatasetType
+from .logging_config import logger
+
+
+class MetamistFetcher:
+    """Class to fetch data from Metamist using the Metamist APIs."""
+
+    def __init__(
+        self,
+        datasets: list[str] | None = None,
+        sequencing_types: list[str] | None = None,
+        sequencing_technologies: list[str] | None = None,
+    ):
+        self.datasets = datasets
+        self.sequencing_types = sequencing_types
+        self.sequencing_technologies = sequencing_technologies
+        self.aapi = AnalysisApi()
+        self.seqr_api = SeqrApi()
+        self.papi = ProjectApi()
+
+    @staticmethod
+    def _sequencing_type_filter(output_path: str, sequencing_type: str) -> bool:
+        if output_path.removeprefix('gs://').split('/')[0].endswith('-test'):
+            return False
+        if sequencing_type == 'genome' and 'exome' in output_path:
+            return False
+        if sequencing_type == 'exome' and 'exome' not in output_path:
+            return False
+
+        return True
+
+    @staticmethod
+    def _sequencing_technology_filter(
+        output_path: str, sequencing_technology: str
+    ) -> bool:
+        if sequencing_technology == 'long-read' and 'pacbio' not in output_path:
+            return False
+        if sequencing_technology == 'short-read' and 'pacbio' in output_path:
+            return False
+
+        return True
+
+    async def get_seqr_projects(
+        self, sequencing_type, ignore_datasets=set[str] | None
+    ) -> list[dict]:
+        """Get all seqr projects from Metamist, excluding the ones in ignore_datasets"""
+        seqr_projects_response = await self.papi.get_seqr_projects_async()
+        seqr_projects = []
+        for project in seqr_projects_response:
+            if ignore_datasets and project['name'] in ignore_datasets:
+                continue
+
+            meta_key = f'seqr-project-{sequencing_type}'
+            seqr_guid = project.get('meta', {}).get(meta_key)
+
+            if not seqr_guid:
+                continue
+
+            seqr_projects.append(
+                {
+                    'name': project['name'],
+                    'guid': seqr_guid,
+                }
+            )
+
+        return seqr_projects
+
+    async def get_participants_from_metamist(
+        self, dataset: str, sequencing_type: str, sequencing_technology: str
+    ) -> list[dict]:
+        """Get participants with families from metamist"""
+        _query = gql(
+            """
+            query MyQuery($dataset: String!, $seqType: String!,  $seqTech: String!) {
+                project(name: $dataset) {
+                    participants {
+                        id
+                        externalId
+                        samples {
+                            sequencingGroups(type: {eq: $seqType}, technology: {eq: $seqTech}) {
+                                id
+                            }
+                        }
+                        families {
+                            externalId
+                            id
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        query_results = await query_async(
+            _query,
+            {
+                'dataset': dataset,
+                'seqType': sequencing_type,
+                'seqTech': sequencing_technology,
+            },
+        )
+        # check if any participant has no family
+        participants = []
+        for participant in query_results['project']['participants']:
+            if not participant['families']:
+                logger.warning(
+                    f'{dataset} :: Participant {participant["externalId"]} has no family - skipping'
+                )
+                continue
+            participants.append(participant)
+
+        return participants
+
+    async def get_individual_metadata_rows_from_metamist(
+        self, dataset: str, participant_eids: set[str]
+    ) -> list[dict]:
+        """Get individual metadata rows from Metamist, containing HPO terms, affected status, and consanguinity. Must specify participant external IDs."""
+        individual_metadata_resp = (
+            await self.seqr_api.get_individual_metadata_for_seqr_async(
+                project=dataset, export_type=ExportType('json')
+            )
+        )
+        if individual_metadata_resp is None or isinstance(
+            individual_metadata_resp, str
+        ):
+            raise ValueError(
+                f'{dataset} :: There is an issue with getting individual metadata from Metamist, please try again later'
+            )
+
+        json_rows: list[dict] = individual_metadata_resp['rows']
+        json_rows = [
+            row for row in json_rows if row['individual_id'] in participant_eids
+        ]
+
+        return json_rows
+
+    async def get_family_ids_from_external_ids(
+        self, dataset: str, family_eids: set[str]
+    ) -> set[str]:
+        """Get internal family IDs from external family IDs"""
+        _query = gql(
+            """
+            query MyQuery($dataset: String!, $familyEids: [String!]) {
+                project(name: $dataset) {
+                    families(externalId: {in_: $familyEids}) {
+                        id
+                    }
+                }
+            }
+            """
+        )
+        query_results = await query_async(
+            _query,
+            {'dataset': dataset, 'familyEids': list(family_eids)},
+        )
+        return {f['id'] for f in query_results['project']['families']}
+
+    async def get_participants_in_families(
+        self, dataset: str, family_eids: set[str]
+    ) -> set[str]:
+        """Get all participants in the specified families"""
+        _query = gql(
+            """
+            query MyQuery($dataset: String!, $familyExtIds: [String!]) {
+              project(name: $dataset) {
+                families(externalId: {in_: $familyExtIds}) {
+                  id
+                  externalId
+                  participants {
+                    id
+                    externalId
+                  }
+                }
+              }
+            }
+            """
+        )
+        participants = set()
+        query_results = await query_async(
+            _query, {'dataset': dataset, 'familyExtIds': list(family_eids)}
+        )
+        families = query_results['project']['families']
+        for family in families:
+            for participant in family['participants']:
+                participants.add(participant['externalId'])
+        return participants
+
+    async def get_pedigree_rows_from_metamist(
+        self,
+        dataset: str,
+        family_eids: set[str],
+    ) -> list[dict] | None:
+        """Get the pedigree from Metamist. Must specify family external IDs."""
+        PED_QUERY = gql(
+            """
+            query MyQuery($dataset: String!, $internalFamilyIds: [Int!]) {
+                project(name: $dataset) {
+                    pedigree(internalFamilyIds: $internalFamilyIds)
+                }
+            }
+            """
+        )
+        family_internal_ids = await self.get_family_ids_from_external_ids(
+            dataset, family_eids
+        )
+
+        ped_data = await query_async(
+            PED_QUERY,
+            {'dataset': dataset, 'internalFamilyIds': list(family_internal_ids)},
+        )
+
+        return ped_data['project']['pedigree']
+
+    @staticmethod
+    async def get_families_metadata_from_metamist(
+        dataset: str,
+        family_eids: set[str],
+    ) -> list[dict]:
+        """
+        Fetch family description and coded phenotype from Metamist. Must specify family external IDs.
+        """
+        _query = gql(
+            """
+            query MyQuery($dataset: String!, $familyEids: [String!]) {
+                project(name: $dataset) {
+                    families(externalId: {in_: $familyEids}) {
+                        id
+                        externalId
+                        description
+                        codedPhenotype
+                    }
+                }
+            }
+            """
+        )
+        query_results = await query_async(
+            _query, {'dataset': dataset, 'familyEids': list(family_eids)}
+        )
+
+        return query_results['project']['families']
+
+    async def get_sgs_and_analyses_with_technology_and_seq_type(
+        self,
+        dataset: str,
+        sequencing_type: str,
+        sequencing_technology: str,
+        analysis_type: str,
+    ) -> list[dict]:
+        """Get sequencing group IDs with the specified sequencing type and technology"""
+        _query = gql(
+            """
+            query MyQuery($dataset: String!, $seqType: String!, $seqTech: String!, $analysisType: String!) {
+              project(name: $dataset) {
+                sequencingGroups(type: {eq: $seqType}, technology: {eq: $seqTech}) {
+                  id
+                  analyses(status: {eq: COMPLETED}, type: {eq: $analysisType}) {
+                    id
+                    output
+                  }
+                  sample {
+                    id
+                    externalId
+                    participant {
+                      id
+                      externalId
+                      families {
+                        id
+                        externalId
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """
+        )
+
+        query_results = await query_async(
+            _query,
+            {
+                'dataset': dataset,
+                'seqType': sequencing_type,
+                'seqTech': sequencing_technology,
+                'analysisType': analysis_type,
+            },
+        )
+        return query_results['project']['sequencingGroups']
+
+    async def get_analyses_for_participants_with_technology_and_seq_type(
+        self,
+        dataset: str,
+        participant_eids: set[str],
+        sequencing_type: str,
+        sequencing_technology: str,
+        analysis_type: str,
+    ) -> list[dict]:
+        """Get analyses of a type from sequencing groups with the specified sequencing type and technology for a set of participants."""
+        _query = gql(
+            """
+            query MyQuery($dataset: String!, $individualExtIds: [String!], $sgType: String!, $sgTech: String!, $analysisType: String!) {
+              project(name: $dataset) {
+                participants(externalId: {in_: $individualExtIds}) {
+                  id
+                  externalId
+                  samples {
+                    id
+                    externalId
+                    sequencingGroups(type: {eq: $sgType}, technology: {eq: $sgTech})  {
+                      id
+                      type
+                      technology
+                      analyses(status: {eq: COMPLETED}, type: {eq: $analysisType}) {
+                        id
+                        output
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """
+        )
+
+        query_results = await query_async(
+            _query,
+            {
+                'dataset': dataset,
+                'individualExtIds': list(participant_eids),
+                'sgType': sequencing_type,
+                'sgTech': sequencing_technology,
+                'analysisType': analysis_type,
+            },
+        )
+        return query_results['project']['participants']
+
+    async def get_latest_es_index_analysis(
+        self, dataset: str, sequencing_type: str, seqr_dataset_type: SeqrDatasetType
+    ) -> dict:
+        """Get the latest ES index analysis from a list of ES index analyses"""
+        es_index_analyses = await self.get_es_index_analyses_from_metamist(
+            dataset, sequencing_type, seqr_dataset_type
+        )
+        return es_index_analyses[-1] if es_index_analyses else None
+
+    async def get_es_index_analyses_from_metamist(
+        self, dataset: str, sequencing_type: str, seqr_dataset_type: SeqrDatasetType
+    ) -> list[dict]:
+        """Get the ES index analyses of a given seqr dataset type for a metamist dataset"""
+        stage_name = ES_INDEX_STAGES[seqr_dataset_type]
+        _query = gql(
+            """
+            query ES_Indices($dataset: String!, $sequencingType: String!, $stage: String!) {
+                project(name: $dataset) {
+                    analyses(type: {eq: "es-index"}, meta: {sequencing_type: $sequencingType, stage: $stage}, status: {eq: COMPLETED}) {
+                        id
+                        output
+                        timestampCompleted
+                        meta
+                        sequencingGroups {
+                            id
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        query_results = await query_async(
+            _query,
+            {
+                'dataset': dataset,
+                'sequencingType': sequencing_type,
+                'stage': stage_name,
+            },
+        )
+
+        es_index_analyses = query_results['project']['analyses']
+        es_index_analyses = [
+            {
+                'id': analysis['id'],
+                'meta': analysis['meta'],
+                'output': analysis['output'],
+                'timestamp_completed': analysis['timestampCompleted'],
+                'sequencing_group_ids': [
+                    sg['id'] for sg in analysis['sequencingGroups']
+                ],
+            }
+            for analysis in es_index_analyses
+            if analysis['timestampCompleted'] and analysis['sequencingGroups']
+        ]
+
+        es_index_analyses = sorted(
+            es_index_analyses,
+            key=lambda el: el['timestamp_completed'],
+        )
+
+        return es_index_analyses
+
+    async def get_reads_map_from_metamist(
+        self,
+        dataset: str,
+        participant_eids: set[str],
+        sequencing_group_ids: set[str],
+        sequencing_type: str,
+        sequencing_technology: str,
+    ) -> dict[str, list[dict[str, str]]]:
+        """
+        Get map of participant EID to cram path.
+
+        Args:
+            dataset (str): The dataset to query.
+            participant_eids (Set[str]): Set of participant external IDs.
+            sequencing_group_ids (Set[str]): Set of sequencing group IDs.
+            sequencing_type (str): Type of sequencing (e.g., 'genome', 'exome').
+            sequencing_technology (str): Technology used for sequencing (e.g., 'short-read', 'long-read').
+
+        Returns:
+            Dict[str, List[Dict[str, str]]]: A dictionary mapping participant IDs to lists of file paths.
+        """
+        # Fetch and filter reads map
+        reads_map = await self.aapi.get_samples_reads_map_async(
+            project=dataset, export_type='json'
+        )
+        reads_map = [r for r in reads_map if r['participant_id'] in participant_eids]
+
+        # Remove duplicates
+        unique_reads = {tuple(sorted(d.items())) for d in reads_map}
+        unique_reads_map = [dict(t) for t in unique_reads]
+
+        logger.info(
+            f'{dataset} :: Filtered reads map to {len(unique_reads_map)} records for {len(participant_eids)} participants.'
+        )
+
+        peid_to_reads_map: dict[str, list[dict[str, str]]] = {
+            peid: [] for peid in participant_eids
+        }
+        already_added = set()
+
+        for row in unique_reads_map:
+            pid, output, sg_id = (
+                row['participant_id'],
+                row['output'],
+                row['sequencing_group_id'],
+            )
+
+            if (
+                sg_id in sequencing_group_ids
+                and output not in already_added
+                and self._sequencing_type_filter(output, sequencing_type)
+                and self._sequencing_technology_filter(output, sequencing_technology)
+            ):
+                peid_to_reads_map[pid].append({'filePath': output})
+                already_added.add(output)
+
+        # Count uploadable reads
+        number_of_uploadable_reads = sum(
+            len(reads) for reads in peid_to_reads_map.values()
+        )
+        logger.info(
+            f'{dataset} :: Found {number_of_uploadable_reads} uploadable reads.'
+        )
+
+        return peid_to_reads_map
+
+
+class FileFetcher:
+    """
+    Class to fetch data from files instead of Metamist. Useful if you have custom sync requirements and you write the data to temp files.
+
+    Eventually these methods should check the file schema and raise errors if the schema is not as expected.
+    """
+
+    def __init__(self, datasets: list[str], sequencing_types: list[str]):
+        self.datasets = datasets
+        self.sequencing_types = sequencing_types
+
+    @staticmethod
+    def get_participants_from_file(file_path: str) -> dict:
+        """
+        Get participants from a file instead of via GraphQL query
+        """
+        with open(file_path, 'r') as f:
+            return json.load(f)
+
+    @staticmethod
+    def get_pedigree_rows_from_file(file_path: str) -> list[dict] | None:
+        """
+        Get pedigree rows directly from a file
+        """
+        with open(file_path, 'r') as f:
+            return json.load(f)
+
+    @staticmethod
+    def get_families_metadata_from_file(file_path: str) -> list[dict]:
+        """
+        Get families metadata rows directly from a file
+        """
+        with open(file_path, 'r') as f:
+            return json.load(f)
+
+    @staticmethod
+    def get_individual_metadata_from_file(file_path: str) -> list[dict]:
+        """
+        Get individual metadata rows directly from a file
+        """
+        with open(file_path, 'r') as f:
+            return json.load(f)
+
+    @staticmethod
+    def get_reads_map_from_file(file_path: str) -> dict[str, list[dict[str, str]]]:
+        """
+        Get the participant external ID to reads map directly from a file
+        """
+        with open(file_path, 'r') as f:
+            return json.load(f)

--- a/db/python/layers/seqr_sync/data_transformers.py
+++ b/db/python/layers/seqr_sync/data_transformers.py
@@ -1,0 +1,172 @@
+from typing import Any
+
+from cloudpathlib import AnyPath
+
+from .config import SeqrDatasetType
+
+
+class SeqrTransformer:
+    """Transform data from Metamist to Seqr format"""
+
+    @staticmethod
+    def process_ped_sex(value):
+        """Process the sex value into seqr's expected format."""
+        if not isinstance(value, int):
+            return value
+        if value == 0:
+            return 'U'
+        if value == 1:
+            return 'M'
+        if value == 2:
+            return 'F'
+        return 'U'
+
+    @staticmethod
+    def process_ped_affected_status(value):
+        """Process an affected status value into seqr's expected format."""
+        if not isinstance(value, int):
+            raise ValueError(f'Unexpected affected value: {value}')
+        return {
+            -9: 'U',
+            0: 'U',
+            1: 'N',
+            2: 'A',
+        }[value]
+
+    @staticmethod
+    def process_individual_metadata_hpo_terms(terms: str):
+        """ "Process hpo terms into a list of terms."""
+        return [t.strip() for t in terms.split(',')]
+
+    @staticmethod
+    def process_individual_metadata_affected_status(affected: str):
+        """Parse the affected value from the input."""
+        affected = str(affected).upper()
+        if affected in ('1', 'U', 'UNAFFECTED'):
+            return 'N'
+        if affected == '2' or affected.startswith('A'):
+            return 'A'
+        if not affected or affected in ('0', 'UNKNOWN'):
+            return 'U'
+
+        return None
+
+    @staticmethod
+    def process_individual_metadata_consanguinity(consanguity: str):
+        """Parse the consanguity value from the input."""
+        if not consanguity:
+            return None
+
+        if isinstance(consanguity, bool):
+            return consanguity
+
+        if consanguity.lower() in ('t', 'true', 'yes', 'y', '1'):
+            return True
+
+        if consanguity.lower() in ('f', 'false', 'no', 'n', '0'):
+            return False
+
+        return None
+
+    def format_families_metadata_rows(self, family_rows: list[dict]) -> list[dict]:
+        """Format the family rows for Seqr"""
+        fam_row_seqr_keys = {
+            'familyId': 'externalId',
+            'displayName': 'externalId',
+            'description': 'description',
+            'codedPhenotype': 'codedPhenotype',
+        }
+
+        family_metadata = [
+            {
+                seqr_key: fam.get(mm_key)
+                for seqr_key, mm_key in fam_row_seqr_keys.items()
+            }
+            for fam in family_rows
+        ]
+
+        return family_metadata
+
+    def format_pedigree_rows(self, ped_rows: list[dict]) -> list[dict]:
+        """Format the pedigree rows for Seqr"""
+        ped_row_seqr_keys = {
+            'familyId': 'family_id',
+            'individualId': 'individual_id',
+            'paternalId': 'paternal_id',
+            'maternalId': 'maternal_id',
+            'notes': 'notes',
+            'sex': 'sex',
+            'affected': 'affected',
+        }
+        for row in ped_rows:
+            row['sex'] = self.process_ped_sex(row['sex'])
+            row['affected'] = self.process_ped_affected_status(row['affected'])
+
+        pedigree_metadata = [
+            {
+                seqr_key: row.get(mm_key)
+                for seqr_key, mm_key in ped_row_seqr_keys.items()
+            }
+            for row in ped_rows
+        ]
+
+        return pedigree_metadata
+
+    def format_individual_metadata_rows(
+        self, individual_metadata_rows: list[dict]
+    ) -> list[dict]:
+        """Format the individual metadata rows for Seqr"""
+        key_processor = {
+            'hpo_terms_present': self.process_individual_metadata_hpo_terms,
+            'hpo_terms_absent': self.process_individual_metadata_hpo_terms,
+            'affected': self.process_individual_metadata_affected_status,
+            'consanguinity': self.process_individual_metadata_consanguinity,
+        }
+
+        seqr_map = {
+            'family_id': 'family_id',
+            'individual_id': 'individual_id',
+            'affected': 'affected',
+            'features': 'hpo_terms_present',
+            'absent_features': 'hpo_terms_absent',
+            'birth_year': 'birth_year',
+            'death_year': 'death_year',
+            'onset_age': 'age_of_onset',
+            'notes': 'individual_notes',
+            'consanguinity': 'consanguinity',
+            'affected_relatives': 'affected_relatives',
+            'expected_inheritance': 'expected_inheritance',
+            'maternal_ethnicity': 'maternal_ancestry',
+            'paternal_ethnicity': 'paternal_ancestry',
+        }
+
+        individual_metadata = []
+        for row in individual_metadata_rows:
+            individual_metadata.append(
+                {
+                    seqr_key: key_processor[sm_key](row[sm_key])
+                    if sm_key in key_processor
+                    else row[sm_key]
+                    for seqr_key, sm_key in seqr_map.items()
+                    if sm_key in row
+                }
+            )
+
+        return individual_metadata
+
+    def format_es_index_analysis(
+        self,
+        es_index_analysis: dict,
+        seqr_dataset_type: SeqrDatasetType,
+        sgid_to_peid_map_path: AnyPath,
+        ignore_extra_samples_in_callset: bool = True,
+    ) -> dict[str, Any]:
+        """Format the ES index analysis for Seqr"""
+        es_index_metadata = {
+            'elasticsearchIndex': es_index_analysis['output'],
+            'datasetType': seqr_dataset_type.value,
+            'mappingFilePath': sgid_to_peid_map_path,
+            'ignoreExtraSamplesInCallset': ignore_extra_samples_in_callset,
+        }
+
+        return es_index_metadata

--- a/db/python/layers/seqr_sync/logging_config.py
+++ b/db/python/layers/seqr_sync/logging_config.py
@@ -1,0 +1,22 @@
+import logging
+
+
+def configure_logging():
+    """Configure logging for the seqr_sync module collection"""
+    loggers_to_silence = [
+        'google.auth.transport.requests',
+        'google.auth._default',
+        'google.auth.compute_engine._metadata',
+    ]
+    for lname in loggers_to_silence:
+        tlogger = logging.getLogger(lname)
+        tlogger.setLevel(level=logging.CRITICAL)
+
+    _logger = logging.getLogger('sync-seqr')
+    _logger.addHandler(logging.StreamHandler())
+    _logger.propagate = False
+    _logger.setLevel(logging.INFO)
+    return _logger
+
+
+logger = configure_logging()

--- a/db/python/layers/seqr_sync/seqr_sync.py
+++ b/db/python/layers/seqr_sync/seqr_sync.py
@@ -1,0 +1,394 @@
+# pylint: disable=missing-timeout,unnecessary-lambda-assignment,import-outside-toplevel,too-many-locals
+import asyncio
+import json
+from typing import Any
+
+import aiohttp
+
+from metamist.parser.generic_parser import chunk
+
+from .config import (
+    SeqrDatasetType,
+    url_family_sync,
+    url_igv_diff,
+    url_igv_individual_update,
+    url_individual_metadata_sync,
+    url_individuals_sync,
+    url_update_es_index,
+    url_update_saved_variants,
+)
+from .data_fetchers import MetamistFetcher
+from .logging_config import logger
+from .utils import get_token
+
+
+class SeqrSync:
+    """Class to sync datasets to seqr via the seqr API urls"""
+
+    def __init__(
+        self,
+        seqr_url_base: str,
+        dataset: str,
+        project_guid: str,
+        sequencing_type: str,
+        seqr_dataset_type: SeqrDatasetType = None,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ):
+        self.seqr_url_base = seqr_url_base
+        self.dataset = dataset
+        self.project_guid = project_guid
+        self.sequencing_type = sequencing_type
+        self.seqr_dataset_type = seqr_dataset_type
+        self.dry_run = dry_run
+        self.verbose = verbose
+
+    def sync_dataset(
+        self,
+        data_to_sync: dict[str, Any],
+    ):
+        """Sync single dataset without looking up seqr guid"""
+        return asyncio.new_event_loop().run_until_complete(
+            self.sync_dataset_async(
+                data_to_sync,
+            )
+        )
+
+    async def sync_dataset_async(
+        self,
+        data_to_sync: dict[str, Any],
+    ):
+        """Synchronisation driver for a single dataset"""
+        logger.info(
+            f'{self.dataset} ({self.sequencing_type} - {self.seqr_dataset_type.value}) :: Syncing to {self.project_guid}'
+        )
+        token = get_token()
+        async with aiohttp.ClientSession() as client:
+            headers: dict[str, str] = {'Authorization': f'Bearer {token}'}
+            params: dict[str, Any] = {
+                'headers': headers,
+                'session': client,
+            }
+            if families_metadata := data_to_sync.get('families'):
+                await self.sync_families_metadata(
+                    **params, families_metadata=families_metadata
+                )
+            if pedigree_data := data_to_sync.get('pedigree'):
+                await self.sync_pedigree(**params, pedigree_data=pedigree_data)
+            if individual_metadata := data_to_sync.get('individual_metadata'):
+                await self.sync_individual_metadata(
+                    **params, individual_metadata=individual_metadata
+                )
+            if es_index_data := data_to_sync.get('es_index_data'):
+                await self.sync_es_index_analyses(
+                    **params,
+                    es_index_data=es_index_data,
+                )
+            if data_to_sync.get('sync_saved_variants'):
+                await self.update_saved_variants(
+                    **params,
+                )
+            if reads_map := data_to_sync.get('reads_map'):
+                await self.sync_reads_map(
+                    **params,
+                    peid_to_reads_map=reads_map,
+                )
+
+    async def sync_pedigree(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        pedigree_data: list[dict],
+    ):
+        """
+        Synchronise pedigree data to a seqr project
+        """
+        req_url = self.seqr_url_base + url_individuals_sync.format(
+            projectGuid=self.project_guid
+        )
+        logger.info(f'{self.dataset} :: Uploading pedigree to {req_url}')
+        if self.verbose:
+            logger.info(f'{self.dataset} :: {json.dumps(pedigree_data, indent=2)}')
+        if self.dry_run:
+            logger.info(f'{self.dataset} :: Dry run, skipping pedigree sync')
+            logger.info(
+                f'{self.dataset} :: Would have uploaded {len(pedigree_data)} records'
+            )
+            return
+        resp = await session.post(
+            req_url, json={'individuals': pedigree_data}, headers=headers
+        )
+        if not resp.ok:
+            logger.warning(
+                f'{self.dataset} :: Confirming pedigree failed: {await resp.text()}'
+            )
+            with open(f'{self.dataset}.ped', 'w+') as f:
+                import csv
+
+                writer = csv.writer(f, delimiter='\t')
+                col_headers = [
+                    'familyId',
+                    'individualId',
+                    'paternalId',
+                    'maternalId',
+                    'sex',
+                    'affected',
+                ]
+                writer.writerows(
+                    [[row[h] for h in col_headers] for row in pedigree_data]
+                )
+
+        resp.raise_for_status()
+
+        logger.info(f'{self.dataset} :: Uploaded pedigree')
+
+    async def sync_families_metadata(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        families_metadata: list[dict],
+    ):
+        """
+        Synchronise families metadata to a seqr project
+        """
+        req_url = self.seqr_url_base + url_family_sync.format(
+            projectGuid=self.project_guid
+        )
+        logger.info(f'{self.dataset} :: Uploading family template to {req_url}')
+        if self.verbose:
+            logger.info(f'{self.dataset} :: {json.dumps(families_metadata, indent=2)}')
+        if self.dry_run:
+            logger.info(f'{self.dataset} :: Dry run, skipping families sync')
+            logger.info(
+                f'{self.dataset} :: Would have uploaded {len(families_metadata)} records'
+            )
+            return
+
+        resp_2 = await session.post(
+            req_url, json={'families': families_metadata}, headers=headers
+        )
+        resp_2.raise_for_status()
+        logger.info(f'{self.dataset} :: Uploaded family template')
+
+    async def sync_individual_metadata(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        individual_metadata: list[dict],
+    ):
+        """
+        Sync individual participant metadata (eg: phenotypes) to a seqr project
+        """
+        req_url = self.seqr_url_base + url_individual_metadata_sync.format(
+            projectGuid=self.project_guid
+        )
+        logger.info(f'{self.dataset} :: Uploading individual metadata to {req_url}')
+        if self.verbose:
+            logger.info(
+                f'{self.dataset} :: {json.dumps(individual_metadata, indent=2)}'
+            )
+        if self.dry_run:
+            logger.info(f'{self.dataset} :: Dry run, skipping individual metadata sync')
+            logger.info(
+                f'{self.dataset} :: Would have uploaded {len(individual_metadata)} records'
+            )
+            return
+
+        resp = await session.post(
+            req_url, json={'individuals': individual_metadata}, headers=headers
+        )
+        resp_text = await resp.text()
+        if resp.status == 400 and 'Unable to find individuals to update' in resp_text:
+            logger.info(f'{self.dataset} :: No individual metadata needed updating')
+            return
+
+        if not resp.ok:
+            logger.info(
+                f'{self.dataset} :: Error syncing individual metadata {resp_text}'
+            )
+            resp.raise_for_status()
+
+        logger.info(f'{self.dataset} :: Uploaded individual metadata')
+
+    async def sync_es_index_analyses(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        es_index_data: list[dict],
+    ):
+        """Update seqr samples for latest elastic-search index"""
+        for es_index in es_index_data:
+            es_index_name = es_index['elasticsearchIndex']
+            req_url = self.seqr_url_base + url_update_es_index.format(
+                projectGuid=self.project_guid
+            )
+            logger.info(
+                f'{self.dataset} :: {self.seqr_dataset_type.value} :: Updating ES index {es_index_name!r} to {req_url}'
+            )
+            if self.verbose:
+                logger.info(f'{self.dataset} :: {json.dumps(es_index, indent=2)}')
+            if self.dry_run:
+                logger.info(f'{self.dataset} :: Dry run, skipping actual update')
+                return
+
+            resp_1 = await session.post(req_url, json=es_index, headers=headers)
+            logger.info(
+                f'{self.dataset} :: {self.seqr_dataset_type} :: Updated ES index {es_index_name!r} with status: {resp_1.status}'
+            )
+            if not resp_1.ok:
+                logger.info(
+                    f'{self.dataset} :: Request failed with information: {resp_1.text}'
+                )
+            resp_1.raise_for_status()
+
+    async def update_saved_variants(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+    ):
+        """POST an empty JSON to update saved variants in the seqr project"""
+        req2_url = self.seqr_url_base + url_update_saved_variants.format(
+            projectGuid=self.project_guid
+        )
+        if self.dry_run:
+            logger.info(f'{self.dataset} :: Dry run, skipping update saved variants')
+            return
+        resp_2 = await session.post(req2_url, json={}, headers=headers)
+        logger.info(
+            f'{self.dataset} :: Updated saved variants with status code: {resp_2.status}'
+        )
+        if not resp_2.ok:
+            logger.info(
+                f'{self.dataset} :: Request failed with information: {resp_2.text()}'
+            )
+        resp_2.raise_for_status()
+
+    async def get_igv_diff(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        peid_to_reads_map: dict[str, list[str]],
+        number_of_uploadable_reads: int,
+    ):
+        """Get IGV diff for a dataset to check if any CRAMS need updating"""
+        req1_url = self.seqr_url_base + url_igv_diff.format(
+            projectGuid=self.project_guid
+        )
+        if self.dry_run:
+            logger.info(f'{self.dataset} :: Dry run, skipping CRAM sync')
+            logger.info(
+                f'{self.dataset} :: Would have uploaded {number_of_uploadable_reads} records'
+            )
+            return {'updates': []}
+
+        resp_1 = await session.post(
+            req1_url, json={'mapping': peid_to_reads_map}, headers=headers
+        )
+        if not resp_1.ok:
+            t = await resp_1.text()
+            logger.info(f'{self.dataset} :: Failed to diff CRAM updates: {t!r}')
+        resp_1.raise_for_status()
+
+        response = await resp_1.json()
+        if 'updates' not in response:
+            logger.info(f'{self.dataset} :: All CRAMS are up to date')
+
+        return response
+
+    async def sync_reads_map(
+        self,
+        session: aiohttp.ClientSession,
+        headers: dict[str, str],
+        peid_to_reads_map: dict[str, list[str]],
+    ):
+        """
+        Get map of participant EID to cram path and sync it to seqr in three steps:
+
+        1. Get the cram map from Metamist or file
+        2. Check which CRAMS need updating with IGV diff
+        3. Update the CRAMS in seqr
+        """
+        logger.info(f'{self.dataset} :: Getting cram map')
+        number_of_uploadable_reads = sum(
+            len(reads) for reads in peid_to_reads_map.values()
+        )
+        logger.info(
+            f'{self.dataset} :: Found {number_of_uploadable_reads} uploadable reads.'
+        )
+
+        response = await self.get_igv_diff(
+            session,
+            headers,
+            peid_to_reads_map,
+            number_of_uploadable_reads,
+        )
+        if 'updates' not in response:
+            logger.info(f'{self.dataset} :: All CRAMS are up to date')
+            return
+
+        async def _make_update_igv_call(update):
+            individual_guid = update['individualGuid']
+            req_igv_update_url = self.seqr_url_base + url_igv_individual_update.format(
+                individualGuid=individual_guid
+            )
+            resp = await session.post(req_igv_update_url, json=update, headers=headers)
+
+            t = await resp.text()
+            if not resp.ok:
+                raise ValueError(
+                    f'{self.dataset} :: Failed to update {individual_guid} with response: {t!r})',
+                    resp,
+                )
+
+            return t
+
+        chunk_size = 10
+        wait_time = 3
+        all_updates = response['updates']
+        exceptions = []
+        for idx, updates in enumerate(chunk(all_updates, chunk_size=10)):
+            if not updates:
+                continue
+            logger.info(
+                f'{self.dataset} :: Updating CRAMs {idx * chunk_size + 1} -> {(min((idx + 1 ) * chunk_size, len(all_updates)))} (/{len(all_updates)})'
+            )
+
+            responses = await asyncio.gather(
+                *[_make_update_igv_call(update) for update in updates],
+                return_exceptions=True,
+            )
+            exceptions.extend(
+                [(r, u) for u, r in zip(updates, responses) if isinstance(r, Exception)]
+            )
+            await asyncio.sleep(wait_time)
+
+        if exceptions:
+            exceptions_str = '\n'.join(f'\t{e} {u}' for e, u in exceptions)
+            logger.info(
+                f'{self.dataset} :: Failed to update {len(exceptions)} CRAMs: \n{exceptions_str}'
+            )
+        logger.info(
+            f'{self.dataset} :: Updated {len(all_updates)} / {number_of_uploadable_reads} CRAMs'
+        )
+
+    def sync_single_dataset_from_name(
+        self,
+        data_to_sync: dict[str, Any],
+    ):
+        """Sync a single dataset by fetching the guid and initiating sync"""
+        seqr_projects = MetamistFetcher().get_seqr_projects(
+            sequencing_type=self.sequencing_type, ignore_datasets=None
+        )
+        for project in seqr_projects:  # type: ignore
+            project_name = project['name']
+            project_guid = project['guid']
+            if project_name != self.dataset:
+                continue
+
+            logger.info(f'Syncing {project_name} to {project_guid}')
+
+            return self.sync_dataset(
+                data_to_sync=data_to_sync,
+            )
+
+        raise ValueError(f'Could not find {self.dataset} seqr project')

--- a/db/python/layers/seqr_sync/utils.py
+++ b/db/python/layers/seqr_sync/utils.py
@@ -1,0 +1,140 @@
+import datetime
+import json
+import logging
+import os
+import re
+
+import google.auth.exceptions
+import google.auth.transport.requests
+from cloudpathlib import AnyPath
+from google.oauth2 import service_account
+
+from .config import CREDENTIALS_FILENAME, MAP_LOCATION, SEQR_AUDIENCE
+from .logging_config import logger
+
+
+def get_token():
+    """Get identity-token for seqr specific service-credentials"""
+    credential_filename = CREDENTIALS_FILENAME
+    with open(credential_filename, 'r') as f:
+        info = json.load(f)
+        credentials_content = (info.get('type') == 'service_account') and info or None
+        credentials = service_account.IDTokenCredentials.from_service_account_info(
+            credentials_content, target_audience=SEQR_AUDIENCE
+        )
+        auth_req = google.auth.transport.requests.Request()
+        credentials.refresh(auth_req)
+        return credentials.token
+
+
+def parse_participants(
+    participants: dict,
+) -> tuple[set[str], set[str], dict[str, list[str]]]:
+    """
+    Parses the participants data from GraphQL / file and returns the data required for syncing
+
+    Returns:
+        - set of family external IDs
+        - set of participant external IDs
+        - dict mapping participant external IDs to internal sequencing group IDs
+    """
+    family_eids: set[str] = set()
+    participant_eids: set[str] = set()
+    peid_to_sgid_map: dict[str, list[str]] = {}
+    for participant in participants:
+        sg_ids = {
+            sg['id'] for s in participant['samples'] for sg in s['sequencingGroups']
+        }
+        if not sg_ids:
+            # nothing more required for this participant
+            continue
+
+        peid_to_sgid_map[participant['externalId']] = list(sg_ids)
+        participant_eids.add(participant['externalId'])
+        family_eids |= {f['externalId'] for f in participant['families']}
+
+    participant_eids = {p['externalId'] for p in participants}
+    filtered_family_eids = {
+        f['externalId'] for p in participants for f in p['families']
+    }
+
+    if not participant_eids:
+        raise ValueError('No participants to sync?')
+    if not filtered_family_eids:
+        raise ValueError('No families to sync')
+
+    return filtered_family_eids, participant_eids, peid_to_sgid_map
+
+
+def get_peid_to_reads_map(
+    sg_participants: dict[str, str], sg_crams: dict[str, str]
+) -> dict[str, list[str]]:
+    """Get a map of participant external IDs to their reads"""
+    peid_to_read_map: dict[str, list[str]] = {}
+    for sg, read_path in sg_crams.items():
+        participant = sg_participants[sg]
+        if participant not in peid_to_read_map:
+            peid_to_read_map[participant] = []
+        peid_to_read_map[participant].append(read_path)
+    return peid_to_read_map
+
+
+def write_sgid_to_peid_map_to_file(
+    dataset: str,
+    peid_to_sgid_map: dict[str, list[str]] | None = None,
+    sgid_to_peid_map: dict[str, str] | None = None,
+):
+    """Write the sgid - peid map to a file in the MAP_LOCATION directory"""
+    if not peid_to_sgid_map and not sgid_to_peid_map:
+        raise ValueError('No data to write to file')
+
+    if peid_to_sgid_map:
+        rows_to_write = [
+            # (ID in ES-Index, External PID in seqr)
+            '\t'.join([sg, pid])
+            for pid, p_sgids in peid_to_sgid_map.items()
+            for sg in p_sgids
+        ]
+    else:
+        rows_to_write = [
+            # (ID in ES-Index, External PID in seqr)
+            '\t'.join([sg, pid])
+            for sg, pid in sgid_to_peid_map.items()
+        ]
+
+    filename = f'{dataset}_sgid_peid_map_{datetime.datetime.now().isoformat()}.tsv'
+    filename = re.sub(r'[/\\?%*:|\'<>\x7F\x00-\x1F]', '-', filename)
+
+    fn_path = os.path.join(MAP_LOCATION, filename)
+    # pylint: disable=no-member
+    with AnyPath(fn_path).open('w+') as f:  # type: ignore
+        f.write('\n'.join(rows_to_write))
+    logger.info(
+        f'{dataset} :: Wrote {len(rows_to_write)} sequencing groups to {fn_path}'
+    )
+
+    return fn_path
+
+
+def check_for_missing_sgs(
+    dataset: str,
+    sequencing_type: str,
+    latest_analysis: dict,
+    peid_to_sgid_map: dict[str, list[str]],
+):
+    """Check for missing SGs in the latest ES index and log warnings if any are found"""
+    sg_ids = set(latest_analysis['sequencing_group_ids'])
+    logger.info(
+        f'{dataset}.{sequencing_type} :: Found {len(sg_ids)} SGs in index {latest_analysis["output"]}'
+    )
+    missing_sg_ids = {
+        sg for sgids in peid_to_sgid_map.values() for sg in sgids
+    } - sg_ids
+    if missing_sg_ids:
+        logging.warning(
+            f'{dataset}.{sequencing_type} :: Samples missing from index {latest_analysis["output"]}: '
+        )
+        for peid, sgids in peid_to_sgid_map.items():
+            missing_sgids = set(sgids) & missing_sg_ids
+            if missing_sgids:
+                logging.warning(f'\t{peid} :: {",".join(missing_sgids)}')


### PR DESCRIPTION
### Seqr Sync module
This PR contains a module to manage seqr syncing between Metamist and seqr. The idea is to abstract the aspects of the seqr sync process so that the data synced to a seqr project can be highly customized / tailored. 

Metamist already has an existing [`seqr` db layer ](https://github.com/populationgenomics/metamist/blob/dev/db/python/layers/seqr.py). This module looks to replace the existing layer with a more robust and abstracted implementation while reusing existing code where possible. A lot of the code in this module was also lifted from the [sync_seqr.py](https://github.com/populationgenomics/metamist/blob/dev/scripts/sync_seqr.py) script in `/scripts`.

**To break down the module:**

- **`seqr_sync.py`** The main part of the module that takes the transformed data and posts it to seqr. Any script used to sync data to seqr should instantiate an instance of this class and call the `sync_dataset` methods.
- **`data_fetchers.py`** Contains classes `MetamistFetcher` and `FileFetcher`. These classes contain methods to get data from Metamist and files respectively. The data will then need to be transformed into seqr's expected formats before being loaded.
- **`data_transformers.py`** Contains the `SeqrTransformer` class which converts from data formats output by Metamist into the data formats expected by seqr. e.g. processing ped sex & affected values, processing hpo terms, formatting the es-index json post, etc.
- **`config.py`** The definitions and global variables that clutter the top of the `sync_seqr.py` Metamist script have been put into this file for cleaner access.
- **`utils.py`** Contains helper methods needed by parts of the sync process, e.g. writing the SG - PID map to the bucket, diffing sequencing groups when loading a new es-index.
- **`logging_config.py`** Neatly contain the logging initialization for simple import and use.


**Still TODO**:

- [ ] Formalise how and where exactly this module belongs in the Metamist repo. 
    - A lot of the methods added in this PR leverage GraphQL queries, however it seems like the convention is that db layers should not use GQL API, and instead just use the standard REST APIs. Is it ok to add a module that leverages GQL like this? Why / why not?
- [ ] Integrate the existing seqr layer methods into this module - e.g. [`generate_seqr_auth_token`](https://github.com/populationgenomics/metamist/blob/93d55aaf60f4baab7144b2dbf613d26e7bf2bde0/db/python/layers/seqr.py#L265), [`send_slack_notification`](https://github.com/populationgenomics/metamist/blob/93d55aaf60f4baab7144b2dbf613d26e7bf2bde0/db/python/layers/seqr.py#L762)
- [ ] Implement simple and painless bulk syncing, i.e. select a number of projects & types to sync and execute all of them
- [ ] Update existing sync UI to work with the new module