### PR TITLE
Removed FCF branch from workflow criteria

### DIFF
--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - id: 'branch-check'
         name: Fail if branch is not main or dev
-        if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/first-class-files-v3')
+        if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         run: |
           echo "This workflow should not be triggered with workflow_dispatch on a branch other than main or dev"
           exit 1


### PR DESCRIPTION
Looks like I forgot to remove the branch from the criteria, when I was testing E2E with prod-pipes.