### PR TITLE
Added branch ref to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@
 
 version: 2
 updates:
+  - target-branch: "dev"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -13,15 +14,13 @@ updates:
     groups:
       minor-and-patch:
         patterns:
-          - "requirements.in"
-          - "requirements-dev.in"
+          - "*"
         update-types:
           - "minor"
           - "patch"
 
       major:
         patterns:
-          - "requirements.in"
-          - "requirements-dev.in"
+          - "*"
         update-types:
           - "major"

--- a/.github/workflows/compile_requirements.yaml
+++ b/.github/workflows/compile_requirements.yaml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }} # Checkout the branch from the pull request
 
       - name: Run pip-compile in Docker
         run: |

--- a/.github/workflows/compile_requirements.yaml
+++ b/.github/workflows/compile_requirements.yaml
@@ -1,4 +1,4 @@
-name: Compile Requirements with Docker
+name: Compile Requirements
 
 on:
   pull_request:
@@ -23,7 +23,7 @@ jobs:
           docker run --platform linux/amd64 \
             -v ${{ github.workspace }}:/opt/metamist \
             --workdir /opt/metamist \
-            --rm python:3.10-slim bash -c " \
+            --rm python:3.11-slim bash -c " \
               pip install pip-tools && \
               echo 'Installed pip-tools!'; \
               echo 'Compiling from requirements.in'; \

--- a/.github/workflows/compile_requirements.yaml
+++ b/.github/workflows/compile_requirements.yaml
@@ -27,9 +27,9 @@ jobs:
               pip install pip-tools && \
               echo 'Installed pip-tools!'; \
               echo 'Compiling from requirements.in'; \
-              pip-compile requirements.in > requirements.txt && \
+              pip-compile requirements.in && \
               echo 'Compiling from requirements-dev.in'; \
-              pip-compile --output-file=requirements-dev.txt requirements-dev.in requirements.in"
+              pip-compile requirements-dev.in"
 
       - name: Commit updated requirements files
         run: |


### PR DESCRIPTION
This adds a branch ref to the workflow so that Dependabot can commit changes to it. The grouping is still problematic but this final fix should hopefully resolve it.