### PR TITLE
When updating Analysis record only set timestamp_completed value if it's not already set.

### DIFF
--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -187,7 +187,10 @@ VALUES ({cs_id_keys}) RETURNING id;"""
 
         if status == AnalysisStatus.COMPLETED:
             fields['timestamp_completed'] = datetime.datetime.utcnow()
-            setters.append('timestamp_completed = :timestamp_completed')
+            # only set timestamp_completed if it's not already set
+            setters.append(
+                'timestamp_completed = CASE WHEN timestamp_completed IS NULL THEN :timestamp_completed ELSE timestamp_completed END',
+            )
 
         if output:
             fields['output'] = output

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -343,7 +343,7 @@ class SequencingGroupTable(DbBase):
         _query = """
         SELECT sg.id, min(s.row_start)
         FROM sequencing_group sg
-        INNER JOIN sample s ON s.id = sg.sample_id
+        INNER JOIN sample FOR SYSTEM_TIME ALL s ON s.id = sg.sample_id
         WHERE sg.id in :sgids
         GROUP BY sg.id
         """

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,4 +1,5 @@
 # pylint: disable=invalid-overridden-method
+import time
 from test.testbase import DbIsolatedTest, run_as_sync
 
 from db.python.filters import GenericFilter
@@ -257,3 +258,67 @@ class TestAnalysis(DbIsolatedTest):
 
         self.assertEqual(sgs[0].id, genome_id)
         self.assertEqual(sgs[1].id, exome_id)
+
+    @run_as_sync
+    async def test_update_analysis(self):
+        """
+        Test Analysis update
+        """
+
+        # create an analysis
+        a_id = await self.al.create_analysis(
+            AnalysisInternal(
+                type='analysis-runner',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[],
+                meta={},
+            ),
+        )
+
+        # get the timestamp_completed of the analysis
+        init_analyses = await self.al.query(
+            AnalysisFilter(
+                project=GenericFilter(eq=self.project_id),
+                type=GenericFilter(eq='analysis-runner'),
+            )
+        )
+
+        # store the timestamp_completed
+        init_timestamp_completed = init_analyses[0].timestamp_completed
+
+        # be sure the now is different than before
+        time.sleep(2)
+
+        # update the analysis with some new data
+        await self.al.update_analysis(
+            a_id,
+            status=AnalysisStatus.COMPLETED,
+            meta={'sequencing_type': 'genome', 'size': 1024},
+            output='test_output',
+        )
+
+        # check the analysis after update
+        # be sure timestamp_completed has not been touched
+        analyses = await self.al.query(
+            AnalysisFilter(
+                project=GenericFilter(eq=self.project_id),
+                type=GenericFilter(eq='analysis-runner'),
+            ),
+        )
+        expected = [
+            AnalysisInternal(
+                id=a_id,
+                type='analysis-runner',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[],
+                cohort_ids=[],
+                output='test_output',
+                timestamp_completed=init_timestamp_completed,
+                project=1,
+                meta={'sequencing_type': 'genome', 'size': 1024},
+                active=True,
+                author=None,
+            ),
+        ]
+
+        self.assertEqual(analyses, expected)


### PR DESCRIPTION
This PR is fixing the issue with timestamp_completed being updated even if it has been set prior.
This is causing issues with seqr aggregation as it can not find any completed cram types prior to May 18, 2022
With more details reported in the close PR:
https://github.com/populationgenomics/metamist/pull/871

There are 5614 records with wrong timestamp_completed.

There are 3 steps to fix this issue:
1. Apply this PR
2. Backup the records to be fixed with this sql:

```
CREATE TABLE analysis_backup_prior_timestamp_completed_update AS
SELECT analysis.*
FROM analysis
INNER JOIN (
SELECT id, MIN(timestamp_completed) as timestamp_completed 
FROM analysis FOR SYSTEM_TIME ALL 
WHERE timestamp_completed IS NOT NULL
GROUP BY id
) as s
on s.id = analysis.id AND analysis.timestamp_completed <> s.timestamp_completed;
```

3. Update existing records with the sql:

```
CREATE TABLE tmp_analysis_new_timestamp_completed AS
SELECT s.id, s.timestamp_completed as new_timestamp_completed
FROM analysis a
INNER JOIN (
SELECT id, MIN(timestamp_completed) as timestamp_completed 
FROM analysis FOR SYSTEM_TIME ALL 
WHERE timestamp_completed IS NOT NULL
GROUP BY id
) as s
on s.id = a.id AND a.timestamp_completed <> s.timestamp_completed;

UPDATE analysis
INNER JOIN tmp_analysis_new_timestamp_completed s
on s.id = analysis.id AND analysis.timestamp_completed <> s.new_timestamp_completed
SET analysis.timestamp_completed = s.new_timestamp_completed
WHERE analysis.id in (SELECT id from tmp_analysis_new_timestamp_completed);


```


