### PR TITLE
SET-547-R3 Custom Project Grouping Fixes

### DIFF
--- a/db/python/tables/bq/billing_base.py
+++ b/db/python/tables/bq/billing_base.py
@@ -391,7 +391,6 @@ class BillingBaseTable(BqDbBase):
         total_monthly_category: dict,
         total_daily_category: dict,
         results: list[BillingCostBudgetRecord],
-        filters: dict | None = None,
     ) -> list[BillingCostBudgetRecord]:
         """
         Add total row: compute + storage to the results
@@ -409,14 +408,8 @@ class BillingBaseTable(BqDbBase):
             )
 
         # Generate appropriate title based on whether filters are applied
-        if filters and 'gcp_project' in filters:
-            gcp_projects = filters['gcp_project']
-            if isinstance(gcp_projects, list) and len(gcp_projects) > 0:
-                field_title = f'Total ({len(gcp_projects)} projects)'
-            else:
-                field_title = f'{BillingColumn.generate_all_title(field)}'
-        else:
-            field_title = f'{BillingColumn.generate_all_title(field)}'
+        # Always use consistent "All X" naming for aggregate rows
+        field_title = f'{BillingColumn.generate_all_title(field)}'
 
         # add total row: compute + storage
         results.append(
@@ -749,7 +742,6 @@ class BillingBaseTable(BqDbBase):
             total_monthly_category,
             total_daily_category,
             results,
-            query.filters,
         )
 
         # add rest of the records: compute + storage

--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -334,6 +334,15 @@ const BillingCostByTime: React.FunctionComponent = () => {
     /* eslint-disable react-hooks/exhaustive-deps */
     React.useEffect(() => {
         if (Boolean(start) && Boolean(end)) {
+            // Check if start date is after end date
+            if (start > end) {
+                setIsLoading(false)
+                setError(undefined)
+                setMessage(
+                    'Start date cannot be later than end date. Please adjust your selection.'
+                )
+                return
+            }
             // Use debounced function for topic filtering
             debouncedGetData(start, end, selectedTopics)
         } else {
@@ -358,17 +367,6 @@ const BillingCostByTime: React.FunctionComponent = () => {
         const matrix: string[][] = []
 
         allTopics.forEach((topic: string) => {
-            // Storage cost row
-            const storageRow: [string, string, ...string[]] = [
-                topic,
-                CloudSpendCategory.STORAGE_COST.toString(),
-                ...months.map((m) => {
-                    const val = data[topic]?.[m]?.[CloudSpendCategory.STORAGE_COST]
-                    return val === undefined ? '' : val.toFixed(2)
-                }),
-            ]
-            matrix.push(storageRow)
-
             const computeRow: [string, string, ...string[]] = [
                 topic,
                 CloudSpendCategory.COMPUTE_COST.toString(),
@@ -378,6 +376,16 @@ const BillingCostByTime: React.FunctionComponent = () => {
                 }),
             ]
             matrix.push(computeRow)
+
+            const storageRow: [string, string, ...string[]] = [
+                topic,
+                CloudSpendCategory.STORAGE_COST.toString(),
+                ...months.map((m) => {
+                    const val = data[topic]?.[m]?.[CloudSpendCategory.STORAGE_COST]
+                    return val === undefined ? '' : val.toFixed(2)
+                }),
+            ]
+            matrix.push(storageRow)
         })
 
         exportTable(

--- a/web/src/pages/billing/BillingInvoiceMonthCost.tsx
+++ b/web/src/pages/billing/BillingInvoiceMonthCost.tsx
@@ -872,9 +872,7 @@ const BillingCurrentCost = () => {
                                             <SUITable.Cell style={{ border: 'none' }} />
                                             <SUITable.Cell>{dk.cost_category}</SUITable.Cell>
 
-                                            {/* Render cells for each visible column in the exact same order as HEADER_FIELDS */}
                                             {HEADER_FIELDS.map((field) => {
-                                                // Skip the 'field' column since it's already rendered
                                                 if (
                                                     field.category === 'field' ||
                                                     !isColumnVisible(field.category)
@@ -882,7 +880,6 @@ const BillingCurrentCost = () => {
                                                     return null
                                                 }
 
-                                                // Determine if this detail row should show data in this column
                                                 let shouldShowData = false
                                                 let dataValue = 0
 

--- a/web/src/pages/billing/BillingInvoiceMonthCost.tsx
+++ b/web/src/pages/billing/BillingInvoiceMonthCost.tsx
@@ -262,6 +262,7 @@ const BillingCurrentCost = () => {
             if (value !== BillingColumn.Topic) {
                 setSelectedTopics([])
             }
+            // Immediate data fetch for Group By selector (no debouncing)
             getData(value as BillingColumn, invoiceMonth, [], [])
         }
     }
@@ -270,7 +271,7 @@ const BillingCurrentCost = () => {
         const value = data.value
         if (typeof value == 'string') {
             setInvoiceMonth(value)
-            // Pass current filters based on groupBy
+            // Immediate data fetch for Invoice Month selector (no debouncing)
             if (groupBy === BillingColumn.GcpProject) {
                 getData(groupBy, value, selectedGcpProjects, [])
             } else if (groupBy === BillingColumn.Topic) {
@@ -297,16 +298,19 @@ const BillingCurrentCost = () => {
         setSelectedTopics(value)
     }
 
+    // Separate useEffect for GCP Project filter changes only
     React.useEffect(() => {
-        // Pass current filters based on groupBy
         if (groupBy === BillingColumn.GcpProject) {
             debouncedGetData(groupBy, invoiceMonth, selectedGcpProjects, [])
-        } else if (groupBy === BillingColumn.Topic) {
-            debouncedGetData(groupBy, invoiceMonth, [], selectedTopics)
-        } else {
-            debouncedGetData(groupBy, invoiceMonth, [], [])
         }
-    }, [groupBy, invoiceMonth, selectedGcpProjects, selectedTopics, debouncedGetData])
+    }, [selectedGcpProjects, debouncedGetData])
+
+    // Separate useEffect for Topic filter changes only
+    React.useEffect(() => {
+        if (groupBy === BillingColumn.Topic) {
+            debouncedGetData(groupBy, invoiceMonth, [], selectedTopics)
+        }
+    }, [selectedTopics, debouncedGetData])
 
     // Define column groups for easier management
     const DAILY_COLUMNS = ['compute_daily', 'storage_daily', 'total_daily']

--- a/web/src/pages/billing/BillingInvoiceMonthCost.tsx
+++ b/web/src/pages/billing/BillingInvoiceMonthCost.tsx
@@ -895,8 +895,8 @@ const BillingCurrentCost = () => {
                                                         shouldShowData = true
                                                         dataValue =
                                                             field.category === 'compute_daily'
-                                                                ? dk.daily_cost
-                                                                : dk.monthly_cost
+                                                                ? dk.daily_cost ?? 0
+                                                                : dk.monthly_cost ?? 0
                                                     }
                                                 } else {
                                                     // Storage costs: show in storage columns
@@ -907,8 +907,8 @@ const BillingCurrentCost = () => {
                                                         shouldShowData = true
                                                         dataValue =
                                                             field.category === 'storage_daily'
-                                                                ? dk.daily_cost
-                                                                : dk.monthly_cost
+                                                                ? dk.daily_cost ?? 0
+                                                                : dk.monthly_cost ?? 0
                                                     }
                                                 }
 

--- a/web/src/pages/billing/BillingInvoiceMonthCost.tsx
+++ b/web/src/pages/billing/BillingInvoiceMonthCost.tsx
@@ -409,6 +409,13 @@ const BillingCurrentCost = () => {
         return `${num.toFixed(0).toString()} % `
     }
 
+    // Helper function to calculate consistent totals from rounded components
+    const getConsistentTotal = (compute: number | null, storage: number | null): number => {
+        const computeRounded = compute ? Math.round(compute * 100) / 100 : 0
+        const storageRounded = storage ? Math.round(storage * 100) / 100 : 0
+        return computeRounded + storageRounded
+    }
+
     if (error)
         return (
             <Message negative>
@@ -831,16 +838,32 @@ const BillingCurrentCost = () => {
                                                         </b>
                                                     </SUITable.Cell>
                                                 )
-                                            default:
+                                            default: {
                                                 // We already checked visibility above, so just render
+                                                const record = p as BillingCostBudgetRecord
+                                                let value = record[
+                                                    k.category as keyof BillingCostBudgetRecord
+                                                ] as number
+
+                                                // Recalculate totals from rounded components for consistency
+                                                if (k.category === 'total_monthly') {
+                                                    value = getConsistentTotal(
+                                                        record.compute_monthly,
+                                                        record.storage_monthly
+                                                    )
+                                                } else if (k.category === 'total_daily') {
+                                                    value = getConsistentTotal(
+                                                        record.compute_daily,
+                                                        record.storage_daily
+                                                    )
+                                                }
+
                                                 return (
                                                     <SUITable.Cell key={k.category}>
-                                                        {
-                                                            // @ts-ignore
-                                                            formatMoney(p[k.category])
-                                                        }
+                                                        {formatMoney(value)}
                                                     </SUITable.Cell>
                                                 )
+                                            }
                                         }
                                     })}
 

--- a/web/src/pages/billing/components/BillingCostByTimeTable.tsx
+++ b/web/src/pages/billing/components/BillingCostByTimeTable.tsx
@@ -15,6 +15,7 @@ import {
 import { IStackedAreaByDateChartData } from '../../../shared/components/Graphs/StackedAreaByDateChart'
 
 import Table from '../../../shared/components/Table'
+import { ThemeContext } from '../../../shared/components/ThemeProvider'
 import { convertFieldName } from '../../../shared/utilities/fieldName'
 import formatMoney from '../../../shared/utilities/formatMoney'
 import { BillingColumn } from '../../../sm-api'
@@ -36,11 +37,20 @@ type SummaryRowData = {
 }
 
 const BreakdownTableRow: React.FC<{ item: BreakdownRowData }> = ({ item: row, ...props }) => {
+    const theme = React.useContext(ThemeContext)
+    const isDarkMode = theme.theme === 'dark-mode'
     return (
         <TableRow
             {...props}
-            className="ui table row"
-            style={row.isTotal ? { backgroundColor: '#f5f5f5', fontWeight: 'bold' } : {}}
+            className={`ui table row${isDarkMode ? ' inverted' : ''}`}
+            style={
+                row.isTotal
+                    ? {
+                          backgroundColor: isDarkMode ? 'rgba(255,255,255,0.08)' : '#f5f5f5',
+                          fontWeight: 'bold',
+                      }
+                    : {}
+            }
         >
             <SUITable.Cell collapsing>
                 <b>{row.date ? row.date.toLocaleDateString() : 'All Time Total'}</b>
@@ -63,8 +73,10 @@ const BreakdownTableRow: React.FC<{ item: BreakdownRowData }> = ({ item: row, ..
 }
 
 const SummaryTableRow: React.FC<{ item: SummaryRowData }> = ({ item: row, ...props }) => {
+    const theme = React.useContext(ThemeContext)
+    const isDarkMode = theme.theme === 'dark-mode'
     return (
-        <TableRow {...props} className="ui table row">
+        <TableRow {...props} className={`ui table row${isDarkMode ? ' inverted' : ''}`}>
             <SUITable.Cell collapsing>
                 <b>{row.date.toLocaleDateString()}</b>
             </SUITable.Cell>
@@ -196,6 +208,8 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
     onExportRequest,
     currentViewMode: externalCurrentViewMode,
 }) => {
+    const theme = React.useContext(ThemeContext)
+    const isDarkMode = theme.theme === 'dark-mode'
     const [internalData, setInternalData] = React.useState<IStackedAreaByDateChartData[]>([])
     const [internalGroups, setInternalGroups] = React.useState<string[]>([])
     const [viewMode, setViewMode] = React.useState<ViewMode>(externalCurrentViewMode || 'summary')
@@ -576,13 +590,13 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                             600,
                             Math.max(200, virtuosoBreakdownData.length * 50 + 100)
                         ),
-                        backgroundColor: 'white',
+                        backgroundColor: 'transparent',
                     }}
                     data={virtuosoBreakdownData}
                     components={VirtuosoBreakdownTableComponents}
                     fixedHeaderContent={() => (
                         <>
-                            <TableRow className="ui table row">
+                            <TableRow className={`ui table row${isDarkMode ? ' inverted' : ''}`}>
                                 <SUITable.HeaderCell colSpan={3} textAlign="center">
                                     <span
                                         style={{
@@ -623,7 +637,7 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                                     Compute Cost
                                 </SUITable.HeaderCell>
                             </TableRow>
-                            <TableRow className="ui table row">
+                            <TableRow className={`ui table row${isDarkMode ? ' inverted' : ''}`}>
                                 <SUITable.HeaderCell
                                     style={{
                                         borderBottom: 'none',
@@ -660,8 +674,14 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                     )}
                     fixedFooterContent={() => (
                         <TableRow
-                            className="ui table row"
-                            style={{ backgroundColor: '#f5f5f5', fontWeight: 'bold' }}
+                            className={`ui table row${isDarkMode ? ' inverted' : ''}`}
+                            style={{
+                                backgroundColor: isDarkMode ? '#1b1c1d' : '#f9f9f9',
+                                fontWeight: 'bold',
+                                position: 'sticky',
+                                bottom: 0,
+                                zIndex: 10,
+                            }}
                         >
                             <SUITable.Cell collapsing style={{ minWidth: '140px' }}>
                                 <b>All Time Total</b>
@@ -673,22 +693,11 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                                 </b>
                             </SUITable.Cell>
                             {headerFields.map((field) => {
-                                const total = breakdownData
-                                    ? Object.values(breakdownData).reduce((dateSum, fieldData) => {
-                                          return (
-                                              dateSum +
-                                              Object.values(fieldData).reduce(
-                                                  (fieldSum, categories) => {
-                                                      return (
-                                                          fieldSum +
-                                                          (categories[field.category] || 0)
-                                                      )
-                                                  },
-                                                  0
-                                              )
-                                          )
-                                      }, 0)
-                                    : 0
+                                // Use same calculation as summary view for consistency
+                                const total = internalData.reduce(
+                                    (acc, cur) => acc + (cur.values[field.category] || 0),
+                                    0
+                                )
                                 return (
                                     <SUITable.Cell
                                         key={`Total ${field.category}`}
@@ -708,13 +717,13 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                 <TableVirtuoso
                     style={{
                         height: Math.min(600, Math.max(200, virtuosoSummaryData.length * 50 + 100)),
-                        backgroundColor: 'white',
+                        backgroundColor: 'transparent',
                     }}
                     data={virtuosoSummaryData}
                     components={VirtuosoSummaryTableComponents}
                     fixedHeaderContent={() => (
                         <>
-                            <TableRow className="ui table row">
+                            <TableRow className={`ui table row${isDarkMode ? ' inverted' : ''}`}>
                                 <SUITable.HeaderCell colSpan={2} textAlign="center">
                                     <span
                                         style={{
@@ -755,7 +764,7 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                                     Compute Cost
                                 </SUITable.HeaderCell>
                             </TableRow>
-                            <TableRow className="ui table row">
+                            <TableRow className={`ui table row${isDarkMode ? ' inverted' : ''}`}>
                                 <SUITable.HeaderCell
                                     style={{
                                         borderBottom: 'none',
@@ -784,8 +793,14 @@ const BillingCostByTimeTable: React.FC<IBillingCostByTimeTableProps> = ({
                     )}
                     fixedFooterContent={() => (
                         <TableRow
-                            className="ui table row"
-                            style={{ backgroundColor: '#f5f5f5', fontWeight: 'bold' }}
+                            className={`ui table row${isDarkMode ? ' inverted' : ''}`}
+                            style={{
+                                backgroundColor: isDarkMode ? '#1b1c1d' : '#f9f9f9',
+                                fontWeight: 'bold',
+                                position: 'sticky',
+                                bottom: 0,
+                                zIndex: 10,
+                            }}
                         >
                             <SUITable.Cell collapsing style={{ minWidth: '140px' }}>
                                 <b>All Time Total</b>


### PR DESCRIPTION
Fixing a few UI bugs here on the recent Custom Project Groupings feature:

### CostByTime
- Dark Mode in the table component
- Group by Topic data not displaying when in breakdown view
- Add % to the Donut chart slices
- Fix Column Visibility Dropdown not working

### BillingInvoiceMonthCost
- Column positioning issue when using the column visibility dropdown on a previous month
- Rounding off logic was causing aggregations to be off by $0.01 as the total and the individual values were rounded off separately
- Make consistent aggregation text on the project view to use "All GCP Projects" instead of "Total (X Projects)" since all other views use "All XYZ" format
- Changing the Group By was setting off a debounced query instead of an immediate query to the API

### CostByMonth
- Improve error message when selecting incompatible start and end dates on CostByMonth
- Use consistent ordering of Compute Type in the exported CSV/TSV files i.e Compute Cost and _then_ Storage Cost