### PR TITLE
Actions security overhaul

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   unittests:
-    uses: './.github/workflows/test.yaml'
+    uses: ./.github/workflows/test.yaml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
+          distribution: 'temurin' # yamllint disable-line rule:quoted-strings
           java-version: '17'
 
       - name: Setup build env

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # yamllint disable-line rule:quoted-strings
+          distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
 
       - name: Setup build env

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,8 +39,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,9 +7,7 @@ on:
       - main
       - dev
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   unittests:
@@ -24,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: unittests
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
@@ -35,30 +36,32 @@ jobs:
         shell: bash -eo pipefail -l {0}
     steps:
       - uses: actions/checkout@v4
-
-      - id: "google-cloud-auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v2"
         with:
-          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
+          persist-credentials: false
 
-      - id: "google-cloud-sdk-setup"
-        name: "Set up Cloud SDK"
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
+
+      - id: 'google-cloud-sdk-setup'
+        name: 'Set up Cloud SDK'
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: "gcloud docker auth"
+      - name: 'gcloud docker auth'
         run: |
           gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - uses: actions/setup-java@v4
         with:
-          distribution: "temurin" # See 'Supported distributions' for available options
-          java-version: "17"
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
 
       - name: Setup build env
         run: |
@@ -80,14 +83,14 @@ jobs:
               --new-version $(cat deploy/python/version.txt)dev$(echo $(git rev-parse HEAD) | cut -c1-7)
           fi
 
-      - name: "build deployable API"
+      - name: 'build deployable API'
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"
           python regenerate_api.py
           ls -lGh metamist
 
         # also copies build artifacts to api/public
-      - name: "build web front-end"
+      - name: 'build web front-end'
         run: |
           set -eo pipefail
           pushd web
@@ -96,7 +99,7 @@ jobs:
           npm run build
           popd
 
-      - name: "build image"
+      - name: 'build image'
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
@@ -107,11 +110,11 @@ jobs:
       - name: Build python package
         run: python setup.py sdist
 
-      - name: "push server image"
+      - name: 'push server image'
         run: |
           docker push $SM_DOCKER
 
-      - name: "deploy to Cloud Run"
+      - name: 'deploy to Cloud Run'
         run: |
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             gcloud_deploy_name=sample-metadata-api
@@ -127,7 +130,5 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/
           skip-existing: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,18 +39,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: 'google-cloud-auth'
-        name: 'Authenticate to Google Cloud'
+      - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
 
-      - id: 'google-cloud-sdk-setup'
-        name: 'Set up Cloud SDK'
+      - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: 'gcloud docker auth'
+      - name: gcloud docker auth
         run: |
           gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 
@@ -83,14 +81,14 @@ jobs:
               --new-version $(cat deploy/python/version.txt)dev$(echo $(git rev-parse HEAD) | cut -c1-7)
           fi
 
-      - name: 'build deployable API'
+      - name: build deployable API
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"
           python regenerate_api.py
           ls -lGh metamist
 
         # also copies build artifacts to api/public
-      - name: 'build web front-end'
+      - name: build web front-end
         run: |
           set -eo pipefail
           pushd web
@@ -99,7 +97,7 @@ jobs:
           npm run build
           popd
 
-      - name: 'build image'
+      - name: build image
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
@@ -110,11 +108,11 @@ jobs:
       - name: Build python package
         run: python setup.py sdist
 
-      - name: 'push server image'
+      - name: push server image
         run: |
           docker push $SM_DOCKER
 
-      - name: 'deploy to Cloud Run'
+      - name: deploy to Cloud Run
         run: |
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             gcloud_deploy_name=sample-metadata-api

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   unittests:
-    uses: ./.github/workflows/test.yaml
+    uses: './.github/workflows/test.yaml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -39,27 +39,29 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
         with:
-          workload_identity_provider: projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider
-          service_account: sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com
+          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
 
-      - name: Set up Cloud SDK
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: gcloud docker auth
+      - name: "gcloud docker auth"
         run: |
           gcloud auth configure-docker australia-southeast1-docker.pkg.dev
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
+          distribution: "temurin" # See 'Supported distributions' for available options
+          java-version: "17"
 
       - name: Setup build env
         run: |
@@ -81,14 +83,14 @@ jobs:
               --new-version $(cat deploy/python/version.txt)dev$(echo $(git rev-parse HEAD) | cut -c1-7)
           fi
 
-      - name: build deployable API
+      - name: "build deployable API"
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"
           python regenerate_api.py
           ls -lGh metamist
 
         # also copies build artifacts to api/public
-      - name: build web front-end
+      - name: "build web front-end"
         run: |
           set -eo pipefail
           pushd web
@@ -97,7 +99,7 @@ jobs:
           npm run build
           popd
 
-      - name: build image
+      - name: "build image"
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
@@ -108,11 +110,11 @@ jobs:
       - name: Build python package
         run: python setup.py sdist
 
-      - name: push server image
+      - name: "push server image"
         run: |
           docker push $SM_DOCKER
 
-      - name: deploy to Cloud Run
+      - name: "deploy to Cloud Run"
         run: |
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             gcloud_deploy_name=sample-metadata-api

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,8 +42,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
+          workload_identity_provider: projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -17,19 +17,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fail if branch is not main or dev
+      - id: "branch-check"
+        name: Fail if branch is not main or dev
         if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         run: |
           echo "This workflow should not be triggered with workflow_dispatch on a branch other than main or dev"
           exit 1
 
-      - name: Authenticate to Google Cloud
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider
-          service_account: sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com
+          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
 
-      - name: Set up Cloud SDK
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Build image with Cloud Build

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,7 +24,7 @@ jobs:
           exit 1
 
       - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v2'
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -17,22 +17,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: 'branch-check'
-        name: Fail if branch is not main or dev
+      - name: Fail if branch is not main or dev
         if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         run: |
           echo "This workflow should not be triggered with workflow_dispatch on a branch other than main or dev"
           exit 1
 
-      - id: 'google-cloud-auth'
-        name: 'Authenticate to Google Cloud'
+      - name: Authenticate to Google Cloud
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
 
-      - id: 'google-cloud-sdk-setup'
-        name: 'Set up Cloud SDK'
+      - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Build image with Cloud Build

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
+          workload_identity_provider: projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/deploy_schema_updater.yaml
+++ b/.github/workflows/deploy_schema_updater.yaml
@@ -3,33 +3,36 @@ name: Deploy Schema Updater
 on:
   workflow_dispatch:
 
-permissions:
-  contents: 'read'
-  id-token: 'write'
+permissions: {}
 
 jobs:
   build-image:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-      - id: "branch-check"
+      - id: 'branch-check'
         name: Fail if branch is not main or dev
         if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         run: |
           echo "This workflow should not be triggered with workflow_dispatch on a branch other than main or dev"
           exit 1
 
-      - id: "google-cloud-auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v2"
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
+          workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
 
-      - id: "google-cloud-sdk-setup"
-        name: "Set up Cloud SDK"
+      - id: 'google-cloud-sdk-setup'
+        name: 'Set up Cloud SDK'
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Build image with Cloud Build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,19 +38,19 @@ jobs:
           # openapi-generator
           wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.3.0/openapi-generator-cli-5.3.0.jar -O openapi-generator-cli.jar
 
-      - name: 'install frontend deps'
+      - name: install frontend deps
         working-directory: ./web
         run: npm ci
 
-      - name: 'check frontend formatting'
+      - name: check frontend formatting
         working-directory: ./web
         run: npm run format:check
 
-      - name: 'check frontend linting'
+      - name: check frontend linting
         working-directory: ./web
         run: npm run lint
 
-      - name: 'build image'
+      - name: build image
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=local \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # yamllint disable-line rule:quoted-strings
+          distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
 
       - name: Setup build env

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,19 +38,19 @@ jobs:
           # openapi-generator
           wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.3.0/openapi-generator-cli-5.3.0.jar -O openapi-generator-cli.jar
 
-      - name: install frontend deps
+      - name: 'install frontend deps'
         working-directory: ./web
         run: npm ci
 
-      - name: check frontend formatting
+      - name: 'check frontend formatting'
         working-directory: ./web
         run: npm run format:check
 
-      - name: check frontend linting
+      - name: 'check frontend linting'
         working-directory: ./web
         run: npm run lint
 
-      - name: build image
+      - name: 'build image'
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=local \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
+          distribution: 'temurin' # yamllint disable-line rule:quoted-strings
           java-version: '17'
 
       - name: Setup build env

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,8 @@
 name: Lint
 on: push
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -15,6 +17,8 @@ jobs:
         shell: bash -eo pipefail -l {0}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: 0 0 * * Sun
+    - cron: '0 0 * * Sun'
   push:
     branches:
       - dev
@@ -27,9 +27,9 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.2.10
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: '${{ steps.app-token.outputs.token }}'
           docker-user: root
           configurationFile: .github/renovate-config.json
         env:
-          LOG_LEVEL: debug
+          LOG_LEVEL: 'debug'
           RENOVATE_PLATFORM_COMMIT: 'true'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 0 * * Sun'
+    - cron: 0 0 * * Sun
   push:
     branches:
       - dev
@@ -27,9 +27,9 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.2.10
         with:
-          token: '${{ steps.app-token.outputs.token }}'
+          token: ${{ steps.app-token.outputs.token }}
           docker-user: root
           configurationFile: .github/renovate-config.json
         env:
-          LOG_LEVEL: 'debug'
+          LOG_LEVEL: debug
           RENOVATE_PLATFORM_COMMIT: 'true'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -7,9 +7,7 @@ on:
       - dev
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   renovate:
@@ -23,6 +21,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.2.10

--- a/.github/workflows/security_checks.yaml
+++ b/.github/workflows/security_checks.yaml
@@ -6,33 +6,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions: {}
+
 jobs:
-  zizmor:
-    name: zizmor latest via PyPI
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
-
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-          category: zizmor
-
   pip-audit:
     runs-on: ubuntu-latest
     name: Pip Audit

--- a/.github/workflows/security_checks.yaml
+++ b/.github/workflows/security_checks.yaml
@@ -2,7 +2,7 @@ name: Security Checks
 
 on:
   push:
-    branches: ['main']
+    branches: [main]
   pull_request:
     branches: ['**']
 

--- a/.github/workflows/security_checks.yaml
+++ b/.github/workflows/security_checks.yaml
@@ -1,15 +1,46 @@
 name: Security Checks
 
 on:
-  workflow_dispatch:
   push:
+    branches: ['main']
+  pull_request:
+    branches: ['**']
 
 jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor
+
   pip-audit:
     runs-on: ubuntu-latest
     name: Pip Audit
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: pypa/gh-action-pip-audit@v1.1.0
         name: Pip Audit Dependencies
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ on:
       SONAR_HOST_URL:
         required: true
 
+permissions: {}
+
 jobs:
   unittests:
     name: Run unit tests
@@ -25,6 +27,8 @@ jobs:
         shell: bash -eo pipefail -l {0}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -111,16 +115,20 @@ jobs:
       - name: Fail if unit tests are not passing
         if: ${{ steps.runtests.outputs.rc != 0}}
         uses: actions/github-script@v6
+        env:
+          rc: ${{ steps.runtests.outputs.rc }}
         with:
           script: |
-            core.setFailed('Unittests failed with rc = ${{ steps.runtests.outputs.rc }}')
+            core.setFailed('Unittests failed with rc = ${rc}')
 
       - name: Fail if web build fails
         if: ${{ steps.runtests.outputs.rc != 0}}
         uses: actions/github-script@v6
+        env:
+          web_rc: ${{ steps.runtests.outputs.web_rc }}
         with:
           script: |
-            core.setFailed('Web failed to build with rc = ${{ steps.runtests.outputs.web_rc }}')
+            core.setFailed('Web failed to build with rc = ${web_rc}')
 
   sonarqube:
     name: SonarQube scan
@@ -132,6 +140,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
 
       # Download the coverage report artifact
       - name: 'Download coverage and execution report'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # yamllint disable-line rule:quoted-strings
+          distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
 
       - name: Setup build env

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
           unzip -o -d liquibase liquibase-${VERSION}.zip
           echo "$(pwd)/liquibase" >> $GITHUB_PATH
 
-      - name: 'build image'
+      - name: build image
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=local \
@@ -66,13 +66,13 @@ jobs:
             -f deploy/api/Dockerfile \
             .
 
-      - name: 'build deployable API'
+      - name: build deployable API
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"
           python regenerate_api.py
           pip install .
 
-      - name: 'Run unit tests'
+      - name: Run unit tests
         id: runtests
         run: |
           coverage run -m pytest --doctest-modules --doctest-continue-on-failure test/ --junitxml=test-execution.xml
@@ -87,19 +87,19 @@ jobs:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: 'Save coverage report as an Artifact'
+      - name: Save coverage report as an Artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: ./coverage.xml
 
-      - name: 'Save execution report as an Artifact'
+      - name: Save execution report as an Artifact
         uses: actions/upload-artifact@v4
         with:
           name: execution-report
           path: ./test-execution.xml
 
-      - name: 'build web front-end'
+      - name: build web front-end
         run: |
           set -eo pipefail
           pushd web
@@ -143,7 +143,7 @@ jobs:
           persist-credentials: false
 
       # Download the coverage report artifact
-      - name: 'Download coverage and execution report'
+      - name: Download coverage and execution report
         uses: actions/download-artifact@v4
         with:
           pattern: '*-report'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
+          distribution: 'temurin' # yamllint disable-line rule:quoted-strings
           java-version: '17'
 
       - name: Setup build env

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
           unzip -o -d liquibase liquibase-${VERSION}.zip
           echo "$(pwd)/liquibase" >> $GITHUB_PATH
 
-      - name: build image
+      - name: 'build image'
         run: |
           docker build \
             --build-arg SM_ENVIRONMENT=local \
@@ -66,13 +66,13 @@ jobs:
             -f deploy/api/Dockerfile \
             .
 
-      - name: build deployable API
+      - name: 'build deployable API'
         run: |
           export OPENAPI_COMMAND="java -jar openapi-generator-cli.jar"
           python regenerate_api.py
           pip install .
 
-      - name: Run unit tests
+      - name: 'Run unit tests'
         id: runtests
         run: |
           coverage run -m pytest --doctest-modules --doctest-continue-on-failure test/ --junitxml=test-execution.xml
@@ -81,25 +81,25 @@ jobs:
 
           echo "rc=$rc" >> $GITHUB_OUTPUT
 
-      - name: Upload coverage report
+      - name: 'Upload coverage report'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Save coverage report as an Artifact
+      - name: 'Save coverage report as an Artifact'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: ./coverage.xml
 
-      - name: Save execution report as an Artifact
+      - name: 'Save execution report as an Artifact'
         uses: actions/upload-artifact@v4
         with:
           name: execution-report
           path: ./test-execution.xml
 
-      - name: build web front-end
+      - name: 'build web front-end'
         run: |
           set -eo pipefail
           pushd web
@@ -143,7 +143,7 @@ jobs:
           persist-credentials: false
 
       # Download the coverage report artifact
-      - name: Download coverage and execution report
+      - name: 'Download coverage and execution report'
         uses: actions/download-artifact@v4
         with:
           pattern: '*-report'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,7 @@ jobs:
 
           echo "rc=$rc" >> $GITHUB_OUTPUT
 
-      - name: 'Upload coverage report'
+      - name: Upload coverage report
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -17,33 +17,29 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - id: 'branch-check'
-        name: Fail if branch is not main or dev
+      - name: Fail if branch is not main or dev
         if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         run: |
           echo "This workflow should not be triggered with workflow_dispatch on a branch other than main or dev"
           exit 1
 
-      - id: 'google-cloud-auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
 
-      - id: 'google-cloud-sdk-setup'
-        name: 'Set up Cloud SDK'
+      - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - id: 'invoke-cloud-run'
-        name: 'Invoke Cloud Run'
+      - name: Invoke Cloud Run
         env:
           ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Target environment (prod or dev)'
+        description: Target environment (prod or dev)
         required: true
-        default: 'dev'
+        default: dev
         type: choice
         options:
           - prod

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-          service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
+          workload_identity_provider: projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: Target environment (prod or dev)
+        description: 'Target environment (prod or dev)'
         required: true
-        default: dev
+        default: 'dev'
         type: choice
         options:
           - prod
@@ -24,22 +24,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fail if branch is not main or dev
+      - id: 'branch-check'
+        name: Fail if branch is not main or dev
         if: github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         run: |
           echo "This workflow should not be triggered with workflow_dispatch on a branch other than main or dev"
           exit 1
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider
-          service_account: sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com
+          workload_identity_provider: 'projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com'
 
-      - name: Set up Cloud SDK
+      - id: 'google-cloud-sdk-setup'
+        name: 'Set up Cloud SDK'
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Invoke Cloud Run
+      - id: 'invoke-cloud-run'
+        name: 'Invoke Cloud Run'
         env:
           ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |

--- a/.github/workflows/trigger_schema_updater.yaml
+++ b/.github/workflows/trigger_schema_updater.yaml
@@ -12,16 +12,17 @@ on:
           - prod
           - dev
 
-permissions:
-  contents: 'read'
-  id-token: 'write'
-
 jobs:
   invoke-cloud-run:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - id: 'branch-check'
         name: Fail if branch is not main or dev
@@ -43,7 +44,9 @@ jobs:
 
       - id: 'invoke-cloud-run'
         name: 'Invoke Cloud Run'
+        env:
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
-          CLOUD_RUN_URL=$(gcloud run services describe schema-updater --region australia-southeast1 --format 'value(status.url)')/execute-liquibase?environment=${{ github.event.inputs.environment }}
+          CLOUD_RUN_URL=$(gcloud run services describe schema-updater --region australia-southeast1 --format 'value(status.url)')/execute-liquibase?environment=$ENVIRONMENT
           TOKEN=$(gcloud auth print-identity-token --impersonate-service-account="sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com" --audiences="$CLOUD_RUN_URL" --include-email)
-            curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/xml" --data-binary "@db/project.xml" $CLOUD_RUN_URL
+            curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/xml" --data-binary "@db/project.xml" "$CLOUD_RUN_URL"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,20 +17,19 @@ repos:
     rev: v0.38.0
     hooks:
       - id: markdownlint
-        args: ["--config", ".markdownlint.json"]
+        args: ['--config', '.markdownlint.json']
 
   - repo: https://github.com/populationgenomics/pre-commits
-    rev: "v0.1.3"
+    rev: 'v0.1.3'
     hooks:
       - id: cpg-id-checker
-        args: ["--extra-pattern", 'TOB\d+']
+        args: ['--extra-pattern', 'TOB\d+']
         exclude: >-
           (?x)^(
               test/test_generic_auditor\.py|
               models/utils/sequencing_group_id_format\.py|
               metamist/audit/README\.md
           )$
-
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
@@ -72,3 +71,8 @@ repos:
         additional_dependencies:
           - strawberry-graphql[fastapi]==0.263.0
           - types-PyMySQL==1.1.0.1
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.5.2
+    hooks:
+      - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,4 +81,4 @@ repos:
     rev: v1.29.0
     hooks:
       - id: yamllint
-        args: [--strict, -c=./.yamllint, .github/workflows]
+        args: [--strict, -c=.yamllint, .github/workflows]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,10 @@ repos:
     rev: v4.5.0
     hooks:
       - id: check-yaml
-        exclude: \.*conda/.*
+        exclude: '\.*conda/.*'
       - id: end-of-file-fixer
       - id: trailing-whitespace
-        exclude: \.txt$|\.tsv$
+        exclude: '\.txt$|\.tsv$'
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: detect-private-key
@@ -17,13 +17,13 @@ repos:
     rev: v0.38.0
     hooks:
       - id: markdownlint
-        args: [--config, .markdownlint.json]
+        args: ["--config", ".markdownlint.json"]
 
   - repo: https://github.com/populationgenomics/pre-commits
-    rev: v0.1.3
+    rev: "v0.1.3"
     hooks:
       - id: cpg-id-checker
-        args: [--extra-pattern, TOB\d+]
+        args: ["--extra-pattern", 'TOB\d+']
         exclude: >-
           (?x)^(
               test/test_generic_auditor\.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,4 +81,4 @@ repos:
     rev: v1.29.0
     hooks:
       - id: yamllint
-        args: [--strict, -c=.yamllint, .github/workflows]
+        args: [--strict, .github/workflows]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,9 +76,3 @@ repos:
     rev: v1.5.2
     hooks:
       - id: zizmor
-
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
-    hooks:
-      - id: yamllint
-        args: [--strict, .github/workflows]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,10 @@ repos:
     rev: v4.5.0
     hooks:
       - id: check-yaml
-        exclude: '\.*conda/.*'
+        exclude: \.*conda/.*
       - id: end-of-file-fixer
       - id: trailing-whitespace
-        exclude: '\.txt$|\.tsv$'
+        exclude: \.txt$|\.tsv$
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: detect-private-key
@@ -17,13 +17,13 @@ repos:
     rev: v0.38.0
     hooks:
       - id: markdownlint
-        args: ['--config', '.markdownlint.json']
+        args: [--config, .markdownlint.json]
 
   - repo: https://github.com/populationgenomics/pre-commits
-    rev: 'v0.1.3'
+    rev: v0.1.3
     hooks:
       - id: cpg-id-checker
-        args: ['--extra-pattern', 'TOB\d+']
+        args: [--extra-pattern, TOB\d+]
         exclude: >-
           (?x)^(
               test/test_generic_auditor\.py|
@@ -76,3 +76,9 @@ repos:
     rev: v1.5.2
     hooks:
       - id: zizmor
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
+        args: [--strict, -c=./.yamllint, .github/workflows]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -273,7 +273,7 @@ itsdangerous==2.2.0
     # via
     #   fastapi
     #   flask
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   fastapi
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,7 +191,7 @@ isodate==0.7.2
     #   azure-storage-file-datalake
 itsdangerous==2.2.0
     # via fastapi
-jinja2==3.1.5
+jinja2==3.1.6
     # via fastapi
 jmespath==1.0.1
     # via


### PR DESCRIPTION
This PR introduces [`zizmor`](https://github.com/woodruffw/zizmor?tab=readme-ov-file) to our pre-commit checks to perform static analysis on our github workflow definitions. As part of this PR, I have also tried to clean up our workflow definitions based on the first set of feedback from the static analysis.

I have also set up [OIDC auth for PyPI](https://docs.pypi.org/trusted-publishers/) which makes the use of the PYPI_API_TOKEN redundant!

The initial scan with `zizmor` showed some initial issues with some of our actions. To summarise some of the issues identified:

- Overly broad permissions given - we had permissions granted to the workflow as a whole instead of each job, which gives all jobs access to the token, even if these jobs don't need it.
- We had some template injection risks
- The `actions/checkout` action stores the GITHUB_TOKEN in the `.git/config` directory unless you explicitly choose not to via `persist-credentials: false`.

<details>

<summary>Zizmor Analysis Results</summary>

```bash
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/deploy.yaml:37:9
   |
37 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/deploy.yaml:11:3
   |
11 |   id-token: write
   |   ^^^^^^^^^^^^^^^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High

info[use-trusted-publishing]: prefer trusted publishing for authentication
   --> ./.github/workflows/deploy.yaml:128:9
    |
128 |         uses: pypa/gh-action-pypi-publish@release/v1
    |         -------------------------------------------- info: this step
129 |         with:
130 |           user: __token__
131 |           password: ${{ secrets.PYPI_API_TOKEN }}
    |           --------------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
    |
    = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/deploy_schema_updater.yaml:15:9
   |
15 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/lint.yaml:17:9
   |
17 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/lint.yaml:5:3
   |
 5 | /   lint:
 6 | |     runs-on: ubuntu-latest
...  |
65 | |       - name: pre-commit
66 | |         run: pre-commit run --all-files
   | |                                        -
   | |________________________________________|
   |                                          this job
   |                                          default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/renovate.yaml:24:9
   |
24 |         - name: Checkout
   |  _________-
25 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/security_checks.yaml:1:1
   |
 1 | / name: Security Checks
 2 | |
...  |
52 | |           inputs: requirements-dev.txt
53 | |           summary: true
   | |________________________- default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/security_checks.yaml:36:3
   |
36 | /   pip-audit:
37 | |     runs-on: ubuntu-latest
...  |
52 | |           inputs: requirements-dev.txt
53 | |           summary: true
   | |                        -
   | |________________________|
   |                          this job
   |                          default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test.yaml:27:9
   |
27 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/test.yaml:132:9
    |
132 |         - uses: actions/checkout@v4
    |  _________-
133 | |         with:
134 | |           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
135 | |
136 | |       # Download the coverage report artifact
    | |_____________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test.yaml:1:1
    |
  1 | / name: Test
  2 | | on:
...   |
153 | |       #   env:
154 | |       #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
    | |____________________________________________________- default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test.yaml:14:3
    |
 14 | /   unittests:
 15 | |     name: Run unit tests
...   |
122 | |           script: |
123 | |             core.setFailed('Web failed to build with rc = ${{ steps.runtests.outputs.web_rc }}')
    | |                                                                                                -
    | |________________________________________________________________________________________________|
    |                                                                                                  this job
    |                                                                                                  default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test.yaml:125:3
    |
125 | /   sonarqube:
126 | |     name: SonarQube scan
...   |
153 | |       #   env:
154 | |       #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
    | |                                                    -
    | |____________________________________________________|
    |                                                      this job
    |                                                      default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/test.yaml:111:9
    |
111 |         - name: Fail if unit tests are not passing
    |           ---------------------------------------- info: this step
112 |           if: ${{ steps.runtests.outputs.rc != 0}}
113 |           uses: actions/github-script@v6
114 |           with:
115 | /           script: |
116 | |             core.setFailed('Unittests failed with rc = ${{ steps.runtests.outputs.rc }}')
    | |_________________________________________________________________________________________- info: steps.runtests.outputs.rc may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/test.yaml:118:9
    |
118 |         - name: Fail if web build fails
    |           ----------------------------- info: this step
119 |           if: ${{ steps.runtests.outputs.rc != 0}}
120 |           uses: actions/github-script@v6
121 |           with:
122 | /           script: |
123 | |             core.setFailed('Web failed to build with rc = ${{ steps.runtests.outputs.web_rc }}')
    | |________________________________________________________________________________________________- info: steps.runtests.outputs.web_rc may expand into attacker-controllable code
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/trigger_schema_updater.yaml:24:9
   |
24 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/trigger_schema_updater.yaml:45:9
   |
45 |   ...   name: 'Invoke Cloud Run'
   |         ^^^^^^^^^^^^^^^^^^^^^^^^ this step
46 | / ...   run: |
47 | | ...     CLOUD_RUN_URL=$(gcloud run services describe schema-updater --region australia-southeast1 --format 'value(status.url)')/execute-liquib...
48 | | ...     TOKEN=$(gcloud auth print-identity-token --impersonate-service-account="sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com...
49 | | ...       curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/xml" --data-binary "@db/project.xml" $CLOUD_RUN_URL
   | |___________________________________________________________________________________________________________________________________________^ github.event.inputs.environment may expand into attacker-controllable code
   |
   = note: audit confidence → High

58 findings (40 suppressed): 0 unknown, 3 informational, 0 low, 13 medium, 2 high
```
</details>