### PR TITLE
Codecov Proposal: Allow the check to succeed even if a coverage threshold is missed

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,11 @@ coverage:
         # basic
         target: auto
         threshold: 0%
+        informational: true
         paths:
           - "db"
           - "scripts"
           - "metamist/parser"
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Sometimes (intermittently?) codecov has no data for either the base or head commit of a PR and can produce no coverage statistics. We don't want the GitHub checks to fail for spurious operational reasons like this, so [mark these coverage checks as informational only](https://docs.codecov.com/docs/commit-status#informational).

For example [here the base commit previously failed CI tests](https://centrepopgen.slack.com/archives/C03FZL2EF24/p1718758732767319), and at several commits in  #875 the HEAD statistics were missing so codecov/patch spuriously failed the build checks.

While it's good to pay attention to the coverage reports, I don't think we veto PRs on the basis of degraded coverage. So at least while there are intermittent spurious failures, we don't lose anything by stopping codecov from putting an :x: on builds.