### PR TITLE
Fix pedigree affected (filled) / unaffected (outline) colouring

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -92,8 +92,8 @@ html[data-theme='dark-mode'] {
     --color-text-href: rgb(188, 188, 251);
 
     --color-pedigree-person-border: rgb(169, 169, 169);
-    --color-pedigree-affected: rgb(51, 51, 51);
-    --color-pedigree-unaffected: rgb(153, 153, 153);
+    --color-pedigree-affected: rgb(153, 153, 153);
+    --color-pedigree-unaffected: rgb(51, 51, 51);
 
     --color-header-row: #383838;
     --color-exome-row: #887830;

--- a/web/src/shared/components/pedigree/TangledTree.tsx
+++ b/web/src/shared/components/pedigree/TangledTree.tsx
@@ -514,7 +514,7 @@ export const PersonNode: React.FC<IPersonNodeProps> = ({
                     strokeLinecap={entry.sex === 1 ? 'square' : 'round'}
                 />
                 <path
-                    stroke={entry.affected === 1 ? colAffected : colUnaffected}
+                    stroke={entry.affected === 2 ? colAffected : colUnaffected}
                     strokeWidth={nodeSize * 0.65}
                     strokeLinecap={entry.sex === 1 ? 'square' : 'round'}
                     d={`M${node.x} ${node.y} L${node.x} ${node.y}`}


### PR DESCRIPTION
Somewhat by luck, the conventional indication was used in dark mode but swapped in light mode.

Status codes are `1`=unaffected / `2`=affected, so correct the conditional in the code and reverse the dark mode colours in the CSS. With those changes, in both light/dark modes, `colAffected` approximately matches the person-border colour and `colUnaffected` approximately matches the background colour (and is used to redraw the interior, producing an outline), as expected. Fixes [SET-164](https://cpg-populationanalysis.atlassian.net/browse/SET-164).

[SET-164]: https://cpg-populationanalysis.atlassian.net/browse/SET-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ