### PR TITLE
Include Failed Jobs in cram size proportion calculation.

### DIFF
--- a/db/python/layers/analysis.py
+++ b/db/python/layers/analysis.py
@@ -175,8 +175,10 @@ class AnalysisLayer(BaseLayer):
             AnalysisFilter(
                 sequencing_group_id=GenericFilter(in_=list(sg_to_project.keys())),
                 type=GenericFilter(eq='cram'),
-                status=GenericFilter(eq=AnalysisStatus.COMPLETED),
-            )
+                status=GenericFilter(
+                    in_=[AnalysisStatus.COMPLETED, AnalysisStatus.FAILED],
+                ),
+            ),
         )
 
         crams_by_sg = group_by(cram_list, lambda c: c.sequencing_group_ids[0])


### PR DESCRIPTION
I had discovered issue with the way we calculate cram proportion size during the seqr billing aggregation.
Only sucessfully completed jobs are included. If job fails its' cost is being ignored.

I've tried to run seqr.py script to reload some of the old records. It is failing on this line:
https://github.com/populationgenomics/cpg-infrastructure/blob/bf3ef24e1d3663442fe237087461b6a42572d48f/cpg_infra/billing_aggregator/aggregate/seqr.py#L623

By investigation the sql records I have noticed that 2022-01-19 we only had failed jobs:

https://batch.hail.populationgenomics.org.au/batches/7284
https://batch.hail.populationgenomics.org.au/batches/7285
https://batch.hail.populationgenomics.org.au/batches/7317
https://batch.hail.populationgenomics.org.au/batches/7321

Their total cost is is around $80 USD as reported by Hail.

This PR is aiming to fix this discrepancy.