### PR TITLE
Dependabot Config Syntax Error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-  - target-branch: "dev"
   - package-ecosystem: "pip"
+    target-branch: "dev"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
There seems to be a syntax error with the target branch, that causes the dependabot checks to fail