### PR TITLE
Library type backpopulate update

### DIFF
--- a/scripts/back_populate_library_type.py
+++ b/scripts/back_populate_library_type.py
@@ -114,6 +114,12 @@ def check_assay_meta_fields(assays: list[dict], update_sequencing_groups: bool):
             assay_meta_fields_to_update['library_type'] = assay['meta'].get(
                 'design_description'
             )
+        
+        # Some fastq files are not named in the standard format, but contain the word 'TWIST'
+        # which we can use to label then with the generic 'TWIST' library type from VCGS
+        elif 'TWIST' in fastq_filename:
+            assay_meta_fields_to_update['facility'] = 'vcgs'
+            assay_meta_fields_to_update['library_type'] = 'TWIST'
 
         else:
             logging.warning(

--- a/scripts/back_populate_library_type.py
+++ b/scripts/back_populate_library_type.py
@@ -44,8 +44,8 @@ _sg_assays_query = gql(
 # VCGS fastq
 # This is the current name format
 vcgs_fastq_regex = (
-    r'(?P<run_date>\d{6})_(?P<g2>[A-Z\d]+)_(?P<g3>\d{4})_'
-    r'(?P<g4>[A-Z]{2}\d+)_(?P<sample_id>[\w\d-]+)_(?P<library_id>[A-Z\d-]+)_'
+    r'(?P<run_date>\d{6,8})_(?P<g2>[A-Z\d]+)_(?P<g3>\d{4})_'
+    r'(?P<g4>[A-Z]{2}\d+)_(?P<sample_id>[\w\d-]+)_(?P<library_id>[A-Z\d-]+\D?)_'
     r'(?P<library_type>[\w\d]+)_(?P<lane>L\d+)_(?P<read>R[12])\.fastq\.gz'
 )
 # Pre mid 2018 the library id was not included:

--- a/scripts/back_populate_library_type.py
+++ b/scripts/back_populate_library_type.py
@@ -114,7 +114,7 @@ def check_assay_meta_fields(assays: list[dict], update_sequencing_groups: bool):
             assay_meta_fields_to_update['library_type'] = assay['meta'].get(
                 'design_description'
             )
-        
+
         # Some fastq files are not named in the standard format, but contain the word 'TWIST'
         # which we can use to label then with the generic 'TWIST' library type from VCGS
         elif 'TWIST' in fastq_filename:


### PR DESCRIPTION
Updates the vcgs fastq filename pattern:
-  Allow 8 digit date codes at the start of the fastq filename (previously only allowed 6 digit codes).
-  Allow a non-digit character (e.g. 'a', 'b') at the end of the "library_id" pattern.

After the changes, the regex pattern now matches for the example fastq filename:
`"20240301_LH00174_0024_TL2404312_23W123456_STAR-20240221a_TwistWES2VCGS2_L001_R1.fastq.gz"`

Prior to this change, the pattern would not match because of the 8 digit date code at the start, as well as because of the "a" at the end of the library ID "STAR-20240221a".

---

Additionally adds a check for the word "TWIST" in the fastq filename, which is occasionally present in some fastq filenames that otherwise don't match the regex. Fastqs containing this term will have their facility and library type updated accordingly.

