### PR TITLE
Remove old permission columns from project table

### DIFF
--- a/db/project.xml
+++ b/db/project.xml
@@ -1865,4 +1865,28 @@
 			remarks="Migration of family external IDs to separate table"
 		/>
 	</changeSet>
+	<changeSet author="dan.coates" id="2024-11-27_clean_up_project_table">
+		<sql>SET @@system_versioning_alter_history = 1;</sql>
+
+		<dropForeignKeyConstraint baseTableName="project"
+			constraintName="FK_PROJECT_READ_GROUP_GROUP_ID" />
+		<dropForeignKeyConstraint baseTableName="project"
+			constraintName="FK_PROJECT_WRITE_GROUP_GROUP_ID" />
+		<dropColumn
+			tableName="project"
+			columnName="read_group_id"
+		/>
+		<dropColumn
+			tableName="project"
+			columnName="write_group_id"
+		/>
+		<dropColumn
+			tableName="project"
+			columnName="read_group_name"
+		/>
+		<dropColumn
+			tableName="project"
+			columnName="write_group_name"
+		/>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
After the last permissions update, we no longer need the group ids and names in the project table. All permissions are managed by the project members table now. 

Note: we'd not normally want to remove columns as it affects the ability to query the system versioned tables for history of those columns. In this case it is ok as we have permission changes recorded in cpg-infra, and we're not actively using the permission history anywhere. 