### PR TITLE
temporarily disable mypy type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,26 +45,27 @@ repos:
       - id: ruff-format
 
   # mypy
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
-    hooks:
-      - id: mypy
-        args: [
-            --pretty,
-            --show-error-codes,
-            --no-strict-optional,
-            --ignore-missing-imports,
-            --install-types,
-            --non-interactive,
-            # --show-error-context,
-            --check-untyped-defs,
-            --explicit-package-bases,
-            --disable-error-code,
-            operator,
-          ]
-        additional_dependencies:
-          - strawberry-graphql[fastapi]==0.291.0
-          - types-PyMySQL==1.1.0.1
+  # @TODO re-enable type checking once migration has progressed enough
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.19.1
+  #   hooks:
+  #     - id: mypy
+  #       args: [
+  #           --pretty,
+  #           --show-error-codes,
+  #           --no-strict-optional,
+  #           --ignore-missing-imports,
+  #           --install-types,
+  #           --non-interactive,
+  #           # --show-error-context,
+  #           --check-untyped-defs,
+  #           --explicit-package-bases,
+  #           --disable-error-code,
+  #           operator,
+  #         ]
+  #       additional_dependencies:
+  #         - strawberry-graphql[fastapi]==0.291.0
+  #         - types-PyMySQL==1.1.0.1
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.5.2


### PR DESCRIPTION
this'll enable us to enforce that other  linting checks pass while working on the migration