### PR TITLE
Update create_test_subset.py for multiple family external IDs

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -48,6 +48,8 @@ papi = ParticipantApi()
 
 DEFAULT_SAMPLES_N = 10
 
+PRIMARY_EXTERNAL_ORG = ''
+
 QUERY_ALL_DATA = gql(
     """
     query getAllData($project: String!, $sids: [String!]) {
@@ -720,7 +722,8 @@ def transfer_families(
         for family in families:
             tsv_writer.writerow(
                 [
-                    family['external_id'],
+                    # import_families() only imports the primary eid anyway
+                    family['external_ids'][PRIMARY_EXTERNAL_ORG],
                     family['description'] or '',
                     family['coded_phenotype'] or '',
                 ]


### PR DESCRIPTION
Since #896, `Family` now has an `external_ids` dict instead of a single `external_id`. Pick out the primary external ID, as `import_families()` will only import that one anyway.