### PR TITLE
Update project_insights code to account for multiple family external ids changes

### DIFF
--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -750,7 +750,7 @@ SELECT
     sg.technology as sequencing_technology,
     s.type as sample_type,
     f.id as family_id,
-    f.external_id as family_external_id,
+    fext.external_id as family_external_id,
     fp.participant_id as participant_id,
     pext.external_id as participant_external_id,
     s.id as sample_id,
@@ -759,6 +759,7 @@ SELECT
 FROM
     family f
     LEFT JOIN family_participant fp ON f.id = fp.family_id
+    LEFT JOIN family_external_id fext ON f.id = fext.family_id
     LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
     LEFT JOIN sample s ON fp.participant_id = s.participant_id
     LEFT JOIN sample_external_id sext ON s.id = sext.sample_id

--- a/test/test_project_insights.py
+++ b/test/test_project_insights.py
@@ -111,3 +111,14 @@ class TestProjectInsights(DbIsolatedTest):
         ]
 
         self.assertEqual(result, expected)
+
+    @run_as_sync
+    async def test_project_insights_details(self):
+        """Test getting the details for all available projects"""
+
+        await self.partl.upsert_participant(get_test_participant())
+
+        # There's not enough data set up to usefully verify the result
+        _ = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome', 'exome']
+        )


### PR DESCRIPTION
When on the final phase of merging #896, I did not exhaustively recheck the code base for newly arrived references to the soon-to-be-obsolete `family.external_id` field. Since that PR had been begun, this code had been merged and uses this field. And unluckily the project_insights test cases tested only the summary not the details, so the old field access was not detected via the unit tests.

Fix this instance to use the new separate `family_external_id` table, and add a details test case that just causes the relevant code to be run.

Note that as for `pext.external_id` and `sext.external_id`, this might benefit from being aggregated (or alternatively maybe joining also on `fext.name = ''`) as at present multiple rows may be returned if an an item actually does have multiple external ids. But that can be adjusted as and when it actually occurs.