### PR TITLE
Document metamist's required Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     url='https://github.com/populationgenomics/metamist',
     license='MIT',
     packages=all_packages,
+    python_requires='>=3.11',
     install_requires=[
         'backoff>=2.2.1',
         'click',


### PR DESCRIPTION
I've long run metamist (and the rest of my CPG work) on Python 3.10, but at least since PR #861 this no longer works — as `StrEnum` was introduced in Python 3.11:

```
ImportError: cannot import name 'StrEnum' from 'enum' (/opt/homebrew/Cellar/python@3.10/3.10.14_1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/enum.py)
```

This is mentioned in _docs/installation.md_, in which PR #696 bumped the documented requirement from 3.10 to 3.11.

This adds a mention in the canonical build-system place. (_pyproject.toml_ would be even more canonical, but we don't use a `[project]` section there, so _setup.py_ is the canonical place for this project.)