### PR TITLE
Bug: allow upsert of samples with assayless sequencing groups

### DIFF
--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -347,7 +347,7 @@ class SequencingGroupLayer(BaseLayer):
         # but we're inside a transaction, so it's not actually committing anything
         # so should be quick to "write" in serial
         for sg in to_insert:
-            assay_ids = [a.id for a in sg.assays]
+            assay_ids = [a.id for a in sg.assays] if sg.assays else None
             sg.id = await self.seqgt.create_sequencing_group(
                 sample_id=sg.sample_id,
                 type_=sg.type,

--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -347,7 +347,7 @@ class SequencingGroupLayer(BaseLayer):
         # but we're inside a transaction, so it's not actually committing anything
         # so should be quick to "write" in serial
         for sg in to_insert:
-            assay_ids = [a.id for a in sg.assays] if sg.assays else None
+            assay_ids = [a.id for a in sg.assays] if sg.assays else []
             sg.id = await self.seqgt.create_sequencing_group(
                 sample_id=sg.sample_id,
                 type_=sg.type,

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -469,17 +469,18 @@ class SequencingGroupTable(DbBase):
                 _query,
                 {**values, 'audit_log_id': await self.audit_log_id()},
             )
-            assay_id_insert_values = [
-                {
-                    'seqgroup': id_of_seq_group,
-                    'assayid': s,
-                    'audit_log_id': await self.audit_log_id(),
-                }
-                for s in assay_ids
-            ]
-            await self.connection.execute_many(
-                _seqg_linker_query, assay_id_insert_values
-            )
+            if assay_ids:
+                assay_id_insert_values = [
+                    {
+                        'seqgroup': id_of_seq_group,
+                        'assayid': s,
+                        'audit_log_id': await self.audit_log_id(),
+                    }
+                    for s in assay_ids
+                ]
+                await self.connection.execute_many(
+                    _seqg_linker_query, assay_id_insert_values
+                )
 
             return id_of_seq_group
 

--- a/test/test_upsert.py
+++ b/test/test_upsert.py
@@ -1,5 +1,3 @@
-from test.testbase import DbIsolatedTest, run_as_sync
-
 from db.python.layers.participant import ParticipantLayer
 from models.models import (
     PRIMARY_EXTERNAL_ORG,
@@ -8,6 +6,7 @@ from models.models import (
     SampleUpsertInternal,
     SequencingGroupUpsertInternal,
 )
+from test.testbase import DbIsolatedTest, run_as_sync
 
 default_assay_meta = {
     'sequencing_type': 'genome',
@@ -266,21 +265,35 @@ class TestUpsert(DbIsolatedTest):
             self.assertIsNotNone(db_sg['sample_id'])
             self.assertIsNotNone(db_sg['type'])
 
-        db_sequencing = await self.connection.connection.fetch_all(
-            'SELECT * FROM assay'
-        )
-        self.assertEqual(5, len(db_sequencing))
-        for db_sg in db_sequencing_groups:
-            self.assertIsNotNone(db_sg['sample_id'])
-            # self.assertIsNotNone(db_sg['type'])
+        db_assays = await self.connection.connection.fetch_all('SELECT * FROM assay')
 
-        db_empty_sequencing_groups = await self.connection.connection.fetch_all(
-            'SELECT sg.id, pei.external_id \
-            FROM sequencing_group AS sg \
-            INNER JOIN sample AS s ON s.id = sg.sample_id \
-            INNER JOIN participant AS p ON p.id = s.participant_id \
-            INNER JOIN participant_external_id AS pei ON p.id = pei.participant_id \
-            WHERE pei = "Athena"'
+        self.assertEqual(4, len(db_assays))
+        for db_a in db_assays:
+            self.assertIsNotNone(db_a['sample_id'])
+            self.assertIsNotNone(db_a['type'])
+
+        db_participant_no_assays = await self.connection.connection.fetch_one(
+            """
+            SELECT COUNT(DISTINCT a.id) AS cnt
+            FROM sample AS s
+            INNER JOIN participant AS p ON p.id = s.participant_id
+            INNER JOIN participant_external_id AS pei ON p.id = pei.participant_id
+            LEFT JOIN assay AS a ON a.sample_id = s.id
+            WHERE pei.external_id = "Athena"
+            """
         )
 
-        self.assertEqual(0, len(db_empty_sequencing_groups))
+        self.assertEqual(0, db_participant_no_assays['cnt'])
+
+        db_participant_has_assays = await self.connection.connection.fetch_one(
+            """
+            SELECT COUNT(DISTINCT a.id) AS cnt
+            FROM sample AS s
+            INNER JOIN participant AS p ON p.id = s.participant_id
+            INNER JOIN participant_external_id AS pei ON p.id = pei.participant_id
+            LEFT JOIN assay AS a ON a.sample_id = s.id
+            WHERE pei.external_id = "Apollo"
+            """
+        )
+
+        self.assertEqual(2, db_participant_has_assays['cnt'])

--- a/test/test_upsert.py
+++ b/test/test_upsert.py
@@ -186,31 +186,7 @@ all_participants = [
                         technology='short-read',
                         platform='illumina',
                         meta={},
-                        assays=[
-                            AssayUpsertInternal(
-                                meta={
-                                    'reads': [
-                                        {
-                                            'basename': 'sample_id003.filename-R1.fastq.gz',
-                                            'checksum': None,
-                                            'class': 'File',
-                                            'location': '/path/to/sample_id003.filename-R1.fastq.gz',
-                                            'size': 111,
-                                        },
-                                        {
-                                            'basename': 'sample_id003.filename-R2.fastq.gz',
-                                            'checksum': None,
-                                            'class': 'File',
-                                            'location': '/path/to/sample_id003.filename-R2.fastq.gz',
-                                            'size': 111,
-                                        },
-                                    ],
-                                    'reads_type': 'fastq',
-                                    **default_assay_meta,
-                                },
-                                type='sequencing',
-                            )
-                        ],
+                        assays=[],
                     )
                 ],
                 type='blood',
@@ -297,3 +273,14 @@ class TestUpsert(DbIsolatedTest):
         for db_sg in db_sequencing_groups:
             self.assertIsNotNone(db_sg['sample_id'])
             # self.assertIsNotNone(db_sg['type'])
+
+        db_empty_sequencing_groups = await self.connection.connection.fetch_all(
+            'SELECT sg.id, pei.external_id \
+            FROM sequencing_group AS sg \
+            INNER JOIN sample AS s ON s.id = sg.sample_id \
+            INNER JOIN participant AS p ON p.id = s.participant_id \
+            INNER JOIN participant_external_id AS pei ON p.id = pei.participant_id \
+            WHERE pei = "Athena"'
+        )
+
+        self.assertEqual(0, len(db_empty_sequencing_groups))


### PR DESCRIPTION
I am working on the ingestion of a large number of `analysis` files that have been generated from long read data. These files have been produced on external pipelines for which the CPG does not have assay data (`bam` or `fastq`). Long read sequencing was performed for a small subset of samples (n=25) from an existing CPG cohort. We have existing `samples` and `participant` metadata previously ingested into metamist for this subset.

To ingest these data, the following steps are required:
* Create a new sequencing group for each `sample` with `type`, `technology` and `platform` to reflect the long read data being ingested
* Create a new `cohort` associated with all newly created sequencing groups to accommodate two cohort-level `analysis` objects
* For each sample-level `analysis` file provided, create a new `analysis` object associated with their corresponding `sample's` new `sequencing group`

## Current functionality

Currently, the `create_sample` endpoint is configured to accept an empty or missing list of assays. Yet in the `sequencing group` `layer` module, the following error is returned when attempting to upsert a sample that includes a sequencing group with no assays:
```
\"/Users/amymin/Documents/Code/metamist-local/api/routes/sample.py\", line 178, in update_sample\n    await st.upsert_sample(sample.to_internal())\n  File \"/Users/amymin/Documents/Code/metamist-local/db/python/layers/sample.py\", line 276, in upsert_sample\n    await sglayer.upsert_sequencing_groups(sample.sequencing_groups)\n  File \"/Users/amymin/Documents/Code/metamist-local/db/python/layers/sequencing_group.py\", line 350, in upsert_sequencing_groups\n    assay_ids = [a.id for a in sg.assays]\n                ^^^^^^^^^^^^^^^^^^^^^^^^^\nTypeError: 'NoneType' object is not iterable\n"}
```
The `sequencing group` `tables` module also does not accommodate an empty list of `assays` when inserting linked `sequencing groups` and `assays` into metamist.

## Updates in this PR
Very minor! Small checks are performed in the `layers` and `tables` modules for an empty list of `assays`. If `None`, the method to upserting the linking table `assays_sequencing_groups` is not called.  
