### PR TITLE
Fix create_test_subset.py CRAM embedded id updating again

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -976,7 +976,8 @@ def main_file_commands(batch, job, old_path: str, new_path: str, sid: tuple[str,
             new_file={'main': '{root}.cram', 'crai': '{root}.cram.crai'}
         )
         job.command(rf"""
-            samtools reheader --no-PG --in-place --command 'sed /^@RG/s/\<SM:{sid[0]}\>/SM:{sid[1]}/g' {old_file}
+            samtools head {old_file} | sed '/^@RG/s/\<SM:{sid[0]}\>/SM:{sid[1]}/g' > $BATCH_TMPDIR/header.txt
+            samtools reheader --no-PG --in-place $BATCH_TMPDIR/header.txt {old_file}
             mv {old_file} {job.new_file.main}
         """)
         batch.write_output(job.new_file.main, new_path)


### PR DESCRIPTION
The `samtools reheader`'s `--command` option passes the command string to `popen(3)`, which invokes the command via a shell. This means that it is impractical to adequately quote shell metacharacters, so the sed command decayed to `…s/<SM:ID>/…` and did not match anything because there are no literal `<`/`>` characters in that header.
    
Instead run `sed(1)` directly without any extra shells by using a temporary file instead of `--command`.

Tested (as previously in #1044) in [batch 595293](https://batch.hail.populationgenomics.org.au/batches/595293/jobs/1). Checking the output file from that job:

```
$ samtools head gs://cpg-<project>-test/cram/JWM5678.cram | grep @RG
@RG	ID:<original-rg-id>	LB:LB0	PL:PL0	PU:PU0	SM:JWM5678
```

Which confirms that `SM` has been updated to JWM5678 as expected.

Fixes #1061.