### PR TITLE
update strawberry to fix pydantic version incompatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -289,6 +289,7 @@ packaging==24.2
     #   google-cloud-bigquery
     #   gunicorn
     #   pytest
+    #   strawberry-graphql
 pathspec==0.12.1
     # via black
 platformdirs==4.3.6
@@ -429,7 +430,7 @@ starlette==0.41.3
     # via
     #   fastapi
     #   strawberry-graphql
-strawberry-graphql[debug-server,fastapi]==0.257.0
+strawberry-graphql[debug-server,fastapi]==0.268.1
     # via
     #   -r requirements-dev.in
     #   -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ google-cloud-pubsub==2.18.3
 google-cloud-storage==1.43.0
 uvicorn~=0.34.2
 fastapi[all]==0.115.6
-strawberry-graphql[fastapi]==0.257.0
+strawberry-graphql[fastapi]==0.268.1
 databases[mysql]==0.9.0
 cryptography>=41.0.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,12 +35,12 @@ azure-storage-file-datalake==12.20.0
     # via cloudpathlib
 backoff==2.2.1
     # via -r requirements.in
-boto3==1.38.11
+boto3==1.38.17
     # via
     #   -r requirements.in
     #   cloudpathlib
     #   cpg-utils
-botocore==1.38.11
+botocore==1.38.17
     # via
     #   -r requirements.in
     #   boto3
@@ -62,7 +62,7 @@ click==8.1.8
     #   rich-toolkit
     #   typer
     #   uvicorn
-cloudpathlib[all,azure,gs,s3]==0.21.0
+cloudpathlib[all,azure,gs,s3]==0.21.1
     # via
     #   -r requirements.in
     #   cpg-utils
@@ -153,7 +153,7 @@ googleapis-common-protos[grpc]==1.70.0
     #   grpcio-status
 graphql-core==3.2.6
     # via strawberry-graphql
-greenlet==3.2.1
+greenlet==3.2.2
     # via sqlalchemy
 grpc-google-iam-v1==0.12.7
     # via
@@ -215,7 +215,9 @@ multidict==6.4.3
 orjson==3.10.18
     # via fastapi
 packaging==25.0
-    # via google-cloud-bigquery
+    # via
+    #   google-cloud-bigquery
+    #   strawberry-graphql
 propcache==0.3.1
     # via
     #   aiohttp
@@ -298,7 +300,7 @@ rich==14.0.0
     # via
     #   rich-toolkit
     #   typer
-rich-toolkit==0.14.5
+rich-toolkit==0.14.6
     # via fastapi-cli
 rsa==4.9.1
     # via google-auth
@@ -315,17 +317,17 @@ slack-sdk==3.20.2
     # via -r requirements.in
 sniffio==1.3.1
     # via anyio
-sqlalchemy==2.0.40
+sqlalchemy==2.0.41
     # via databases
 starlette==0.41.3
     # via fastapi
-strawberry-graphql[fastapi]==0.257.0
+strawberry-graphql[fastapi]==0.268.1
     # via -r requirements.in
 tabulate==0.9.0
     # via cpg-utils
 toml==0.10.2
     # via cpg-utils
-typer==0.15.3
+typer==0.15.4
     # via fastapi-cli
 typing-extensions==4.13.2
     # via


### PR DESCRIPTION
A recent update to uvicorn dependency resulted in pydantic being updated to 2.11, this update caused an incompatibility with our version of strawberry which was referencing an internal property `is_new_type` from within pydantic. This requirements update upgrades to the newest version of strawberry which contains a fix for this version incompatibility.

see https://github.com/strawberry-graphql/strawberry/issues/3807