### PR TITLE
SET-553 R1 display average per sample storage costs each month

### DIFF
--- a/api/routes/billing.py
+++ b/api/routes/billing.py
@@ -18,10 +18,10 @@ from db.python.layers.billing import BillingLayer
 from models.models import (
     AnalysisCostRecord,
     BillingCostBudgetRecord,
+    BillingRunningCostQueryModel,
     BillingSampleQueryModel,
     BillingTotalCostQueryModel,
     BillingTotalCostRecord,
-    BillingRunningCostQueryModel,
 )
 
 router = APIRouter(prefix='/billing', tags=['billing'])
@@ -324,6 +324,7 @@ async def get_cost_by_batch_id(
 async def get_total_cost(
     query: BillingTotalCostQueryModel,
     author: str = get_author,
+    connection: Connection = get_projectless_db_connection,
 ) -> list[BillingTotalCostRecord]:
     """Get Total cost of selected fields for requested time interval
 
@@ -520,7 +521,7 @@ async def get_total_cost(
 
     """
     billing_layer = _get_billing_layer_from(author)
-    records = await billing_layer.get_total_cost(query)
+    records = await billing_layer.get_total_cost(query, connection)
     return [BillingTotalCostRecord.from_json(record) for record in records]
 
 

--- a/db/python/layers/billing.py
+++ b/db/python/layers/billing.py
@@ -12,9 +12,9 @@ from models.models import (
     AnalysisCostRecord,
     BillingColumn,
     BillingCostBudgetRecord,
+    BillingRunningCostQueryModel,
     BillingSampleQueryModel,
     BillingTotalCostQueryModel,
-    BillingRunningCostQueryModel,
 )
 
 
@@ -187,12 +187,13 @@ class BillingLayer(BqBaseLayer):
     async def get_total_cost(
         self,
         query: BillingTotalCostQueryModel,
+        connection: Connection | None = None,
     ) -> list[dict] | None:
         """
         Get Total cost of selected fields for requested time interval
         """
         billing_table = self.table_factory(query.source, query.fields, query.filters)
-        return await billing_table.get_total_cost(query)
+        return await billing_table.get_total_cost(query, connection)
 
     async def get_running_cost(
         self,

--- a/db/python/layers/billing.py
+++ b/db/python/layers/billing.py
@@ -194,9 +194,10 @@ class BillingLayer(BqBaseLayer):
         """
         billing_table = self.table_factory(query.source, query.fields, query.filters)
         result = await billing_table.get_total_cost(query)
-        # if include average sample cost is requested, we need to use the extended table
+
+        # if include average sample cost is requested, we need to append that information from sample history
         if query.include_average_sample_cost:
-            # append 'average_sample_cost' to cost_category if cost_category and topic is present in the query.fields
+            # append 'average_sample_cost'
             result = await billing_table.append_sample_cost(connection, result)
 
         return result

--- a/db/python/layers/billing.py
+++ b/db/python/layers/billing.py
@@ -193,7 +193,13 @@ class BillingLayer(BqBaseLayer):
         Get Total cost of selected fields for requested time interval
         """
         billing_table = self.table_factory(query.source, query.fields, query.filters)
-        return await billing_table.get_total_cost(query, connection)
+        result = await billing_table.get_total_cost(query)
+        # if include average sample cost is requested, we need to use the extended table
+        if query.include_average_sample_cost:
+            # append 'average_sample_cost' to cost_category if cost_category and topic is present in the query.fields
+            result = await billing_table.append_sample_cost(connection, result)
+
+        return result
 
     async def get_running_cost(
         self,

--- a/db/python/tables/bq/billing_base.py
+++ b/db/python/tables/bq/billing_base.py
@@ -581,7 +581,7 @@ class BillingBaseTable(BqDbBase):
 
     async def _get_samples_per_project(self, connection: Connection) -> dict[str, int]:
         """
-        Get number of samples per metamist project, where projects is list of topics
+        Get number of samples per metamist project, map project to dataset/topic
         """
         _query = """
             SELECT s.project, COUNT(DISTINCT s.id) as samples
@@ -593,6 +593,7 @@ class BillingBaseTable(BqDbBase):
             _query,
         )
         projects = {row.project: row.samples for row in rows}
+
         # convert project_id to project dataset/topic (GCP project names)
         project_samples_cnt: dict[str, int] = {}
         for project_id in projects.keys():
@@ -606,7 +607,7 @@ class BillingBaseTable(BqDbBase):
     ) -> list[dict] | None:
         """
         For each topic in results, calculate number of samples per metamist project
-        and divide the cost by number of samples to get average sample cost
+        and divide the cost by number of samples to get average sample storage cost
         """
         if not connection or not results:
             return results

--- a/models/models/billing.py
+++ b/models/models/billing.py
@@ -220,6 +220,9 @@ class BillingTotalCostQueryModel(SMBase):
     # optional, show the min cost, e.g. 0.01, if not set, will show all
     min_cost: float | None = None
 
+    # optional, show average sample cost if True
+    include_average_sample_cost: bool = False
+
     def __hash__(self):
         """Create hash for this object to use in caching"""
         return hash(self.model_dump_json())

--- a/test/test_layers_billing.py
+++ b/test/test_layers_billing.py
@@ -1,7 +1,5 @@
 # pylint: disable=protected-access
 import datetime
-from test.testbase import run_as_sync
-from test.testbqbase import BqTest
 from unittest import mock
 
 import google.cloud.bigquery as bq
@@ -9,6 +7,8 @@ import google.cloud.bigquery as bq
 from db.python.layers.billing import BillingLayer
 from models.enums import BillingSource
 from models.models import BillingColumn, BillingTotalCostQueryModel
+from test.testbase import run_as_sync
+from test.testbqbase import BqTest
 
 
 class TestBillingLayer(BqTest):
@@ -311,7 +311,7 @@ class TestBillingLayer(BqTest):
         query = BillingTotalCostQueryModel(fields=[], start_date='', end_date='')
 
         with self.assertRaises(ValueError) as context:
-            await layer.get_total_cost(query)
+            await layer.get_total_cost(query, connection=None)
 
         self.assertTrue('Date and Fields are required' in str(context.exception))
 
@@ -319,7 +319,7 @@ class TestBillingLayer(BqTest):
         query = BillingTotalCostQueryModel(
             fields=[BillingColumn.TOPIC], start_date='2024-01-01', end_date='2024-01-03'
         )
-        records = await layer.get_total_cost(query)
+        records = await layer.get_total_cost(query, connection=None)
         self.assertEqual([], records)
 
         # get_total_cost with mockup data is tested in test/test_bq_billing_base.py

--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -29,6 +29,7 @@ import FieldSelector from './components/FieldSelector'
 enum CloudSpendCategory {
     STORAGE_COST = 'Storage Cost',
     COMPUTE_COST = 'Compute Cost',
+    SAMPLE_COST = 'Avg. Sample Storage Cost (Est.)',
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any  -- too many anys in the file to fix right now but would be good to sort out when we can */
@@ -100,6 +101,10 @@ const BillingCostByTime: React.FunctionComponent = () => {
     const convertCostCategory = (costCategory: string | null | undefined) => {
         if (costCategory?.startsWith('Cloud Storage')) {
             return CloudSpendCategory.STORAGE_COST
+        }
+        // if costCategory is equal to 'Average Sample Storage Cost', then return SAMPLE_COST
+        if (costCategory === 'Average Sample Storage Cost') {
+            return CloudSpendCategory.SAMPLE_COST
         }
         return CloudSpendCategory.COMPUTE_COST
     }
@@ -184,6 +189,10 @@ const BillingCostByTime: React.FunctionComponent = () => {
                     Object.values(CloudSpendCategory).forEach((category) => {
                         // Sum costs across all regular topics for this month/category
                         let totalCost = 0
+                        // if cost_category is SAMPLE_COST, then skip it
+                        if (category === CloudSpendCategory.SAMPLE_COST) {
+                            return
+                        }
                         Object.keys(recTotals).forEach((topic) => {
                             if (topic !== allTopicsKey && recTotals[topic][month]?.[category]) {
                                 totalCost += recTotals[topic][month][category]
@@ -386,6 +395,16 @@ const BillingCostByTime: React.FunctionComponent = () => {
                 }),
             ]
             matrix.push(storageRow)
+
+            const sampleCostRow: [string, string, ...string[]] = [
+                topic,
+                CloudSpendCategory.SAMPLE_COST.toString(),
+                ...months.map((m) => {
+                    const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_COST]
+                    return val === undefined ? '' : val.toFixed(2)
+                }),
+            ]
+            matrix.push(sampleCostRow)
         })
 
         exportTable(

--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -251,6 +251,7 @@ const BillingCostByTime: React.FunctionComponent = () => {
                     source: BillingSource.Aggregate,
                     time_periods: BillingTimePeriods.InvoiceMonth,
                     filters: queryFilters,
+                    include_average_sample_cost: true,
                 })
             }, 1000),
         [getData]

--- a/web/src/pages/billing/components/BillingCostByMonthTable.tsx
+++ b/web/src/pages/billing/components/BillingCostByMonthTable.tsx
@@ -53,7 +53,7 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
             </div>
         )
     }
-    const compTypes = ['Compute Cost', 'Storage Cost']
+    const compTypes = ['Compute Cost', 'Storage Cost', 'Avg. Sample Storage Cost (Est.)']
 
     // Get all topics in the order they were provided
     const getAllTopics = () => {
@@ -66,6 +66,8 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
         return allTopics.map((key) => (
             <>
                 {compTypes.map((compType, index) => (
+                    // if All Topics, skip the Average Sample Cost row
+                    key === 'All Topics' && compType === 'Avg. Sample Storage Cost (Est.)' ? null : (
                     <SUITable.Row key={`${key}-${index}-row`}>
                         <SUITable.Cell key={`${key}-${index}-topic`}>
                             {index === 0 && <b>{key}</b>}
@@ -79,7 +81,7 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
                             </SUITable.Cell>
                         ))}
                     </SUITable.Row>
-                ))}
+                )))}
             </>
         ))
     }

--- a/web/src/pages/billing/components/BillingCostByMonthTable.tsx
+++ b/web/src/pages/billing/components/BillingCostByMonthTable.tsx
@@ -65,23 +65,27 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
 
         return allTopics.map((key) => (
             <>
-                {compTypes.map((compType, index) => (
+                {compTypes.map((compType, index) =>
                     // if All Topics, skip the Average Sample Cost row
-                    key === 'All Topics' && compType === 'Avg. Sample Storage Cost (Est.)' ? null : (
-                    <SUITable.Row key={`${key}-${index}-row`}>
-                        <SUITable.Cell key={`${key}-${index}-topic`}>
-                            {index === 0 && <b>{key}</b>}
-                        </SUITable.Cell>
-                        <SUITable.Cell key={`${key}-${index}-compType`}>{compType}</SUITable.Cell>
-                        {months.map((month) => (
-                            <SUITable.Cell key={`${key}-${index}-${month}`}>
-                                {data[key] && data[key][month] && data[key][month][compType]
-                                    ? formatMoney(data[key][month][compType])
-                                    : null}
+                    key === 'All Topics' &&
+                    compType === 'Avg. Sample Storage Cost (Est.)' ? null : (
+                        <SUITable.Row key={`${key}-${index}-row`}>
+                            <SUITable.Cell key={`${key}-${index}-topic`}>
+                                {index === 0 && <b>{key}</b>}
                             </SUITable.Cell>
-                        ))}
-                    </SUITable.Row>
-                )))}
+                            <SUITable.Cell key={`${key}-${index}-compType`}>
+                                {compType}
+                            </SUITable.Cell>
+                            {months.map((month) => (
+                                <SUITable.Cell key={`${key}-${index}-${month}`}>
+                                    {data[key] && data[key][month] && data[key][month][compType]
+                                        ? formatMoney(data[key][month][compType])
+                                        : null}
+                                </SUITable.Cell>
+                            ))}
+                        </SUITable.Row>
+                    )
+                )}
             </>
         ))
     }


### PR DESCRIPTION
This PR adds new category cost (Avg Sample Storage Cost) to Billing Cost By Month report.
It is using simple logic:
[Avg Sample Storage Cost] = [Cloud Storage] / [No of samples]
where [No of samples] is calculated using audit log information and it is accumulated over the months.
 
Both Backend and Frontend have been updated to show the new row.
First row in the report (All Topics) does not include this category as it is not relevant, e.g. some topics do not have samples.
 