### PR TITLE
Remove last direct use of typing_extensions as we assume Python 3.11

### DIFF
--- a/metamist/parser/generic_parser.py
+++ b/metamist/parser/generic_parser.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import re
-import sys
 from abc import abstractmethod
 from collections import defaultdict
 from functools import wraps
@@ -17,6 +16,7 @@ from typing import (
     Hashable,
     Iterable,
     Iterator,
+    Literal,
     Match,
     Sequence,
     TypeVar,
@@ -36,12 +36,6 @@ from metamist.models import (
     SequencingGroupUpsert,
 )
 from metamist.parser.cloudhelper import CloudHelper, group_by
-
-# https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__file__)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'urllib3 >= 1.25.3',
         'python-dateutil',
         'requests',
-        'typing-extensions',
         # for get id-token
         'cpg-utils >= 5.0.5',
         'gql[aiohttp,requests]',


### PR DESCRIPTION
This is fine as `Literal` is already just-plain-imported-from-typing elsewhere in the code. Moreover, even if the requirements for code in _metamist/parser/…_ were different, _generic_parser.py_ uses `:=` so already requires Python ≥ 3.8.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1733794957376819?thread_ts=1733790144.424069&cid=C030X7WGFCL

Not sure this will particularly make a difference, as `typing-extensions` still appears in _requirements.txt_ etc as it's pulled in by `anyio` et al. But it's a tidy-up nonetheless.