### PR TITLE
Analysis files mover script

### DIFF
--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -28,7 +28,7 @@ from metamist.parser.generic_metadata_parser import run_as_sync
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(
     """
-    query sgAnalyses($sequencingGroupIds: [String]!, $dataset: String!, $analysisTypes: [String!]) {
+    query sgAnalyses($sequencingGroupIds: [String!], $dataset: String!, $analysisTypes: [String!]) {
         project(name: $dataset) {
             sequencingGroups(id: {in_: $sequencingGroupIds}) {
                 id

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -1,0 +1,314 @@
+"""
+This script is used to update analysis records associated with sequencing groups
+that have been moved to a new project / dataset, as well as copy the files
+associated with the analysis to the new project's cloud storage bucket.
+
+The script is designed to be run via analysis-runner using a service account
+that has access to both the source and destination project's buckets.
+
+The script assumes that the sequencing group and analysis records have been
+updated in the database with the new project id.
+
+Note that not every file that needs to be moved to the new cloud storage
+bucket will be associated with an analysis record. This script also checks
+for the existence of files in the source bucket that are not associated with
+an analysis record, and copies them to the destination bucket.
+"""
+
+import logging
+import sys
+
+import click
+
+from cpg_utils.config import config_retrieve
+from google.cloud import storage
+from metamist.apis import AnalysisApi
+from metamist.models import AnalysisUpdateModel, AnalysisStatus
+from metamist.graphql import gql, query
+
+# Define the query to get the analysis records that need to be moved
+ANALYSES_QUERY = gql(
+    """
+    query sgAnalyses($sequencingGroupIds: [String]!, $dataset: String!, analysisTypes: [String!]) {
+        project(name: $dataset) {
+            sequencingGroups(id: {in_: $sequencingGroupIds}) {
+                id
+                analyses(type: {in_: $analysisTypes}, status: {eq: COMPLETED}) {
+                    id
+                    type
+                    meta
+                    outputs
+                }
+            }
+        }
+    }
+    """
+)
+
+ANALYSIS_TYPES = ['cram', 'gvcf', 'web', 'sv']
+
+UNRECORDED_ANALYSIS_FILES = [
+    # Mito CRAM files
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.base_level_coverage.tsv',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.cram',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.cram.crai',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vcf.bgz',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vcf.bgz.tbi',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vep.vcf.gz',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vep.vcf.gz.tbi',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.shifted_mito.cram',
+    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.shifted_mito.cram.crai',
+    # CramQc stage files
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}.variant_calling_detail_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}.variant_calling_summary_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_fastqc.html',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_fastqc.zip',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_picard_wgs_metrics.csv',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_samtools_stats.txt',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_verify_bamid.selfSM',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/verify_bamid/{sg_id}.verify-bamid.selfSM',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/samtools_stats/{sg_id}.samtools-stats',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/alignment_summary_metrics/{sg_id}.alignment_summary_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/base_distribution_by_cycle_metrics/{sg_id}.base_distribution_by_cycle_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/insert_size_metrics/{sg_id}.insert_size_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/quality_by_cycle_metrics/{sg_id}.quality_by_cycle_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/quality_yield_metrics/{sg_id}.quality_yield_metrics',
+    'gs://cpg-{dataset}-{bucket_access_level}/qc/picard_wgs_metrics/{sg_id}.picard-wgs-metrics',
+    # Single Sample SV stage files
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.coverage_counts.tsv.gz',
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.pe.txt.gz',
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.pe.txt.gz.tbi',
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sd.txt.gz',
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sd.txt.gz.tbi',
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sr.txt.gz',
+    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sr.txt.gz.tbi',
+    # Somalier stage files
+    'gs://cpg-{dataset}-{bucket_access_level}/cram/{sg_id}.cram.somalier',
+    'gs://cpg-{dataset}-{bucket_access_level}/gvcf/{sg_id}.g.vcf.gz.somalier',
+    # Stripy stage files
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/stripy/{sg_id}.stripy.json',
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/stripy/{sg_id}.stripy.log.txt',
+    # MitoReport stage files
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.coverage_mean.txt',
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.coverage_median.txt',
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.coverage_metrics.txt',
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.haplocheck.txt',
+    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.theoretical_sensitivity.txt',
+]
+
+UNRECORDED_ANALYSIS_FOLDERS = [
+    # MitoReport stage folder
+    'gs://cpg-{dataset}-{bucket_access_level}-web/mito/mitoreport-{sg_id}/',
+]
+
+
+def get_analyses_to_update_and_files_to_move(
+    sequencing_group_ids: list[str],
+    old_dataset: str,
+    new_dataset: str,
+) -> tuple[list[tuple[str, AnalysisUpdateModel]], list[tuple[str, str]]]:
+    """
+    Returns the analyses to update and the files to move.
+    """
+    analysis_query_result = query(
+        ANALYSES_QUERY,
+        variables={
+            'sequencingGroupIds': sequencing_group_ids,
+            'dataset': new_dataset,
+            'analysisTypes': ANALYSIS_TYPES,
+        },
+    )
+
+    analyses_to_update = []
+    files_to_move = []
+    for sg in analysis_query_result['project']['sequencingGroups']:
+        for analysis in sg['analyses']:
+            if (
+                analysis['type'] == 'sv'
+                and analysis['meta'].get('stage') != 'GatherSampleEvidence'
+            ):
+                # Skip the SV analyses that are not the GatherSampleEvidence stage
+                continue
+
+            analysis_id = analysis['id']
+
+            current_outputs = analysis['outputs']
+
+            new_outputs = current_outputs.copy()
+            new_outputs['path'] = current_outputs['path'].replace(
+                old_dataset, new_dataset
+            )
+            new_outputs['dirname'] = current_outputs['dirname'].replace(
+                old_dataset, new_dataset
+            )
+
+            files_to_move.append((current_outputs['path'], new_outputs['path']))
+
+            if analysis['type'] == 'cram':
+                files_to_move.append(
+                    (current_outputs['path'] + '.crai', new_outputs['path'] + '.crai')
+                )
+            if analysis['type'] == 'gvcf':
+                files_to_move.append(
+                    (current_outputs['path'] + '.tbi', new_outputs['path'] + '.tbi')
+                )
+
+            new_meta = analysis['meta'].copy()
+            new_meta['dataset'] = new_dataset
+
+            analyses_to_update.append(
+                (
+                    analysis_id,
+                    AnalysisUpdateModel(
+                        status=AnalysisStatus('COMPLETED'),
+                        outputs=new_outputs,
+                        meta=new_meta,
+                    ),
+                )
+            )
+
+    return analyses_to_update, files_to_move
+
+
+def move_files(
+    files_to_move: list[tuple[str, str]],
+):
+    """
+    Moves the files from the old path to the new path.
+    """
+    storage_client = storage.Client()
+
+    for old_path, new_path in files_to_move:
+        logging.info(f'Copying {old_path} to {new_path}')
+
+        source_bucket_name = old_path.split('/')[2]
+        destination_bucket_name = new_path.split('/')[2]
+
+        source_bucket = storage_client.bucket(source_bucket_name)
+        destination_bucket = storage_client.bucket(destination_bucket_name)
+
+        source_blob = source_bucket.blob(old_path[len(f'gs://{source_bucket_name}/') :])
+        try:
+            blob_copy = source_bucket.copy_blob(
+                source_blob, 
+                destination_bucket,
+                new_path[len(f'gs://{destination_bucket_name}/'):]
+            )
+            source_bucket.delete_blob(source_blob)
+            print(
+                "Blob {} in bucket {} moved to blob {} in bucket {}.".format(
+                    source_blob.name,
+                    source_bucket.name,
+                    blob_copy.name,
+                    destination_bucket.name,
+                )
+            )
+        except storage.blob.CopyBlobError as e:
+            logging.error(f'Blob {source_blob.name} not found in bucket {source_bucket.name}')
+
+
+def update_analyses(
+    analyses_to_update: list[tuple[str, AnalysisUpdateModel]],
+):
+    """
+    Updates the analyses with the new outputs and meta data.
+    """
+    analysis_api = AnalysisApi()
+
+    for analysis_id, update_model in analyses_to_update:
+        logging.info(
+            f'Updating analysis {analysis_id} with new outputs and meta fields'
+        )
+        analysis_api.update_analysis(analysis_id, update_model)
+
+
+@click.command()
+@click.option(
+    '--sequencing-group-ids',
+    '-s',
+    required=True,
+    multiple=True,
+    help='The sequencing group id(s)',
+)
+@click.option('--old-dataset', '-o', required=True, help='The old dataset name')
+@click.option('--new-dataset', '-n', required=True, help='The new dataset name')
+def main(
+    sequencing_group_ids: tuple[str],
+    old_dataset: str,
+    new_dataset: str,
+):
+    logging.info(
+        f'Running move analyses across projects script for sequencing group(s): {sequencing_group_ids}'
+    )
+    logging.info(f'Moving analyses from dataset {old_dataset} to dataset {new_dataset}')
+
+    access_level = config_retrieve(['workflow', 'access_level'])
+    bucket_access_level = 'main' if access_level == 'full' else 'test'
+
+    logging.info(
+        f'Will copy files from cpg-{old_dataset}-{bucket_access_level} to cpg-{new_dataset}-{bucket_access_level}'
+    )
+
+    # Get the analyses to update
+    analyses_to_update, files_to_move = get_analyses_to_update_and_files_to_move(
+        list(sequencing_group_ids), old_dataset, new_dataset
+    )
+
+    storage_client = storage.Client()
+
+    # Add the unrecorded analysis files to the files to move
+    for sequencing_group_id in sequencing_group_ids:
+        for old_path_template in UNRECORDED_ANALYSIS_FILES:
+            old_path = old_path_template.format(
+                dataset=old_dataset,
+                bucket_access_level=bucket_access_level,
+                sg_id=sequencing_group_id,
+            )
+            new_path = old_path_template.format(
+                dataset=new_dataset,
+                bucket_access_level=bucket_access_level,
+                sg_id=sequencing_group_id,
+            )
+
+            files_to_move.append((old_path, new_path))
+
+    # Add the unrecored analysis folders to the files to move
+    for sequencing_group_id in sequencing_group_ids:
+        for old_folder_template in UNRECORDED_ANALYSIS_FOLDERS:
+            old_folder = old_folder_template.format(
+                dataset=old_dataset,
+                bucket_access_level=bucket_access_level,
+                sg_id=sequencing_group_id,
+            )
+
+            old_bucket = storage_client.bucket(old_folder.split('/')[2])
+            blobs = storage_client.list_blobs(
+                old_bucket,
+                prefix=old_folder.removeprefix(f'gs://{old_bucket.name}/'),
+            )
+            for source_blob in blobs:
+                files_to_move.append(
+                    (
+                        source_blob.name,
+                        source_blob.name.replace(old_dataset, new_dataset),
+                    )
+                )
+
+    # Move the files
+    move_files(files_to_move)
+    logging.info(f'{len(files_to_move)} Files moved successfully')
+
+    # Update the analyses
+    update_analyses(analyses_to_update)
+    logging.info(f'{len(analyses_to_update)} Analyses updated successfully')
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        stream=sys.stderr,
+    )
+
+    main()  # pylint: disable=no-value-for-parameter

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -24,12 +24,23 @@ from metamist.models import AnalysisUpdateModel, AnalysisStatus
 from metamist.graphql import gql, query
 from metamist.parser.generic_metadata_parser import run_as_sync
 
-logging.basicConfig(
-    format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+# logging.basicConfig(
+#     format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+#     datefmt='%Y-%m-%d %H:%M:%S',
+# )
+# logger = logging.getLogger(__file__)
+# logger.addHandler(logging.StreamHandler())
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter(
+    fmt='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S',
-    level=logging.INFO,
 )
+handler.setFormatter(formatter)
 logger = logging.getLogger(__name__)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
 
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -250,28 +250,26 @@ def move_files(
         source_blob_size = convert_size(source_blob.size)
         if source_blob.storage_class in ['COLDLINE', 'ARCHIVE'] and unarchive:
             logger.info(
-                f'{old_path} ({source_blob_size}) in {source_bucket_name} is in {source_blob.storage_class} storage class'
+                f'Blob {old_path} ({source_blob_size}) in {source_bucket_name} is in {source_blob.storage_class} storage class'
             )
             if dry_run:
                 logger.info(
-                    f'DRY RUN :: Would have updated storage class of {old_path} to NEARLINE'
+                    f'DRY RUN :: Would have updated storage class of {old_path} to NEARLINE\n'
                 )
                 continue
-            logger.info(f'Updating storage class of {old_path} to NEARLINE')
+            logger.info(f'Updating storage class of {old_path} to NEARLINE\n')
             source_blob.update_storage_class('NEARLINE')
 
         if dry_run:
             logger.info(
-                f'DRY RUN :: Would have copied {old_path} ({source_blob_size}) to {new_path}'
+                f'DRY RUN :: Would have copied {old_path} ({source_blob_size}) to {new_path}\n'
             )
             continue
-        logger.info(f'Copying {old_path} ({source_blob_size}) to {new_path}')
 
         destination_blob_name = new_path[len(f'gs://{destination_bucket_name}/') :]
-
         if destination_bucket.get_blob(destination_blob_name):
             logger.error(
-                f'Blob {destination_blob_name} already exists in bucket {destination_bucket_name}'
+                f'Blob {destination_blob_name} already exists in bucket {destination_bucket_name}\n'
             )
             continue
 
@@ -282,13 +280,8 @@ def move_files(
                 destination_blob_name,
             )
             source_bucket.delete_blob(source_blob)
-            print(
-                'Blob {} in bucket {} moved to blob {} in bucket {}.'.format(  # pylint: disable=consider-using-f-string
-                    source_blob.name,
-                    source_bucket.name,
-                    blob_copy.name,
-                    destination_bucket.name,
-                )
+            logger.info(
+                f'Moved {old_path} ({convert_size(blob_copy.size)}) to {new_path} successfully\n'
             )
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'{e}: Blob {source_blob.name} failed to copy.')
@@ -366,7 +359,8 @@ async def main(
     logger.info(
         f'Moving analyses across projects for sequencing group(s): {sorted(sequencing_group_ids)}'
     )
-    logger.info(f'From dataset: {old_dataset} To dataset: {new_dataset}')
+    logger.info(f'From dataset: {old_dataset}')
+    logger.info(f'To dataset:   {new_dataset}\n')
 
     storage_client = storage.Client()
     gcp_project = config_retrieve(['workflow', 'dataset_gcp_project'])
@@ -376,7 +370,7 @@ async def main(
     old_bucket_name = f'cpg-{old_dataset.replace("-test", "")}-{bucket_access_level}'
     new_bucket_name = f'cpg-{new_dataset.replace("-test", "")}-{bucket_access_level}'
 
-    logger.info(f'Moving files from {old_bucket_name} to {new_bucket_name}')
+    logger.info(f'Moving files from {old_bucket_name} to {new_bucket_name}\n')
 
     # Get the analyses to update
     analyses_to_update, files_to_move = get_analyses_to_update_and_files_to_move(

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -26,14 +26,14 @@ from metamist.parser.generic_metadata_parser import run_as_sync
 
 handler = logging.StreamHandler()
 formatter = logging.Formatter(
-    fmt='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
+    fmt='%(asctime)s %(levelname)s:%(lineno)d - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S',
 )
 handler.setFormatter(formatter)
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-# logger.propagate = False
+logger.propagate = False
 
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(
@@ -233,6 +233,7 @@ def move_files(
     if not dry_run:
         logger.info(f'{len(files_to_move)} files moved successfully')
 
+
 def update_analyses(
     analyses_to_update: list[dict[str, Any]],
     dry_run: bool,
@@ -286,9 +287,9 @@ async def main(
     if dry_run:
         logger.info('Dry run mode enabled. No changes will be made.\n')
     logger.info(
-        f'Move analyses across projects for sequencing group(s): {sorted(sequencing_group_ids)}'
+        f'Moving analyses across projects for sequencing group(s): {sorted(sequencing_group_ids)}'
     )
-    logger.info(f'Moving analyses from dataset {old_dataset} to dataset {new_dataset}')
+    logger.info(f'From dataset: {old_dataset} To dataset: {new_dataset}')
 
     access_level = config_retrieve(['workflow', 'access_level'])
     bucket_access_level = 'main' if access_level == 'full' else 'test'
@@ -300,7 +301,7 @@ async def main(
         '-test-test', '-test'
     )
 
-    logger.info(f'Will copy files from {old_bucket_name} to {new_bucket_name}')
+    logger.info(f'Moving files primarily from {old_bucket_name} to {new_bucket_name}')
 
     # Get the analyses to update
     analyses_to_update, files_to_move = get_analyses_to_update_and_files_to_move(

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -31,6 +31,7 @@ logging.basicConfig(
 logger = logging.getLogger(__file__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
+logger.propagate = False
 
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -24,12 +24,12 @@ from metamist.models import AnalysisUpdateModel, AnalysisStatus
 from metamist.graphql import gql, query
 from metamist.parser.generic_metadata_parser import run_as_sync
 
-logger = logging.getLogger(__file__)
-logger.addHandler(logging.StreamHandler())
 logging.basicConfig(
     format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S',
 )
+logger = logging.getLogger(__file__)
+logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
 # Define the query to get the analysis records that need to be moved

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -227,6 +227,8 @@ def move_files(
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'{e}: Blob {source_blob.name} failed to copy.')
 
+    if not dry_run:
+        logger.info(f'{len(files_to_move)} files moved successfully')
 
 def update_analyses(
     analyses_to_update: list[dict[str, Any]],
@@ -340,7 +342,6 @@ async def main(
 
     # Move the files
     move_files(files_to_move, dry_run)
-    logger.info(f'{len(files_to_move)} Files moved successfully')
 
     # Update the analyses
     await update_analyses(analyses_to_update, dry_run)

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -48,56 +48,56 @@ ANALYSIS_TYPES = ['cram', 'gvcf', 'web', 'sv']
 
 UNRECORDED_ANALYSIS_FILES = [
     # Mito CRAM files
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.base_level_coverage.tsv',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.cram',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.cram.crai',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vcf.bgz',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vcf.bgz.tbi',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vep.vcf.gz',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.mito.vep.vcf.gz.tbi',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.shifted_mito.cram',
-    'gs://cpg-{dataset}-{bucket_access_level}/mito/{sg_id}.shifted_mito.cram.crai',
+    'gs://{bucket_name}/mito/{sg_id}.base_level_coverage.tsv',
+    'gs://{bucket_name}/mito/{sg_id}.mito.cram',
+    'gs://{bucket_name}/mito/{sg_id}.mito.cram.crai',
+    'gs://{bucket_name}/mito/{sg_id}.mito.vcf.bgz',
+    'gs://{bucket_name}/mito/{sg_id}.mito.vcf.bgz.tbi',
+    'gs://{bucket_name}/mito/{sg_id}.mito.vep.vcf.gz',
+    'gs://{bucket_name}/mito/{sg_id}.mito.vep.vcf.gz.tbi',
+    'gs://{bucket_name}/mito/{sg_id}.shifted_mito.cram',
+    'gs://{bucket_name}/mito/{sg_id}.shifted_mito.cram.crai',
     # CramQc stage files
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}.variant_calling_detail_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}.variant_calling_summary_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_fastqc.html',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_fastqc.zip',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_picard_wgs_metrics.csv',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_samtools_stats.txt',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/{sg_id}_verify_bamid.selfSM',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/verify_bamid/{sg_id}.verify-bamid.selfSM',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/samtools_stats/{sg_id}.samtools-stats',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/alignment_summary_metrics/{sg_id}.alignment_summary_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/base_distribution_by_cycle_metrics/{sg_id}.base_distribution_by_cycle_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/insert_size_metrics/{sg_id}.insert_size_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/quality_by_cycle_metrics/{sg_id}.quality_by_cycle_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/quality_yield_metrics/{sg_id}.quality_yield_metrics',
-    'gs://cpg-{dataset}-{bucket_access_level}/qc/picard_wgs_metrics/{sg_id}.picard-wgs-metrics',
+    'gs://{bucket_name}/qc/{sg_id}.variant_calling_detail_metrics',
+    'gs://{bucket_name}/qc/{sg_id}.variant_calling_summary_metrics',
+    'gs://{bucket_name}/qc/{sg_id}_fastqc.html',
+    'gs://{bucket_name}/qc/{sg_id}_fastqc.zip',
+    'gs://{bucket_name}/qc/{sg_id}_picard_wgs_metrics.csv',
+    'gs://{bucket_name}/qc/{sg_id}_samtools_stats.txt',
+    'gs://{bucket_name}/qc/{sg_id}_verify_bamid.selfSM',
+    'gs://{bucket_name}/qc/verify_bamid/{sg_id}.verify-bamid.selfSM',
+    'gs://{bucket_name}/qc/samtools_stats/{sg_id}.samtools-stats',
+    'gs://{bucket_name}/qc/alignment_summary_metrics/{sg_id}.alignment_summary_metrics',
+    'gs://{bucket_name}/qc/base_distribution_by_cycle_metrics/{sg_id}.base_distribution_by_cycle_metrics',
+    'gs://{bucket_name}/qc/insert_size_metrics/{sg_id}.insert_size_metrics',
+    'gs://{bucket_name}/qc/quality_by_cycle_metrics/{sg_id}.quality_by_cycle_metrics',
+    'gs://{bucket_name}/qc/quality_yield_metrics/{sg_id}.quality_yield_metrics',
+    'gs://{bucket_name}/qc/picard_wgs_metrics/{sg_id}.picard-wgs-metrics',
     # Single Sample SV stage files
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.coverage_counts.tsv.gz',
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.pe.txt.gz',
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.pe.txt.gz.tbi',
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sd.txt.gz',
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sd.txt.gz.tbi',
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sr.txt.gz',
-    'gs://cpg-{dataset}-{bucket_access_level}/sv_evidence/{sg_id}.sr.txt.gz.tbi',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.coverage_counts.tsv.gz',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.pe.txt.gz',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.pe.txt.gz.tbi',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.sd.txt.gz',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.sd.txt.gz.tbi',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.sr.txt.gz',
+    'gs://{bucket_name}/sv_evidence/{sg_id}.sr.txt.gz.tbi',
     # Somalier stage files
-    'gs://cpg-{dataset}-{bucket_access_level}/cram/{sg_id}.cram.somalier',
-    'gs://cpg-{dataset}-{bucket_access_level}/gvcf/{sg_id}.g.vcf.gz.somalier',
+    'gs://{bucket_name}/cram/{sg_id}.cram.somalier',
+    'gs://{bucket_name}/gvcf/{sg_id}.g.vcf.gz.somalier',
     # Stripy stage files
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/stripy/{sg_id}.stripy.json',
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/stripy/{sg_id}.stripy.log.txt',
+    'gs://{bucket_name}-analysis/stripy/{sg_id}.stripy.json',
+    'gs://{bucket_name}-analysis/stripy/{sg_id}.stripy.log.txt',
     # MitoReport stage files
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.coverage_mean.txt',
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.coverage_median.txt',
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.coverage_metrics.txt',
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.haplocheck.txt',
-    'gs://cpg-{dataset}-{bucket_access_level}-analysis/mito/{sg_id}.theoretical_sensitivity.txt',
+    'gs://{bucket_name}-analysis/mito/{sg_id}.coverage_mean.txt',
+    'gs://{bucket_name}-analysis/mito/{sg_id}.coverage_median.txt',
+    'gs://{bucket_name}-analysis/mito/{sg_id}.coverage_metrics.txt',
+    'gs://{bucket_name}-analysis/mito/{sg_id}.haplocheck.txt',
+    'gs://{bucket_name}-analysis/mito/{sg_id}.theoretical_sensitivity.txt',
 ]
 
 UNRECORDED_ANALYSIS_FOLDERS = [
     # MitoReport stage folder
-    'gs://cpg-{dataset}-{bucket_access_level}-web/mito/mitoreport-{sg_id}/',
+    'gs://{bucket_name}-web/mito/mitoreport-{sg_id}/',
 ]
 
 
@@ -280,9 +280,12 @@ async def main(
 
     access_level = config_retrieve(['workflow', 'access_level'])
     bucket_access_level = 'main' if access_level == 'full' else 'test'
+    
+    old_bucket_name = f'cpg-{old_dataset}-{bucket_access_level}'.replace('-test-test', '-test')
+    new_bucket_name = f'cpg-{new_dataset}-{bucket_access_level}'.replace('-test-test', '-test')
 
     logging.info(
-        f'Will copy files from cpg-{old_dataset}-{bucket_access_level} to cpg-{new_dataset}-{bucket_access_level}'
+        f'Will copy files from {old_bucket_name} to {new_bucket_name}'
     )
 
     # Get the analyses to update
@@ -296,13 +299,11 @@ async def main(
     for sequencing_group_id in sequencing_group_ids:
         for old_path_template in UNRECORDED_ANALYSIS_FILES:
             old_path = old_path_template.format(
-                dataset=old_dataset,
-                bucket_access_level=bucket_access_level,
+                bucket_name=old_bucket_name,
                 sg_id=sequencing_group_id,
             )
             new_path = old_path_template.format(
-                dataset=new_dataset,
-                bucket_access_level=bucket_access_level,
+                bucket_name=new_bucket_name,
                 sg_id=sequencing_group_id,
             )
 
@@ -312,11 +313,9 @@ async def main(
     for sequencing_group_id in sequencing_group_ids:
         for old_folder_template in UNRECORDED_ANALYSIS_FOLDERS:
             old_folder = old_folder_template.format(
-                dataset=old_dataset,
-                bucket_access_level=bucket_access_level,
+                bucket_name=old_bucket_name,
                 sg_id=sequencing_group_id,
             )
-
             old_bucket = storage_client.bucket(old_folder.split('/')[2])
             blobs = storage_client.list_blobs(
                 old_bucket,

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -28,7 +28,7 @@ from metamist.parser.generic_metadata_parser import run_as_sync
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(
     """
-    query sgAnalyses($sequencingGroupIds: [String]!, $dataset: String!, analysisTypes: [String!]) {
+    query sgAnalyses($sequencingGroupIds: [String]!, $dataset: String!, $analysisTypes: [String!]) {
         project(name: $dataset) {
             sequencingGroups(id: {in_: $sequencingGroupIds}) {
                 id

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -168,8 +168,8 @@ def get_analyses_to_update_and_files_to_move(
                 {
                     'id': analysis['id'],
                     'status': 'COMPLETED',
-                    'new_outputs': new_outputs,
-                    'new_meta': new_meta,
+                    'outputs': new_outputs,
+                    'meta': new_meta,
                     'old_outputs': current_outputs,
                     'old_meta': old_meta,
                 }
@@ -253,8 +253,8 @@ def update_analyses(
             continue
         update_model = AnalysisUpdateModel(
             status=AnalysisStatus(analysis['status']),
-            outputs=analysis['new_outputs'],
-            meta=analysis['new_meta'],
+            outputs=analysis['outputs'],
+            meta=analysis['meta'],
         )
         promises.append(
             analysis_api.update_analysis_async(analysis['id'], update_model)

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -345,4 +345,4 @@ if __name__ == '__main__':
         stream=sys.stderr,
     )
 
-    main()  # pylint: disable=no-value-for-parameter
+    asyncio.run(main())  # pylint: disable=no-value-for-parameter

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -27,11 +27,9 @@ from metamist.parser.generic_metadata_parser import run_as_sync
 logging.basicConfig(
     format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S',
+    level=logging.INFO,
 )
-logger = logging.getLogger(__file__)
-logger.addHandler(logging.StreamHandler())
-logger.setLevel(logging.INFO)
-logger.propagate = False
+logger = logging.getLogger(__name__)
 
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -168,6 +168,8 @@ def get_analyses_to_update_and_files_to_move(
             analyses_to_update.append(
                 {
                     'id': analysis['id'],
+                    'sg_id': sg['id'],
+                    'type': analysis['type'],
                     'outputs': new_outputs,
                     'meta': new_meta,
                 }
@@ -301,7 +303,9 @@ def update_analyses(
 
     promises = []
     for analysis in analyses_to_update:
-        logger.info(f'Analysis {analysis["id"]}')
+        logger.info(
+            f'Analysis: {analysis["id"]}. SG: {analysis["sg_id"]}. Type: {analysis["type"]}.'
+        )
         logger.info(f'    New outputs path: {analysis["outputs"]["path"]}')
         logger.info(f'    New meta dataset: {analysis["meta"]["dataset"]}')
         if dry_run:

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -24,13 +24,6 @@ from metamist.models import AnalysisUpdateModel, AnalysisStatus
 from metamist.graphql import gql, query
 from metamist.parser.generic_metadata_parser import run_as_sync
 
-# logging.basicConfig(
-#     format='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
-#     datefmt='%Y-%m-%d %H:%M:%S',
-# )
-# logger = logging.getLogger(__file__)
-# logger.addHandler(logging.StreamHandler())
-
 handler = logging.StreamHandler()
 formatter = logging.Formatter(
     fmt='%(asctime)s %(levelname)s %(module)s:%(lineno)d - %(message)s',
@@ -40,7 +33,7 @@ handler.setFormatter(formatter)
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
-logger.propagate = False
+# logger.propagate = False
 
 # Define the query to get the analysis records that need to be moved
 ANALYSES_QUERY = gql(


### PR DESCRIPTION
This script is intended to be used for sequencing groups which have been moved across projects, or from one dataset to another. 

Assuming the records have been update in the MariaDB backend, i.e. the `analysis` and `sequencing_group` records have had their `project` field updated, this script completes the move by:

- Finding analyses of the types `cram`, `gvcf`, `web`, `sv` and moving their outputs to the new bucket
- Updating the above analysis records with the new paths
- Finding and moving a number of extra outputs which are not currently recorded in the analysis table.

It will also

- Unarchive `COLDLINE` or `ARCHIVE` blobs before copying, if the `unarchive` flag is set
- Log everything that is changed, copied, or updated


---

Test run: https://batch.hail.populationgenomics.org.au/batches/534393/jobs/1

This is only a dry run, since I don't have a repro case of an SG who's records/analyses have been moved to a new project but who's files are still in the old bucket. 