### PR TITLE
Consolidate deploy workflow into test

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -1,0 +1,124 @@
+name: Deploy Dev
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  deploy:
+    name: Deploy Dev
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      SM_DOCKER: australia-southeast1-docker.pkg.dev/sample-metadata/images/server:${{ github.sha }}
+    defaults:
+      run:
+        shell: bash -eo pipefail -l {0}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - id: "google-cloud-auth"
+        name: "Authenticate to Google Cloud"
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: "projects/774248915715/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          service_account: "sample-metadata-deploy@sample-metadata.iam.gserviceaccount.com"
+
+      - id: "google-cloud-sdk-setup"
+        name: "Set up Cloud SDK"
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: "gcloud docker auth"
+        run: |
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin" # See 'Supported distributions' for available options
+          java-version: "17"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e #v6.8.0
+        with:
+          activate-environment: true
+          enable-cache: false
+          version: 0.8.22 #uv version
+
+      - name: Setup build env
+        run: uv sync
+
+      - name: prepare-deployment
+        run: |
+          echo DEPLOYMENT_TYPE=dev >> $GITHUB_ENV
+          echo SM_ENVIRONMENT=development >> $GITHUB_ENV
+          uv run bump-my-version bump patch \
+            --no-commit --allow-dirty \
+            --new-version $(cat deploy/python/version.txt).dev0+$(echo $(git rev-parse HEAD) | cut -c1-7)
+
+      - name: "build deployable API"
+        run: |
+          uv run regenerate_api.py
+          ls -lGh packages/metamist/src/metamist/
+
+        # also copies build artifacts to api/public
+      - name: "build web front-end"
+        run: |
+          set -eo pipefail
+          pushd web
+          # installs package-lock, not what it thinks it should be
+          npm ci
+          npm run build
+          popd
+
+      - name: "build image"
+        run: |
+          docker build \
+            --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
+            --tag $SM_DOCKER \
+            -f deploy/api/Dockerfile \
+            .
+
+      - name: Build python package
+        run: |
+          pushd packages/metamist
+          uv build --sdist --out-dir dist
+          popd
+
+      - name: Smoke test python package
+        run: |
+          # There should only be one tarball here but a loop means
+          # we don't need to work out what the filename ended up being
+          for tarball in packages/metamist/dist/*.tar.gz; do
+            echo "Testing package dist $tarball"
+            uv run \
+              --with "$tarball" \
+              --no-project \
+              --isolated \
+              -- python -c "import metamist;"
+          done
+
+      - name: "push server image"
+        run: |
+          docker push $SM_DOCKER
+
+      - name: "deploy to Cloud Run"
+        run: |
+          gcloud run deploy \
+            sample-metadata-api-dev --image $SM_DOCKER \
+            --region australia-southeast1 --no-allow-unauthenticated \
+            --platform managed

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,11 +1,9 @@
-name: Deploy
+name: Deploy Prod
 on:
-  # Building on manual dispatch, and pushes to dev / main. But restricting
-  workflow_dispatch:
   push:
     branches:
       - main
-      - dev
+  workflow_dispatch:
 
 permissions: {}
 
@@ -18,7 +16,7 @@ jobs:
       SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
   deploy:
-    name: Deploy
+    name: Deploy Prod
     runs-on: ubuntu-latest
     needs: unittests
     environment: production
@@ -29,7 +27,6 @@ jobs:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      # used for generating API
       SM_DOCKER: australia-southeast1-docker.pkg.dev/sample-metadata/images/server:${{ github.sha }}
     defaults:
       run:
@@ -75,17 +72,8 @@ jobs:
 
       - name: prepare-deployment
         run: |
-          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-            echo DEPLOYMENT_TYPE=prod >> $GITHUB_ENV
-            echo SM_ENVIRONMENT=production >> $GITHUB_ENV
-          else
-            echo DEPLOYMENT_TYPE=dev >> $GITHUB_ENV
-            echo SM_ENVIRONMENT=development >> $GITHUB_ENV
-            # add
-            uv run bump-my-version bump patch \
-              --no-commit --allow-dirty \
-              --new-version $(cat deploy/python/version.txt).dev0+$(echo $(git rev-parse HEAD) | cut -c1-7)
-          fi
+          echo DEPLOYMENT_TYPE=prod >> $GITHUB_ENV
+          echo SM_ENVIRONMENT=production >> $GITHUB_ENV
 
       - name: "build deployable API"
         run: |
@@ -135,18 +123,12 @@ jobs:
 
       - name: "deploy to Cloud Run"
         run: |
-          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-            gcloud_deploy_name=sample-metadata-api
-          else
-            gcloud_deploy_name=sample-metadata-api-dev
-          fi
           gcloud run deploy \
-            $gcloud_deploy_name --image $SM_DOCKER \
+            sample-metadata-api --image $SM_DOCKER \
             --region australia-southeast1 --no-allow-unauthenticated \
             --platform managed
 
       - name: Publish package
-        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/metamist/dist

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Test
 on:
   push:
+    branches-ignore:
+      - main
   workflow_call:
     secrets:
       CODECOV_TOKEN:
@@ -9,6 +11,7 @@ on:
         required: true
       SONAR_HOST_URL:
         required: true
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
## Description

Separates test and deploy into independent workflow files with different behavior per branch:

dev: Deploy runs concurrently with tests (faster feedback loop)
main: Deploy is gated on tests passing via workflow_call (safe prod deploys)

## Changes

`test.yaml`: Now excludes main from its push trigger (`branches-ignore: [main]`), since tests on main run via `deploy-prod.yaml`'s `workflow_call`. 

`deploy-dev.yaml` (new): Triggers on push to dev, deploys immediately without waiting for tests.

`deploy-prod.yaml` (new): Triggers on push to main, calls `test.yaml` via `workflow_call` and only deploys if tests pass. 

`deploy.yaml` (deleted): Replaced by the two branch-specific workflows above.

I was originally trying to use `workflow_run` but that always reads the workflow file from the repo's default branch (dev), meaning changes to the prod deploy workflow would take effect via dev rather than main. Using `workflow_call` avoids this and the workflow file is always read from the branch being pushed to.