### PR TITLE
Fix return type of enum create routes

### DIFF
--- a/api/routes/enum.py
+++ b/api/routes/enum.py
@@ -22,9 +22,7 @@ def _create_route(e: Type[EnumTable]):
         return await e(connection).get()
 
     @router.post('/' + hyphenated_name, operation_id='post' + camel_case_name + 's')
-    async def post(
-        new_type: str, connection=get_projectless_db_connection
-    ) -> list[str]:
+    async def post(new_type: str, connection=get_projectless_db_connection) -> str:
         return await e(connection).insert(new_type)
 
 


### PR DESCRIPTION
The return type was list[str] but the table method actually just returned a string. This caused a 500 error on the response