### PR TITLE
SET-372 - Switch query result table to monospace so that text is aligned

### DIFF
--- a/web/src/pages/report/chart/TableFromQuery.tsx
+++ b/web/src/pages/report/chart/TableFromQuery.tsx
@@ -73,6 +73,9 @@ export function TableFromQuery(props: TableProps) {
             columns={columns}
             getRowId={(row) => row.__index}
             density="compact"
+            sx={{
+                fontFamily: 'monospace',
+            }}
         />
     )
 }


### PR DESCRIPTION
Tiny change, just a nice QOL thing for string of the same length to be visually aligned. Particularly useful for a table that contains lots of stringy ids. 