### PR TITLE
Script to upsert MGRB participants

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.4.0
     # via aiohttp
-aiohttp==3.10.5
+aiohttp==3.10.*
     # via -r requirements.in
 aiomysql==0.2.0
     # via databases
@@ -479,5 +479,5 @@ wrapt==1.16.0
     # via
     #   deprecated
     #   testcontainers
-yarl==1.9.10
+yarl==1.12.*
     # via aiohttp

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -110,7 +110,7 @@ docker==7.1.0
     # via testcontainers
 email-validator==2.2.0
     # via fastapi
-fastapi[all]==0.112.2
+fastapi[all]==0.115.5
     # via
     #   -r requirements.in
     #   strawberry-graphql
@@ -413,7 +413,7 @@ sqlalchemy==2.0.34
     # via
     #   databases
     #   testcontainers
-starlette==0.40.0
+starlette==0.41.2
     # via
     #   fastapi
     #   strawberry-graphql

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -413,7 +413,7 @@ sqlalchemy==2.0.34
     # via
     #   databases
     #   testcontainers
-starlette==0.38.4
+starlette==0.40.0
     # via
     #   fastapi
     #   strawberry-graphql
@@ -471,7 +471,7 @@ watchfiles==0.24.0
     # via uvicorn
 websockets==13.0.1
     # via uvicorn
-werkzeug==3.0.4
+werkzeug==3.0.6
     # via
     #   flask
     #   functions-framework

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ google-cloud-logging==2.7.0
 google-cloud-pubsub==2.18.3
 google-cloud-storage==1.43.0
 uvicorn==0.29.0
-fastapi[all]==0.112.2
+fastapi[all]==0.115.5
 strawberry-graphql[fastapi]==0.243.0
 databases[mysql]==0.9.0
 cryptography>=41.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
     # via fastapi
-fastapi[all]==0.112.2
+fastapi[all]==0.115.5
     # via
     #   -r requirements.in
     #   strawberry-graphql
@@ -298,7 +298,7 @@ sniffio==1.3.1
     #   httpx
 sqlalchemy==2.0.34
     # via databases
-starlette==0.40.0
+starlette==0.41.2
     # via fastapi
 strawberry-graphql[fastapi]==0.243.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.4.0
     # via aiohttp
-aiohttp==3.10.5
+aiohttp==3.10.*
     # via -r requirements.in
 aiomysql==0.2.0
     # via databases
@@ -338,5 +338,5 @@ websockets==13.0.1
     # via uvicorn
 wrapt==1.16.0
     # via deprecated
-yarl==1.9.10
+yarl==1.12.*
     # via aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -298,7 +298,7 @@ sniffio==1.3.1
     #   httpx
 sqlalchemy==2.0.34
     # via databases
-starlette==0.38.4
+starlette==0.40.0
     # via fastapi
 strawberry-graphql[fastapi]==0.243.0
     # via -r requirements.in

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -163,9 +163,7 @@ def main(project: str, participant_meta: str, sample_meta: str):
     participant_upserts = []
     for peid, sample_upserts in participant_sample_map.items():
         participant_upserts.append(
-            create_participant(
-                sample_upserts, peid, participant_sex_map[peid]
-            )
+            create_participant(sample_upserts, peid, participant_sex_map[peid])
         )
 
     # Upsert participants

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -105,14 +105,16 @@ def read_files_from_gcs(bucket_name: str, file_path: str):
 
 
 @click.command()
+@click.option('--test', is_flag=True, help='Run in test mode.')
 @click.option('--project', help='Project name to upsert participants to.')
 @click.option('--participant-meta', help='Path to participant metadata CSV.')
 @click.option('--sample-meta', help='Path to sample metadata CSV.')
-def main(project: str, participant_meta: str, sample_meta: str):
+def main(test: bool, project: str, participant_meta: str, sample_meta: str):
     """Upsert participants to metamist"""
     # Query metamist
     data_response = get_sample_data(project)
     project_id = data_response.get('project')['id']
+    bucket_name = f'cpg-{project}-{'test' if test else 'main'}-upload'
 
     sample_eid_mapping = map_sample_eid_to_sample_data(data_response)
 
@@ -120,8 +122,8 @@ def main(project: str, participant_meta: str, sample_meta: str):
     logging.basicConfig(level=logging.INFO)
 
     # Read in csv
-    participant_data_io = read_files_from_gcs(BUCKET_NAME, participant_meta)
-    sample_data_io = read_files_from_gcs(BUCKET_NAME, sample_meta)
+    participant_data_io = read_files_from_gcs(bucket_name, participant_meta)
+    sample_data_io = read_files_from_gcs(bucket_name, sample_meta)
 
     participant_data_list = list(csv.DictReader(participant_data_io))
     sample_data_list = list(csv.DictReader(sample_data_io, delimiter='\t'))

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -1,0 +1,179 @@
+import csv
+import logging
+from collections import defaultdict
+from io import StringIO
+from typing import Dict, List
+
+import click
+from google.cloud import storage
+
+from metamist.apis import ParticipantApi
+from metamist.graphql import gql, query
+from metamist.models import (
+    ParticipantUpsert,
+    SampleUpsert,
+)
+
+BUCKET_NAME = 'cpg-mgrb-test-upload'
+
+SAMPLE_QUERY = gql(
+    """
+    query getSampleData($project: String!) {
+        project(name: $project) {
+            id
+        }
+        sample(project: {eq: $project}) {
+            id
+            active
+            externalId
+            sequencingGroups {
+            id
+            assays {
+                id
+                meta
+            }
+            analyses {
+                id
+                output
+                outputs
+                meta
+                }
+            }
+        }
+    }
+    """
+)
+
+PARTICIPANT_QUERY = gql(
+    """
+    query getParticipantData($project: String!) {
+    project(name: $project) {
+        participants {
+            id
+            externalId
+            }
+        }
+    }
+    """
+)
+
+papi = ParticipantApi()
+
+
+def map_sample_eid_to_sample_data(data):
+    """Map sample external ID to sample data"""
+    return {sample['externalId']: sample for sample in data['sample']}
+
+
+def get_sample_data(project):
+    """Get sample data from metamist"""
+    response = query(SAMPLE_QUERY, {'project': project})
+    if not isinstance(response, dict):
+        raise ValueError('Expected a dictionary response from query')
+    return response
+
+
+def create_participant(sample_data: list, peid: str, sex: int):
+    """Create participant upsert object"""
+    participant_upsert = [
+        ParticipantUpsert(
+            id=None,
+            external_ids={'': peid},
+            reported_sex=sex,
+            samples=sample_data,
+        ),
+    ]
+    return participant_upsert
+
+
+def create_sample(project_id: int, seid: str, siid: str):
+    """Create sample upsert object"""
+    return SampleUpsert(
+        id=siid,
+        external_ids={'': seid},
+        project=project_id,
+    )
+
+
+def read_files_from_gcs(bucket_name, file_path):
+    """Read files from GCS"""
+    client = storage.Client()
+    bucket = client.get_bucket(bucket_name)
+    blob = bucket.blob(file_path)
+    blob = blob.download_as_text(encoding='utf-8')
+    return StringIO(blob)
+
+
+@click.command()
+@click.option('--project', help='Project name to upsert participants to.')
+@click.option('--participant-meta', help='Path to participant metadata CSV.')
+@click.option('--sample-meta', help='Path to sample metadata CSV.')
+def main(project: str, participant_meta: str, sample_meta: str):
+    """Upsert participants to metamist"""
+    # Query metamist
+    data_response = get_sample_data(project)
+    project_id = data_response.get('project')['id']
+
+    sample_eid_mapping = map_sample_eid_to_sample_data(data_response)
+
+    # Set up logging
+    logging.basicConfig(level=logging.INFO)
+
+    # Read in csv
+    participant_data_io = read_files_from_gcs(BUCKET_NAME, participant_meta)
+    sample_data_io = read_files_from_gcs(BUCKET_NAME, sample_meta)
+
+    participant_data_list = list(csv.DictReader(participant_data_io))
+    sample_data_list = list(csv.DictReader(sample_data_io, delimiter='\t'))
+
+    # Count of samples for each participant
+    participant_sample_count: Dict[str, int] = defaultdict(int)
+    metadata_map = {}
+    for meta_row in participant_data_list:
+        metadata_map[meta_row['sampleID']] = meta_row
+        peid = meta_row['externalID']
+        participant_sample_count[peid] += 1
+
+    # Map peid to a list of sample upsert objects
+    participant_sex_map = {}
+    participant_sample_map: Dict[str, List[SampleUpsert]] = defaultdict(list)
+
+    for name_row in sample_data_list:
+        # Get the external ID
+        seid = '.'.join(name_row['CRAM'].split('.')[:2])
+
+        meta_row = metadata_map.get(name_row['RGSM (SampleID)'])
+        # Get participant external ID
+        peid = meta_row['externalID']
+
+        # Code sex
+        sex = 2 if meta_row['isFemale'].upper() == 'TRUE' else 1
+
+        # Get the sample internal ID
+        if seid not in sample_eid_mapping:
+            print(f'Sample {seid} not found in metamist.')
+            continue
+        siid = sample_eid_mapping[seid]['id']
+
+        if peid not in participant_sample_map:
+            participant_sample_map[peid] = []
+            participant_sex_map[peid] = sex
+        participant_sample_map[peid].append(create_sample(project_id, seid, siid))
+
+    participant_upserts = []
+    for peid, sample_upserts in participant_sample_map.items():
+        participant_upserts.append(
+            create_participant(
+                sample_upserts, peid, participant_sex_map[peid]
+            )
+        )
+
+    # Upsert participants
+    for participant_upsert in participant_upserts:
+        api_response = papi.upsert_participants(project, participant_upsert)
+        print(api_response)
+
+
+if __name__ == '__main__':
+    # pylint: disable=no-value-for-parameter
+    main()

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -114,7 +114,7 @@ def main(test_bucket: bool, project: str, participant_meta: str, sample_meta: st
     # Query metamist
     data_response = get_sample_data(project)
     project_id = data_response.get('project')['id']
-    bucket_name = f'cpg-{project}-{'test' if test_bucket else 'main'}-upload'
+    bucket_name = f'cpg-{project}-{"test" if test_bucket else "main"}-upload'
 
     sample_eid_mapping = map_sample_eid_to_sample_data(data_response)
 

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -75,15 +75,12 @@ def get_sample_data(project: str):
 
 def create_participant(sample_data: list, peid: str, sex: int):
     """Create participant upsert object"""
-    participant_upsert = [
-        ParticipantUpsert(
-            id=None,
-            external_ids={'': peid},
-            reported_sex=sex,
-            samples=sample_data,
-        ),
-    ]
-    return participant_upsert
+    return ParticipantUpsert(
+        id=None,
+        external_ids={'': peid},
+        reported_sex=sex,
+        samples=sample_data,
+    )
 
 
 def create_sample(project_id: int, seid: str, siid: str):
@@ -169,9 +166,8 @@ def main(test_bucket: bool, project: str, participant_meta: str, sample_meta: st
         )
 
     # Upsert participants
-    for participant_upsert in participant_upserts:
-        api_response = papi.upsert_participants(project, participant_upsert)
-        print(api_response)
+    api_response = papi.upsert_participants(project, participant_upserts)
+    print(api_response)
 
 
 if __name__ == '__main__':

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -106,7 +106,14 @@ def read_files_from_gcs(bucket_name: str, file_path: str):
 @click.option('--project', help='Project name to upsert participants to.')
 @click.option('--participant-meta', help='Path to participant metadata CSV.')
 @click.option('--sample-meta', help='Path to sample metadata CSV.')
-def main(test_bucket: bool, project: str, participant_meta: str, sample_meta: str):
+@click.option('--sample-external-id-column', help='Column name for sample external ID.')
+def main(
+    test_bucket: bool,
+    project: str,
+    participant_meta: str,
+    sample_meta: str,
+    sample_external_id_column: str,
+):
     """Upsert participants to metamist"""
     # Query metamist
     data_response = get_sample_data(project)
@@ -141,7 +148,7 @@ def main(test_bucket: bool, project: str, participant_meta: str, sample_meta: st
         # Get the external ID
         seid = '.'.join(name_row['CRAM'].split('.')[:2])
 
-        meta_row = metadata_map.get(name_row['RGSM (SampleID)'])
+        meta_row = metadata_map.get(name_row[sample_external_id_column])
         # Get participant external ID
         peid = meta_row['externalID']
 

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -105,16 +105,16 @@ def read_files_from_gcs(bucket_name: str, file_path: str):
 
 
 @click.command()
-@click.option('--test', is_flag=True, help='Run in test mode.')
+@click.option('--test-bucket', is_flag=True, help='Run in test mode.')
 @click.option('--project', help='Project name to upsert participants to.')
 @click.option('--participant-meta', help='Path to participant metadata CSV.')
 @click.option('--sample-meta', help='Path to sample metadata CSV.')
-def main(test: bool, project: str, participant_meta: str, sample_meta: str):
+def main(test_bucket: bool, project: str, participant_meta: str, sample_meta: str):
     """Upsert participants to metamist"""
     # Query metamist
     data_response = get_sample_data(project)
     project_id = data_response.get('project')['id']
-    bucket_name = f'cpg-{project}-{'test' if test else 'main'}-upload'
+    bucket_name = f'cpg-{project}-{'test' if test_bucket else 'main'}-upload'
 
     sample_eid_mapping = map_sample_eid_to_sample_data(data_response)
 

--- a/scripts/upsert_mgrb_participants.py
+++ b/scripts/upsert_mgrb_participants.py
@@ -60,12 +60,12 @@ PARTICIPANT_QUERY = gql(
 papi = ParticipantApi()
 
 
-def map_sample_eid_to_sample_data(data):
+def map_sample_eid_to_sample_data(data: Dict[str, list]):
     """Map sample external ID to sample data"""
     return {sample['externalId']: sample for sample in data['sample']}
 
 
-def get_sample_data(project):
+def get_sample_data(project: str):
     """Get sample data from metamist"""
     response = query(SAMPLE_QUERY, {'project': project})
     if not isinstance(response, dict):
@@ -95,7 +95,7 @@ def create_sample(project_id: int, seid: str, siid: str):
     )
 
 
-def read_files_from_gcs(bucket_name, file_path):
+def read_files_from_gcs(bucket_name: str, file_path: str):
     """Read files from GCS"""
     client = storage.Client()
     bucket = client.get_bucket(bucket_name)

--- a/scripts/upsert_participants.py
+++ b/scripts/upsert_participants.py
@@ -111,11 +111,10 @@ def main(
     sample_meta: str,
     sample_external_id_column: str,
     external_org_name: str,
-):
+):  # pylint: disable=too-many-locals
     """Upsert participants to metamist"""
     # Query metamist
-    project = bucket.split('-')[1] # project name derived from bucket name
-    project = 'mgrb-dev'
+    project = bucket.split('-')[1]  # project name derived from bucket name
     data_response = get_sample_data(project)
     project_id = data_response.get('project')['id']
 
@@ -163,12 +162,16 @@ def main(
         if peid not in participant_sample_map:
             participant_sample_map[peid] = []
             participant_sex_map[peid] = sex
-        participant_sample_map[peid].append(create_sample(project_id, seid, siid, external_org_name))
+        participant_sample_map[peid].append(
+            create_sample(project_id, seid, siid, external_org_name)
+        )
 
     participant_upserts = []
     for peid, sample_upserts in participant_sample_map.items():
         participant_upserts.append(
-            create_participant(sample_upserts, peid, participant_sex_map[peid], external_org_name)
+            create_participant(
+                sample_upserts, peid, participant_sex_map[peid], external_org_name
+            )
         )
 
     # Upsert participants


### PR DESCRIPTION
As per [this Slack thread](https://centrepopgen.slack.com/archives/C030X7WGFCL/p1728524002090459).

MGRB data was ingested without participants. The rest of the data such as sample's sequencing_groups etc. was still ingested however they were never assigned to a participant. Not having participants breaks production-pipelines.

This PR creates new participants and adds the current sample data to them.

@milo-hyben and I have pair programmed and run the results on mgrb-test in metamist that has now fixed the data in metamist.