### PR TITLE
Updated pre-commit's strawberry-graphql pinned version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,5 +70,5 @@ repos:
             operator,
           ]
         additional_dependencies:
-          - strawberry-graphql[fastapi]==0.206.0
+          - strawberry-graphql[fastapi]==0.263.0
           - types-PyMySQL==1.1.0.1


### PR DESCRIPTION
The previously pinned version does not support Python 3.13, which pre-commit may choose to base its checker installations on. Pre-commit has been doing this locally for me for a while, leading to pre-commit hooks failing every time due to

```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 2

mypy.ini:11: error: Error importing plugin "strawberry.ext.mypy_plugin": cannot
import name '_create_fn' from 'dataclasses'
(/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/dataclasses.py)
 [misc]
    plugins = strawberry.ext.mypy_plugin
    ^
Found 1 error in 1 file (errors prevented further checking)
```

Updating [past 0.240.1](https://strawberry.rocks/changelog#02401---2024-09-11) fixes this. This PR updates to the current release — which was released yesterday, which may or may not make us comfortable.

