### PR TITLE
Increased the dirname column size

### DIFF
--- a/db/project.xml
+++ b/db/project.xml
@@ -1595,4 +1595,9 @@
 		<sql>ALTER TABLE `analysis_outputs` ADD SYSTEM VERSIONING;</sql>
 		<sql>ALTER TABLE `analysis_outputs` ADD CONSTRAINT `chk_file_id_output` CHECK ((file_id IS NOT NULL AND output IS NULL) OR (file_id IS NULL AND output IS NOT NULL));</sql>
 	</changeSet>
+	<changeSet id="2024-08-22_fcf_dirname" author="yash.pankhania">
+		<sql>ALTER TABLE `output_file` DROP SYSTEM VERSIONING;</sql>
+		<sql>ALTER TABLE output_file MODIFY dirname VARCHAR(255);</sql>
+		<sql>ALTER TABLE `output_file` ADD SYSTEM VERSIONING;</sql>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Some bucket names are longer than 100 characters that I originally anticipated to be our limit. This increases that to 255 chars.