### PR TITLE
SET-716 add ancestry information to processing time report

### DIFF
--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -154,6 +154,7 @@ function ProcessingTimesByAncestry(props: { project: string }) {
                                 ELSE '72+ hours'
                             END AS duration,
                         from durations
+                        where duration is not null
                         group by 2, 3 order by 2, 3
                     `,
                 },
@@ -422,7 +423,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     strftime(collection_time, '%Y-%m-%d %H:%M:%S') as collection_time,
                                     strftime(process_end_time, '%Y-%m-%d %H:%M:%S') as process_end_time,
                                     duration,
-                                    ancestry
+                                    array_to_string(ancestry, ', ')
                                 from durations
                                 order by duration desc nulls last
                             `,


### PR DESCRIPTION
It would be useful to include a new Ancestry column in the table that appears on the OurDNA report page. A plot has also been included to visualise differences in processing times between major ancestries.