### PR TITLE
Fix analysis status and dest blob name

### DIFF
--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -278,7 +278,6 @@ def move_files(
             blob_copy = source_bucket.copy_blob(
                 source_blob,
                 destination_bucket,
-                destination_blob_name,
             )
             source_bucket.delete_blob(source_blob)
             logger.info(
@@ -312,7 +311,7 @@ def update_analyses(
             logger.info(f'DRY RUN :: Skipping updating analysis {analysis["id"]}')
             continue
         update_model = AnalysisUpdateModel(
-            status=AnalysisStatus('COMPLETED'),
+            status=AnalysisStatus('completed'),
             outputs=analysis['outputs'],
             meta=analysis['meta'],
         )


### PR DESCRIPTION
I ran into some errors when using this script on main without dry-run.

https://batch.hail.populationgenomics.org.au/batches/593947/jobs/1

1. The analysis status is expecting lower-case 'completed' string
2. There is some issue with the `destination_blob_name` in the `bucket.copy_blob` call. 
```
ERROR:288 - <Blob: cpg-dataset-main, mito/CPGXXXXXX.cram, 123456789> could not be converted to unicode: Blob mito/CPGXXXXXX.cram failed to copy.
```
I can't tell exactly what the issue is, since it seems to me like the `destination_blob_name` is the correct string, e.g. 'mito/CPGXXXXXX.cram'. 
I have done some testing locally, it should be fine to remove the destination blob name from the `copy_blob` call entirely. If the destination name is none, then the source name will be used, which is exactly what we want. Hopefully this will resolve the error.
```python
# from google cloud storage bucket.copy_blob
if new_name is None:
     new_name = blob.name
```