### PR TITLE
Replace some usages of deprecated functions

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -1617,5 +1617,5 @@ schema = strawberry.Schema(
     query=Query, mutation=Mutation, extensions=[QueryDepthLimiter(max_depth=10)]
 )
 MetamistGraphQLRouter: GraphQLRouter = GraphQLRouter(
-    schema, graphiql=True, context_getter=get_context
+    schema, graphql_ide='graphiql', context_getter=get_context
 )

--- a/models/models/output_file.py
+++ b/models/models/output_file.py
@@ -265,7 +265,7 @@ class OutputFileInternal(SMBase):
             # If the file variable is a tuple, we assume it is a tuple of (file_obj, json_structure)
             if isinstance(file, tuple):
                 file_obj, json_structure = file
-                file_obj = file_obj.dict()
+                file_obj = file_obj.model_dump()
                 fields = OutputFileInternal.model_fields.keys()  # type:ignore[attr-defined]
 
                 # Populate the file_root dictionary with the fields from the file_obj.


### PR DESCRIPTION
We require `strawberry-graphql[fastapi]==0.268.1`, so it's safe to use [`graphql_ide`, introduced in 0.213.0](https://strawberry.rocks/docs/breaking-changes/0.213.0).

Follow PR #888 in using pydantic's `model_dump()`.