### PR TITLE
fix: Adds phenotypic information to participants

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -894,6 +894,7 @@ def transfer_participants(
                 'karyotype': participant.get('karyotype'),
                 'reported_gender': participant.get('reportedGender'),
                 'reported_sex': participant.get('reportedSex'),
+                'phenotypes': participant.get('phenotypes'),
                 'id': participant.get('id'),
                 'samples': [],
             }


### PR DESCRIPTION
During participant upsert into the new project we query for a range of annotations in the previous project and move most of them - `phenotypes` is the exception.

This adds phenotypes into the participant upsert, no change to the graphQL query required. 

As this is an upsert, and the 'random' sample/family selection is seeded, am I right in thinking that we'll be able to rerun the process after this change, the same samples/participants will be selected for migration, and all the sample/participant/sequencing group IDs in the target project will be maintained, but the phenotype information will be updated? 

In addition, as all files are already generated/copied, and the target project is in test, would I be able to run this locally to update the phenotypic information? 🤔 