### PR TITLE
Lock openapi schema version for swagger UI to 3.0.2

### DIFF
--- a/api/utils/openapi.py
+++ b/api/utils/openapi.py
@@ -78,7 +78,7 @@ def get_openapi_schema_func(app, version):
             version=version,
             routes=app.routes,
             # update when FastAPI + swagger supports 3.1.0
-            # openapi_version='3.1.0'
+            openapi_version='3.0.2',
         )
 
         openapi_schema['servers'] = [{'url': url} for url in URLS]


### PR DESCRIPTION
Not quite sure why this suddenly broke, but this seems to fix it