### PR TITLE
Add transaction helper to remove boilerplate for nested transactions

### DIFF
--- a/db/python/connect.py
+++ b/db/python/connect.py
@@ -7,8 +7,10 @@ import json
 import logging
 import os
 from collections.abc import Iterable
+from contextlib import asynccontextmanager
 
 from psycopg import AsyncConnection
+from psycopg.pq import TransactionStatus
 from psycopg.rows import DictRow, dict_row
 from psycopg.types.enum import EnumInfo, register_enum
 from psycopg_pool import AsyncConnectionPool
@@ -17,6 +19,7 @@ from api.settings import DB_POOL_MAX_SIZE, DB_POOL_MIN_SIZE
 from db.python.tables.project import ProjectPermissionsTable
 from db.python.utils import (
     InternalError,
+    NoOpAenter,
     NoProjectAccess,
     NotFoundError,
     ProjectDoesNotExist,
@@ -82,6 +85,24 @@ class Connection:
     def project_id(self):
         """Safely get the project id from the project model attached to the connection"""
         return self.project.id if self.project is not None else None
+
+    @asynccontextmanager
+    async def transaction(self):
+        """
+        Async context manager to open a transaction if there isn't already one open
+
+        This helps avoid us creating a bunch of savepoints with nested transactions.
+        We rarely, if ever, need to partially roll back a transaction so savepoints
+        are an unnecessary performance hit in most cases.
+
+        @see https://about.gitlab.com/blog/why-we-spent-the-last-month-eliminating-postgresql-subtransactions/
+        """
+        conn = self.pg_connection
+        in_transaction = conn.info.transaction_status == TransactionStatus.INTRANS
+
+        with_function = conn.transaction if not in_transaction else NoOpAenter
+        async with with_function():
+            yield
 
     def all_projects(self):
         """Return all projects that the current user has access to"""

--- a/db/python/layers/assay.py
+++ b/db/python/layers/assay.py
@@ -1,9 +1,6 @@
-from psycopg.pq import TransactionStatus
-
 from db.python.layers.base import BaseLayer, Connection
 from db.python.tables.assay import AssayFilter, AssayTable
 from db.python.tables.sample import SampleTable
-from db.python.utils import NoOpAenter
 from models.models.assay import AssayInternal, AssayUpsertInternal
 from models.models.project import (
     FullWriteAccessRoles,
@@ -132,12 +129,7 @@ class AssayLayer(BaseLayer):
             project_ids, allowed_roles=FullWriteAccessRoles
         )
 
-        conn = self.connection.pg_connection
-        in_transaction = conn.info.transaction_status == TransactionStatus.INTRANS
-
-        with_function = conn.transaction if not in_transaction else NoOpAenter
-
-        async with with_function():
+        async with self.connection.transaction():
             for a in assays:
                 await self.upsert_assay(a)
 

--- a/db/python/tables/assay.py
+++ b/db/python/tables/assay.py
@@ -5,12 +5,11 @@ from string.templatelib import Template
 from typing import Any, NamedTuple
 
 from psycopg import sql
-from psycopg.pq import TransactionStatus
 from psycopg.types.json import Jsonb
 
 from db.python.filters import GenericFilter, GenericFilterModel, GenericMetaFilter
 from db.python.tables.base import DbBase
-from db.python.utils import NoOpAenter, NotFoundError
+from db.python.utils import NotFoundError
 from models.models.assay import AssayId, AssayInternal
 from models.models.project import ProjectId
 from models.models.sequencing_group import SequencingGroupInternalId
@@ -294,11 +293,8 @@ class AssayTable(DbBase):
         """
 
         conn = self.connection.pg_connection
-        in_transaction = conn.info.transaction_status == TransactionStatus.INTRANS
 
-        with_function = conn.transaction if not in_transaction else NoOpAenter
-
-        async with with_function():
+        async with self.connection.transaction():
             cur = await conn.execute(
                 _query,
                 {
@@ -357,10 +353,8 @@ class AssayTable(DbBase):
         """Update an assay"""
 
         conn = self.connection.pg_connection
-        in_transaction = conn.info.transaction_status == TransactionStatus.INTRANS
-        with_function = conn.transaction if not in_transaction else NoOpAenter
 
-        async with with_function():
+        async with self.connection.transaction():
             audit_log_id = await self.audit_log_id()
 
             updaters: list[Template] = [t'audit_log_id = {audit_log_id}']


### PR DESCRIPTION
This helper on the connection class allows us to conditionally enter a transaction if not already in one. Psycopg supports nested transactions with postgres savepoints but partial rollbacks is not a feature that we actually need - so in most cases it is fine to just have a single parent transaction. There's a bit of code involved in checking the current transaction status so this wraps that in a method on the connection model to save having to write it each time.