### PR TITLE
Add method to get QC web reports from db with web api

### DIFF
--- a/api/routes/web.py
+++ b/api/routes/web.py
@@ -30,6 +30,7 @@ from models.models.web import (
     ProjectParticipantGridField,
     ProjectParticipantGridResponse,
     ProjectSummary,
+    ProjectWebReport,
 )
 
 
@@ -144,6 +145,28 @@ async def export_project_participants(
         # content-disposition doesn't work here :(
         headers={},
     )
+
+
+@router.get(
+    '/{project}/webReports/{sequencing_type}',
+    operation_id='getProjectWebReports',
+    response_model=list[ProjectWebReport],
+)
+async def get_project_web_reports(
+    sequencing_types: list[str] | None = None,
+    stages: list[str] | None = None,
+    connection: Connection = get_project_db_connection(ReadAccessRoles),
+) -> list[ProjectWebReport]:
+    """Get web reports for the project and sequencing type"""
+    if not connection.project_id:
+        raise ValueError('No project was detected through the authentication')
+
+    wlayer = WebLayer(connection)
+    reports = await wlayer.get_project_web_reports(
+        sequencing_types=sequencing_types, stages=stages
+    )
+
+    return [r.to_external() for r in reports]
 
 
 def get_field_from_obj(obj, field: ProjectParticipantGridField) -> str | None:

--- a/api/routes/web.py
+++ b/api/routes/web.py
@@ -30,7 +30,7 @@ from models.models.web import (
     ProjectParticipantGridField,
     ProjectParticipantGridResponse,
     ProjectSummary,
-    ProjectWebReport,
+    ProjectQcWebReport,
 )
 
 
@@ -149,20 +149,20 @@ async def export_project_participants(
 
 @router.get(
     '/{project}/webReports/{sequencing_type}',
-    operation_id='getProjectWebReports',
-    response_model=list[ProjectWebReport],
+    operation_id='getProjectQcWebReports',
+    response_model=list[ProjectQcWebReport],
 )
-async def get_project_web_reports(
+async def get_project_qc_web_reports(
     sequencing_types: list[str] | None = None,
     stages: list[str] | None = None,
     connection: Connection = get_project_db_connection(ReadAccessRoles),
-) -> list[ProjectWebReport]:
+) -> list[ProjectQcWebReport]:
     """Get web reports for the project and sequencing type"""
     if not connection.project_id:
         raise ValueError('No project was detected through the authentication')
 
     wlayer = WebLayer(connection)
-    reports = await wlayer.get_project_web_reports(
+    reports = await wlayer.get_project_qc_web_reports(
         sequencing_types=sequencing_types, stages=stages
     )
 

--- a/db/python/layers/web.py
+++ b/db/python/layers/web.py
@@ -31,7 +31,7 @@ from models.models.sequencing_group import SequencingGroupInternal
 from models.models.web import (
     ProjectSummaryInternal,
     WebProject,
-    ProjectWebReportInternal,
+    ProjectQcWebReportInternal,
 )
 
 
@@ -48,7 +48,7 @@ class WebLayer(BaseLayer):
         webdb = WebDb(self.connection)
         return await webdb.get_project_summary()
 
-    async def get_project_web_reports(
+    async def get_project_qc_web_reports(
         self,
         sequencing_types: list[str] | None = None,
         stages: list[str] | None = None,
@@ -57,7 +57,7 @@ class WebLayer(BaseLayer):
         Get web reports for a project, optionally filtered by sequencing type.
         """
         webdb = WebDb(self.connection)
-        return await webdb.get_project_web_reports(
+        return await webdb.get_project_qc_web_reports(
             sequencing_types=sequencing_types or [],
             stages=stages or [],
         )
@@ -111,10 +111,10 @@ class WebDb(DbBase):
         WHERE s.project = :project"""
         return await self.connection.fetch_val(_query, {'project': self.project_id})
 
-    async def get_project_web_reports(
+    async def get_project_qc_web_reports(
         self, sequencing_types: list[str], stages: list[str]
     ):
-        """Get web analyses for a project filtered by sequencing type and stage."""
+        """Get qc web report analyses for a project filtered by sequencing type and stage."""
         _query = """
         SELECT
             a.id,
@@ -142,7 +142,7 @@ class WebDb(DbBase):
             },
         )
         return [
-            ProjectWebReportInternal(
+            ProjectQcWebReportInternal(
                 id=report['id'],
                 timestamp_completed=report['timestamp_completed'],
                 output=report['output'],

--- a/models/models/web.py
+++ b/models/models/web.py
@@ -113,7 +113,11 @@ class ProjectQcWebReportInternal(SMBase):
         Convert "gs://cpg-dataset-(main|test)/qc/cram/<sg_hash>/multiqc_data.json"
         to      "https://(main|test)-web.populationgenomics.org.au/dataset/qc/cram/<sg_hash>/multiqc.html"
         """
-        if not self.output or not self.output.startswith('gs://'):
+        if (
+            (not self.output)
+            or (not self.output.startswith('gs://'))
+            or ('multiqc_data.json' not in self.output)
+        ):
             return None
         bucket_name, blob_name = self.output.removeprefix('gs://').split('/', 1)
         blob_name = blob_name.replace('multiqc_data.json', 'multiqc.html')

--- a/models/models/web.py
+++ b/models/models/web.py
@@ -84,6 +84,55 @@ class ProjectSummary(SMBase):
     seqr_sync_types: list[str]
 
 
+class ProjectWebReport(SMBase):
+    """Return class for the project web report endpoint"""
+
+    id: int
+    timestamp_completed: str
+    sequencing_type: str
+    stage: str
+    output: str
+    html_path: str | None = None
+    sequencing_groups: list[str] | None = None
+
+
+class ProjectWebReportInternal(SMBase):
+    """Return class for the project web report endpoint"""
+
+    id: int
+    timestamp_completed: str
+    sequencing_type: str
+    stage: str
+    output: str
+    sequencing_groups: list[str] | None = None
+
+    def _html_path(self) -> str | None:
+        """
+        Format the HTML path for the report from the output path
+
+        Convert "gs://cpg-dataset-(main|test)/qc/cram/<sg_hash>/multiqc_data.json"
+        to      "https://(main|test)-web.populationgenomics.org.au/dataset/qc/cram/<sg_hash>/multiqc.html"
+        """
+        if not self.output or not self.output.startswith('gs://'):
+            return None
+        bucket_name, blob_name = self.output.removeprefix('gs://').split('/', 1)
+        blob_name = blob_name.replace('multiqc_data.json', 'multiqc.html')
+        dataset_name, access_level = bucket_name.removeprefix('cpg-').split('-', 1)
+        return f'https://{access_level}-web.populationgenomics.org.au/{dataset_name}/{blob_name}'
+
+    def to_external(self):
+        """Convert to transport model"""
+        return ProjectWebReport(
+            id=self.id,
+            timestamp_completed=self.timestamp_completed,
+            sequencing_type=self.sequencing_type,
+            stage=self.stage,
+            output=self.output,
+            html_path=self._html_path(),
+            sequencing_groups=self.sequencing_groups,
+        )
+
+
 class ProjectParticipantGridFilterType(Enum):
     """Filter types for grid response"""
 

--- a/models/models/web.py
+++ b/models/models/web.py
@@ -84,7 +84,7 @@ class ProjectSummary(SMBase):
     seqr_sync_types: list[str]
 
 
-class ProjectWebReport(SMBase):
+class ProjectQcWebReport(SMBase):
     """Return class for the project web report endpoint"""
 
     id: int
@@ -96,7 +96,7 @@ class ProjectWebReport(SMBase):
     sequencing_groups: list[str] | None = None
 
 
-class ProjectWebReportInternal(SMBase):
+class ProjectQcWebReportInternal(SMBase):
     """Return class for the project web report endpoint"""
 
     id: int
@@ -122,7 +122,7 @@ class ProjectWebReportInternal(SMBase):
 
     def to_external(self):
         """Convert to transport model"""
-        return ProjectWebReport(
+        return ProjectQcWebReport(
             id=self.id,
             timestamp_completed=self.timestamp_completed,
             sequencing_type=self.sequencing_type,


### PR DESCRIPTION
**This PR**
- Introduces a new `WebAPI` endpoint to get QC report entries for a given project, and for given sequencing types and analysis.meta stages.
- Adds a new method to the `WebLayer` to query the database for the QC entries
- Adds a new method to the `WebDb` which queries the `analysis` and `analysis_outputs` table for QC records with the given sequencing types and stages.
- Adds new models `ProjectQcWebReport` and `ProjectQcWebReportInternal`
  - These models capture the analysis information (id, timestamp, seq type, stage, output path, sequencing groups)
  - Contains a method to transform the `analysis.output` into the pure HTML path that can be visited in the browser

Still TODO:
- Update the frontend code to pull in the QC web reports for a dataset and display the URLs for the most recent reports
- Possibly add logic to display multiple / all report links? And let the user see what sequencing groups are in each report?

---

At present, when visiting the Metamist [`Project` page](https://sample-metadata.populationgenomics.org.au/project/thousand-genomes), the user is presented with links to MultiQC reports. 

<img width="973" alt="image" src="https://github.com/user-attachments/assets/78c413e5-8c09-48fb-8c65-8219d49659df" />

These reports are hard-coded URLs that are based on the dataset name and nothing else (see [the frontend code](https://github.com/populationgenomics/metamist/blob/3a4880187b49446b03933351be7f57cf5c2c325a/web/src/pages/project/MultiQCReports.tsx#L10)). **This is bad because these links go to historic QC reports, not recent ones**. Mistakenly viewing old reports can lead to errors and misunderstandings from unaware analysts.

To fix this, we need to query the database to get the analysis records and file paths to the QC outputs, and then use some logic to feed the HTML path of the latest report in to the front end. 