### PR TITLE
Enable create_test_subset.py to update embedded sample IDs

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -891,7 +891,7 @@ def rewrite_file(
     elif new_path.endswith('.md5'):
         logger.info(f'Regenerating {new_path} by checksumming {new_base_path}')
         cmd = f"""
-        gcloud storage cat {new_base_path!r} | md5sum | gcloud storage cp - {new_path!r}
+        gcloud storage cat {new_base_path!r} | md5sum | cut -d' ' -f1 | gcloud storage cp - {new_path!r}
         """
     else:
         logger.info(f'Copying to {new_path} without any rewriting')


### PR DESCRIPTION
This splits out the _create_test_subset.py_ changes from PR #504. Currently implemented for CRAM files and gVCF files. Fixes [SET-491](https://cpg-populationanalysis.atlassian.net/browse/SET-491).

[SET-491]: https://cpg-populationanalysis.atlassian.net/browse/SET-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ