### PR TITLE
Fixed faulty FCF dictionary behaviour

### DIFF
--- a/db/project.xml
+++ b/db/project.xml
@@ -1774,5 +1774,19 @@
 
 		<sql>ALTER TABLE family_comment ADD SYSTEM VERSIONING;</sql>
 	</changeSet>
+	<changeSet id="2024-09-25_add_unique_fcf_constraint" author="yash.pankhania">
+		<!-- Adding Unique Constraint to analysis_outputs table -->
+		<sql>ALTER TABLE `analysis_outputs` DROP SYSTEM VERSIONING;</sql>
+		<sql>
+        ALTER TABLE analysis_outputs
+		ADD CONSTRAINT unique_analysis_file
+    	UNIQUE (analysis_id, file_id, json_structure);</sql>
+		<sql>
+		ALTER TABLE analysis_outputs
+		ADD CONSTRAINT unique_analysis_output
+    	UNIQUE (analysis_id, output, json_structure);
+		</sql>
+		<sql>ALTER TABLE `analysis_outputs` ADD SYSTEM VERSIONING;</sql>
+	</changeSet>
 
 </databaseChangeLog>

--- a/models/models/output_file.py
+++ b/models/models/output_file.py
@@ -177,13 +177,12 @@ class OutputFileInternal(SMBase):
                 if not blobs and not isinstance(blobs, list):
                     blobs = OutputFileInternal.list_blobs(
                         bucket=params['bucket'],
-                        prefix=(
-                            params['path_after_bucket'] if params['prefix'] else None
-                        ),
+                        prefix=params['blob_name'],
                         delimiter=params['delimiter'],
                         client=client,
                         versions=False,
                     )
+
                 for blob in blobs:
                     if blob.name == params['blob_name']:
                         # .mt files present as folders on gcs so calculating checksums is not avail.
@@ -191,6 +190,7 @@ class OutputFileInternal(SMBase):
                             file_checksum = blob.crc32c  # pylint: disable=E1101
                             valid = True
                             size = blob.size  # pylint: disable=E1101
+                            break
 
             return OutputFileInternal.from_db(
                 **{


### PR DESCRIPTION
There was an issue reported by @EddieLF where the dictionary passed to the `/update` endpoint was being discarded. I traced the bug to the GCS Client not listing blobs as expected. The behaviour seems to have changed recently and I have tried to fix this by using `blob_name` which does not have a `/` at the front. There are some additional changes being made:

- Unique constraint added to ensure we do not add the same file/output over and over again to the join table. There is a caveat here - MariaDB does not treat NULL values as the same, and so rows with NULL values in some columns look unique despite being the same. I have added a DISTINCT clause to my query but there could be a lot of duplicate inserts to this table. This is worth looking at, in more detail. Open for suggestions <3 
- Query should return all outputs (both files and plain strings), which it now does.