### PR TITLE
Fix for billing Cost By Invoice Month chart, solid vs diagonal pattern.

### DIFF
--- a/web/src/shared/components/Graphs/HorizontalStackedBarChart.tsx
+++ b/web/src/shared/components/Graphs/HorizontalStackedBarChart.tsx
@@ -161,9 +161,12 @@ const HorizontalStackedBarChart: React.FC<HorizontalStackedBarChartProps> = ({
             .style('font-size', '18px') // make the axis labels bigger
             .call(d3.axisLeft(yScale).tickSize(0).tickPadding(5))
 
-        // color palette
+        // Determine color patterns (solid vs diagonal) based on number of series
+        // if len(typeKeys) is odd then pattern1/pattern0
+        // else if len(typeKeys) is even then pattern0/pattern1
+        const colorPatterns = typeKeys.length % 2 === 0 ? ['url(#pattern0)', 'url(#pattern1)'] : ['url(#pattern1)', 'url(#pattern0)']
         // @ts-ignore
-        const color = d3.scaleOrdinal().domain(typeKeys).range(['url(#pattern0)', 'url(#pattern1)'])
+        const color = d3.scaleOrdinal().domain(typeKeys).range(colorPatterns)
 
         // @ts-ignore
         const color_fnc = (d) => {


### PR DESCRIPTION
This PR is fixing reported by when for some months storage pattern is swapped with compute as reported here:

https://centrepopgen.slack.com/archives/C05TVRB8N86/p1757998282163549

Issue is related to number of projects displayed, odd vs even particularly.