### PR TITLE
Limit existing data query to specific project

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -95,7 +95,6 @@ QUERY_ALL_DATA = gql(
     """
 )
 
-# TODO: We can change this to filter external sample ids
 EXISTING_DATA_QUERY = gql(
     """
     query getExistingData($project: String!) {
@@ -111,7 +110,7 @@ EXISTING_DATA_QUERY = gql(
                         meta
                         type
                     }
-                    analyses {
+                    analyses(project: {eq: $project}) {
                         id
                         type
                     }


### PR DESCRIPTION
Exact failure mode identified by @dancoates. Example failure https://batch.hail.populationgenomics.org.au/batches/595308/jobs/1

This query should be "get all the things in the target project"

Instead it's "for all samples in the target project, get all their things". If samples in the target project have been run in bulk analysis (e.g. `acute-care` samples have analysis entries from `seqr`) then the associated analysis come from several projects.

I've been using this script by scoping the service account doing the transfer to the project being transferred, in which case this causes problems. This can be overcome by running the transfer using an umbrella project (e.g. seqr), but the issue here is that the only analysis entries we should be accessing are the ones *in* the source project.