### PR TITLE
Format money using `toLocaleString()` instead of complicated regex

### DIFF
--- a/web/src/shared/utilities/formatMoney.ts
+++ b/web/src/shared/utilities/formatMoney.ts
@@ -1,4 +1,11 @@
-const formatMoney = (val: number | undefined | null, dp: number = 2): string =>
-    val ? `$${val.toFixed(dp).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}` : ''
+const formatMoney = (val: number | undefined | null, dp: number = 2): string => {
+    const options = {
+        style: 'currency',
+        currency: 'AUD',
+        minimumFractionDigits: dp,
+        maximumFractionDigits: dp,
+    } as Intl.NumberFormatOptions
+    return val ? val.toLocaleString('en-AU', options) : ''
+}
 
 export default formatMoney


### PR DESCRIPTION
I noticed looking at billing pages that current metamist prints currency amounts with commas both before and after the decimal point (see the foobar figure on the right with 4 dp):

<img width="302" alt="Screenshot 2025-02-25 at 10 04 59" src="https://github.com/user-attachments/assets/381e6dea-4750-46a5-bf03-8bef89dbe1ae" />

IMHO this makes the numbers harder to read (and suggests that there is a separate 789 number presented after the first). This was introduced accidentally during PR #957, which changed the regex to avoid a sonarqube diagnostic.

This rewrites the code using `toLocaleString()` instead of a complicated regex. I am no JavaScript expert, but I trust this is suitably portable — we use `DateTime.toLocaleString()` et al elsewhere, though I guess that is not exactly the same thing.

With this these figures are displayed as follows:

<img width="302" alt="Screenshot 2025-02-25 at 10 04 52" src="https://github.com/user-attachments/assets/8c6f4fc7-4b51-4d4f-b8cd-f233a2994eed" />
