### PR TITLE
[test] Silence port errors + simplify test db construction

### DIFF
--- a/db/python/connect.py
+++ b/db/python/connect.py
@@ -369,9 +369,7 @@ class SMConnections:
             if log_database_queries is not None
             else LOG_DATABASE_QUERIES
         )
-        return databases.Database(
-            config.get_connection_string(), echo=LOG_DATABASE_QUERIES
-        )
+        return databases.Database(config.get_connection_string(), echo=_should_log)
 
     @staticmethod
     async def connect():

--- a/db/python/connect.py
+++ b/db/python/connect.py
@@ -359,9 +359,16 @@ class SMConnections:
         return SMConnections._credentials
 
     @staticmethod
-    def make_connection(config: DatabaseConfiguration):
+    def make_connection(
+        config: DatabaseConfiguration, log_database_queries: bool | None = None
+    ):
         """Create connection from dbname"""
         # the connection string will prepare pooling automatically
+        _should_log = (
+            log_database_queries
+            if log_database_queries is not None
+            else LOG_DATABASE_QUERIES
+        )
         return databases.Database(
             config.get_connection_string(), echo=LOG_DATABASE_QUERIES
         )

--- a/test/testbase.py
+++ b/test/testbase.py
@@ -50,7 +50,7 @@ for lname in (
 def find_and_bind_socket() -> socket.socket:
     """Find free port to run tests on"""
     s = socket.socket()
-    s.bind(('', 0))  # Bind to a free port provided by the host.
+    # s.bind(('', 0))  # Bind to a free port provided by the host.
     return s
 
 

--- a/test/testbase.py
+++ b/test/testbase.py
@@ -103,7 +103,7 @@ class DbTest(unittest.TestCase):
             try:
                 db = MySqlContainer('mariadb:11.2.2', password='test')
                 socket = find_and_bind_socket()
-                port_to_expose = int(socket.getsockname()[1])
+                port_to_expose = socket.getsockname()[1]
                 cls.socket_by_class[cls.__name__] = socket
 
                 # override the default port to map the container to

--- a/test/testbase.py
+++ b/test/testbase.py
@@ -109,7 +109,7 @@ class DbTest(unittest.TestCase):
 
                     # override the default port to map the container to
                     db.with_bind_ports(db.port, port_to_expose)
-                    # logger.disabled = True
+                    logger.disabled = True
                     db.start()
                     logger.disabled = False
                     cls.dbs = db
@@ -132,7 +132,6 @@ class DbTest(unittest.TestCase):
                         password=db.password,
                         dbname=db.dbname,
                     ),
-                    log_database_queries=True,
                 )
 
                 # create the database for each test class, and give permissions

--- a/test/testbase.py
+++ b/test/testbase.py
@@ -4,6 +4,7 @@ import asyncio
 import dataclasses
 import logging
 import os
+import socket
 import subprocess
 import unittest
 from functools import wraps
@@ -46,6 +47,15 @@ for lname in (
 
 
 loop = asyncio.new_event_loop()
+
+
+def find_free_port():
+    """Find free port to run tests on"""
+    s = socket.socket()
+    s.bind(('', 0))  # Bind to a free port provided by the host.
+    free_port_number = s.getsockname()[1]  # Return the port number assigned.
+    s.close()  # free the port so we can immediately use
+    return free_port_number
 
 
 def run_as_sync(f):
@@ -95,7 +105,7 @@ class DbTest(unittest.TestCase):
                 if not cls.dbs:
                     db = MySqlContainer('mariadb:11.2.2', password='test')
 
-                    port_to_expose = 3309  # hopefully it's free
+                    port_to_expose = find_free_port()
 
                     # override the default port to map the container to
                     db.with_bind_ports(db.port, port_to_expose)

--- a/test/testbase.py
+++ b/test/testbase.py
@@ -127,7 +127,7 @@ class DbTest(unittest.TestCase):
 
                 # create the database for each test class, and give permissions
                 await _root_connection.connect()
-                await _root_connection.execute(f"CREATE DATABASE {db_name};")
+                await _root_connection.execute(f'CREATE DATABASE {db_name};')
                 await _root_connection.execute(
                     f"GRANT ALL PRIVILEGES ON `{db_name}`.* TO {db.username}@'%';"
                 )

--- a/test/testbase.py
+++ b/test/testbase.py
@@ -136,25 +136,20 @@ class DbTest(unittest.TestCase):
 
                 # mfranklin -> future dancoates: if you work out how to copy the
                 #       database instead of running liquibase, that would be great
-                is_copying_enabled = False
-
-                if is_copying_enabled:
-                    raise NotImplementedError("Copying databases doesn't work")
-                else:
-                    lcon_string = f'jdbc:mariadb://{db.get_container_host_ip()}:{port_to_expose}/{db_name}'
-                    # apply the liquibase schema
-                    command = [
-                        'liquibase',
-                        *('--changeLogFile', db_prefix + '/project.xml'),
-                        *('--defaultsFile', db_prefix + '/liquibase.properties'),
-                        *('--url', lcon_string),
-                        *('--driver', 'org.mariadb.jdbc.Driver'),
-                        *('--classpath', db_prefix + '/mariadb-java-client-3.0.3.jar'),
-                        *('--username', db.username),
-                        *('--password', db.password),
-                        'update',
-                    ]
-                    subprocess.check_output(command, stderr=subprocess.STDOUT)
+                lcon_string = f'jdbc:mariadb://{db.get_container_host_ip()}:{port_to_expose}/{db_name}'
+                # apply the liquibase schema
+                command = [
+                    'liquibase',
+                    *('--changeLogFile', db_prefix + '/project.xml'),
+                    *('--defaultsFile', db_prefix + '/liquibase.properties'),
+                    *('--url', lcon_string),
+                    *('--driver', 'org.mariadb.jdbc.Driver'),
+                    *('--classpath', db_prefix + '/mariadb-java-client-3.0.3.jar'),
+                    *('--username', db.username),
+                    *('--password', db.password),
+                    'update',
+                ]
+                subprocess.check_output(command, stderr=subprocess.STDOUT)
 
                 cls.author = 'testuser'
 


### PR DESCRIPTION
~~I don't know why this isn't working ...~~
Looks like it more just accidentally always worked.

This PR:
- When searching for a free port, explicitly disconnect before giving to the database (rather than the accidental garbage collection free up)
- Reduces the number of containers used, by creating multiple databases on the same MariaDB instance.