### PR TITLE
Fix family external id participant grid filter

### DIFF
--- a/web/src/pages/project/ValueFilter.tsx
+++ b/web/src/pages/project/ValueFilter.tsx
@@ -85,22 +85,19 @@ export const ValueFilter: React.FC<IValueFilter> = ({
     //  So check if the filterKey starts with 'meta.' to determine if it is a meta key, and
     //  then check the [category].meta object for the value
 
+    if (!field.filter_key) return <></>
+
+    /* eslint-disable react-hooks/rules-of-hooks*/
     const [_defaultFilterType, setDefaultFilterType] = React.useState<
         ProjectParticipantGridFilterType | undefined
     >()
-
-    let optionsToCheck = props?.filterValues?.[category] || {}
-    const name = (field.filter_key ?? '').replace(/^meta\./, '')
-
-    // @ts-ignore
-    const _value = optionsToCheck?.[name]?.[operator]
-    const [_tempValue, setTempValue] = React.useState<string | undefined>(_value ?? '')
-    const tempValue = _tempValue ?? _value
-
-    if (!field.filter_key) return <></>
+    /* eslint-enable react-hooks/rules-of-hooks*/
 
     const isMeta = field.filter_key?.startsWith('meta.')
     // set name to the filterKey without the .meta prefix
+    const name = field.filter_key.replace(/^meta\./, '')
+
+    let optionsToCheck = props?.filterValues?.[category] || {}
 
     if (isMeta) {
         // get the meta bit from the filterValues
@@ -145,6 +142,14 @@ export const ValueFilter: React.FC<IValueFilter> = ({
         queryType = _defaultFilterType || options[0] || ProjectParticipantGridFilterType.Icontains
         operator = getOperatorFromFilterType(queryType)
     }
+
+    // @ts-ignore
+    const _value = optionsToCheck?.[name]?.[operator]
+
+    /* eslint-disable react-hooks/rules-of-hooks*/
+    const [_tempValue, setTempValue] = React.useState<string | undefined>(_value ?? '')
+    /* eslint-enable react-hooks/rules-of-hooks*/
+    const tempValue = _tempValue ?? _value
 
     const updateQueryType = (newFilterType: ProjectParticipantGridFilterType) => {
         setDefaultFilterType(newFilterType)


### PR DESCRIPTION
- Rolls back changes to value filter introduced in #957, this is just to allow for this quick fix, they can be re-added later when we have time to test and bugfix them
- Adds support for querying participant grid by family external id