### PR TITLE
Upgrade deprecated pydantic methods

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -213,7 +213,9 @@ class GraphQLCohortTemplate:
             id=cohort_template_id_format(internal.id),
             name=internal.name,
             description=internal.description,
-            criteria=internal.criteria.to_external(project_names=project_names).dict(),
+            criteria=internal.criteria.to_external(
+                project_names=project_names
+            ).model_dump(),
             project_id=internal.project,
         )
 

--- a/models/models/billing.py
+++ b/models/models/billing.py
@@ -220,7 +220,7 @@ class BillingTotalCostQueryModel(SMBase):
 
     def __hash__(self):
         """Create hash for this object to use in caching"""
-        return hash(self.json())
+        return hash(self.model_dump_json())
 
     def to_filter(self) -> BillingFilter:
         """

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -266,11 +266,11 @@ class TestCohortData(DbIsolatedTest):
         cc_external = CohortCriteria(**cc_external_dict)
         cc_internal = cc_external.to_internal(projects_internal=[self.project_id])
         self.assertIsInstance(cc_internal, CohortCriteriaInternal)
-        self.assertDictEqual(cc_internal.dict(), cc_internal_dict)
+        self.assertDictEqual(cc_internal.model_dump(), cc_internal_dict)
 
         cc_ext_trip = cc_internal.to_external(project_names=[self.project_name])
         self.assertIsInstance(cc_ext_trip, CohortCriteria)
-        self.assertDictEqual(cc_ext_trip.dict(), cc_external_dict)
+        self.assertDictEqual(cc_ext_trip.model_dump(), cc_external_dict)
 
         ctpl_internal_dict = {
             'id': 496,
@@ -289,7 +289,7 @@ class TestCohortData(DbIsolatedTest):
             criteria_projects=[self.project_id], template_project=self.project_id
         )
         self.assertIsInstance(ctpl_internal, CohortTemplateInternal)
-        self.assertDictEqual(ctpl_internal.dict(), ctpl_internal_dict)
+        self.assertDictEqual(ctpl_internal.model_dump(), ctpl_internal_dict)
 
     @run_as_sync
     async def test_create_cohort_by_sgs(self):


### PR DESCRIPTION
@dancoates As soon as you mentioned it, I couldn't not see them.

```
.../python3.11/site-packages/pydantic/main.py:1094: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/

.../3.11.9/x64/lib/python3.11/site-packages/pydantic/main.py:1070: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
```