### PR TITLE
[SET-989] Migrate project insights queries

### DIFF
--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -665,7 +665,6 @@ class ParticipantLayer(BaseLayer):
                 await slayer.upsert_samples(
                     participant.samples,
                     project=project,
-                    open_transaction=False,
                 )
 
             if participant.phenotypes:

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, NamedTuple
 
 from databases.interfaces import Record
+from psycopg import sql
 
 from db.python.enum_tables import SequencingPlatformTable as SeqPlatformTable
 from db.python.enum_tables import SequencingTechnologyTable as SeqTechTable
@@ -642,17 +643,17 @@ class ProjectInsightsDb(DbBase):
             SELECT
                 project,
                 MAX(timestamp_completed) as max_timestamp,
-                meta ->> 'sequencing_type' as sequencing_type
+                LOWER(meta ->> 'sequencing_type') as sequencing_type
             FROM analysis
             WHERE
                 status = 'completed'
                 AND type = 'custom'
                 AND LOWER(meta ->> 'stage') = 'annotatedataset'
                 AND LOWER(meta ->> 'sequencing_type') = ANY({sequencing_types_param})
-            GROUP BY project, meta ->> 'sequencing_type'
+            GROUP BY project, LOWER(meta ->> 'sequencing_type')
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
+        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
         WHERE
             a.type = 'custom'
             AND a.status = 'completed'
@@ -692,16 +693,16 @@ class ProjectInsightsDb(DbBase):
             SELECT
                 project,
                 MAX(timestamp_completed) as max_timestamp,
-                meta ->> 'sequencing_type' as sequencing_type,
-                meta ->> 'stage' as stage
+                LOWER(meta ->> 'sequencing_type') as sequencing_type,
+                LOWER(meta ->> 'stage') as stage
             FROM analysis
             WHERE type = 'es-index'
             AND status = 'completed'
-            GROUP BY project, sequencing_type, stage
+            GROUP BY project, LOWER(meta ->> 'sequencing_type'), LOWER(meta ->> 'stage')
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
-        AND LOWER(a.meta ->> 'stage') = LOWER(max_timestamps.stage)
+        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
+        AND LOWER(a.meta ->> 'stage') = max_timestamps.stage
         WHERE
             a.project = ANY({project_ids})
             AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param});
@@ -763,6 +764,7 @@ class ProjectInsightsDb(DbBase):
             fp.participant_id,
             sg.id;
         """
+
         _query_results = await (
             await self.connection.pg_connection.execute(_query)
         ).fetchall()
@@ -807,15 +809,15 @@ class ProjectInsightsDb(DbBase):
             a.meta -> 'outliers_detected' as outliers_detected,
             a.meta -> 'outlier_loci' as outlier_loci
         FROM analysis a
-        LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
+        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
         LEFT JOIN output_file of on of.id = ao.file_id
-        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
         INNER JOIN (
             SELECT
                 asg.sequencing_group_id,
                 MAX(a.id) as max_analysis_id
             FROM analysis a
-            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
             WHERE type = 'web'
             AND status = 'completed'
             AND project = ANY({project_ids})

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -929,7 +929,7 @@ class ProjectInsightsDb(DbBase):
         self, project_names: list[str], sequencing_types: list[str]
     ):
         """Combines the results of the above queries into a response"""
-        projects = self._connection.get_and_check_access_to_projects_for_names(
+        projects = self.connection.get_and_check_access_to_projects_for_names(
             project_names=project_names, allowed_roles=ReadAccessRoles
         )
         project_ids: list[ProjectId] = [project.id for project in projects]
@@ -971,7 +971,7 @@ class ProjectInsightsDb(DbBase):
             + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
         )
 
-        sequencing_technologies = await SeqTechTable(self._connection).get()
+        sequencing_technologies = await SeqTechTable(self.connection).get()
         # Get all possible combinations of the projects, sequencing types, and sequencing technologies
         combinations = itertools.product(
             projects, sequencing_types, sequencing_technologies
@@ -1030,7 +1030,7 @@ class ProjectInsightsDb(DbBase):
         self, project_names: list[str], sequencing_types: list[str]
     ):
         """Combines the results of the queries above into a response"""
-        projects = self._connection.get_and_check_access_to_projects_for_names(
+        projects = self.connection.get_and_check_access_to_projects_for_names(
             project_names=project_names, allowed_roles=ReadAccessRoles
         )
         project_ids: list[ProjectId] = [project.id for project in projects]
@@ -1062,8 +1062,8 @@ class ProjectInsightsDb(DbBase):
             + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
         )
 
-        sequencing_platforms = await SeqPlatformTable(self._connection).get()
-        sequencing_technologies = await SeqTechTable(self._connection).get()
+        sequencing_platforms = await SeqPlatformTable(self.connection).get()
+        sequencing_technologies = await SeqTechTable(self.connection).get()
 
         # Get all possible combinations of the projects, sequencing types, platforms, and technologies
         combinations = itertools.product(

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -1,7 +1,6 @@
 # mypy: disable-error-code="attr-defined,arg-type,index,call-overload"
 import asyncio
 import itertools
-import json
 from datetime import datetime
 from typing import Any, NamedTuple
 
@@ -253,9 +252,7 @@ class ProjectInsightsDb(DbBase):
                 ),
                 'outliers_detected': stripy_report.outliers_detected,
                 'outlier_loci': (
-                    json.loads(stripy_report.outlier_loci)
-                    if stripy_report.outlier_loci
-                    else None
+                    stripy_report.outlier_loci if stripy_report.outlier_loci else None
                 ),
                 'timestamp_completed': stripy_report.timestamp_completed.isoformat()
                 if stripy_report.timestamp_completed

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -152,7 +152,7 @@ class ProjectInsightsDb(DbBase):
         return external_ids_value
 
     def parse_project_seqtype_technology_keyed_rows(
-        self, rows: list[Record], value_field: str
+        self, rows: list[dict[Any, Any]], value_field: str
     ) -> dict[ProjectSeqTypeTechnologyKey, Any]:
         """
         Parse rows that are keyed by project, sequencing type, and sequencing technology
@@ -167,13 +167,7 @@ class ProjectInsightsDb(DbBase):
                 row['sequencing_type'],
                 row['sequencing_technology'],
             )
-            if value_field == 'sequencing_group_ids':
-                parsed_rows[key] = [int(sgid) for sgid in row[value_field].split(',')]
-            else:
-                try:
-                    parsed_rows[key] = row[value_field]
-                except KeyError:
-                    parsed_rows[key] = None
+            parsed_rows[key] = row.get(value_field)
         return parsed_rows
 
     async def _get_sequencing_groups_by_analysis_ids(
@@ -182,26 +176,25 @@ class ProjectInsightsDb(DbBase):
         """Get sequencing groups for a list of analysis ids"""
         if not analysis_ids:
             return {}
-        _query = """
-SELECT
-    analysis_id,
-    GROUP_CONCAT(sequencing_group_id) as sequencing_group_ids
-FROM analysis_sequencing_group
-WHERE analysis_id IN :analysis_ids
-GROUP BY analysis_id;
+        _query = t"""
+        SELECT
+            analysis_id,
+            ARRAY_AGG(sequencing_group_id) as sequencing_group_ids
+        FROM analysis_sequencing_group
+        WHERE analysis_id = ANY({analysis_ids})
+        GROUP BY analysis_id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'analysis_ids': analysis_ids,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
         sequencing_groups_by_analysis_id: dict[
             AnalysisId, list[SequencingGroupInternalId]
         ] = {}
         for row in _query_results:
-            sequencing_groups_by_analysis_id[row['analysis_id']] = [
-                int(sgid) for sgid in row['sequencing_group_ids'].split(',')
+            sequencing_groups_by_analysis_id[row['analysis_id']] = row[
+                'sequencing_group_ids'
             ]
 
         return sequencing_groups_by_analysis_id
@@ -410,33 +403,29 @@ GROUP BY analysis_id;
     async def _total_families_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    f.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT f.id) as num_families
-FROM
-    family f
-    LEFT JOIN family_participant fp ON f.id = fp.family_id
-    LEFT JOIN sample s ON fp.participant_id = s.participant_id
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    f.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    f.project,
-    sg.type,
-    sg.technology;
+        _query = t"""
+        SELECT
+            f.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT f.id) as num_families
+        FROM
+            family f
+            LEFT JOIN family_participant fp ON f.id = fp.family_id
+            LEFT JOIN sample s ON fp.participant_id = s.participant_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            f.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            f.project,
+            sg.type,
+            sg.technology;
         """
 
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_families'
         )
@@ -444,31 +433,29 @@ GROUP BY
     async def _total_participants_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    p.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT p.id) as num_participants
-FROM
-    participant p
-    LEFT JOIN sample s ON p.id = s.participant_id
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    p.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    p.project,
-    sg.type,
-    sg.technology;
+
+        _query = t"""
+        SELECT
+            p.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT p.id) as num_participants
+        FROM
+            participant p
+            LEFT JOIN sample s ON p.id = s.participant_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            p.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            p.project,
+            sg.type,
+            sg.technology;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_participants'
         )
@@ -476,30 +463,29 @@ GROUP BY
     async def _total_samples_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    s.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT s.id) as num_samples
-FROM
-    sample s
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    s.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    s.project,
-    sg.type,
-    sg.technology;
+
+        _query = t"""
+        SELECT
+            s.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT s.id) as num_samples
+        FROM
+            sample s
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            s.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            s.project,
+            sg.type,
+            sg.technology;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_samples'
         )
@@ -507,30 +493,27 @@ GROUP BY
     async def _total_sequencing_groups_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    s.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT sg.id) as num_sgs
-FROM
-    sequencing_group sg
-    LEFT JOIN sample s on s.id = sg.sample_id
-WHERE
-    s.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    s.project,
-    sg.type,
-    sg.technology;
+        _query = t"""
+        SELECT
+            s.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT sg.id) as num_sgs
+        FROM
+            sequencing_group sg
+            LEFT JOIN sample s on s.id = sg.sample_id
+        WHERE
+            s.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            s.project,
+            sg.type,
+            sg.technology;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_sgs'
         )
@@ -540,34 +523,32 @@ GROUP BY
         project_ids: list[ProjectId],
         sequencing_types: list[SequencingType],
     ) -> dict[ProjectSeqTypeTechnologyKey, list[SequencingGroupInternalId]]:
-        _query = """
-SELECT
-    a.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    GROUP_CONCAT(DISTINCT asg.sequencing_group_id) as sequencing_group_ids
-FROM
-    analysis a
-    LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-    LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
-WHERE
-    a.project IN :projects
-    AND sg.type IN :sequencing_types
-    AND a.type = 'CRAM'
-    AND a.status = 'COMPLETED'
-GROUP BY
-    a.project,
-    sg.type,
-    sg.technology;
+        # TODO check CRAM or cram
+        _query = t"""
+        SELECT
+            a.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            ARRAY_AGG(DISTINCT asg.sequencing_group_id) as sequencing_group_ids
+        FROM
+            analysis a
+            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
+        WHERE
+            a.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+            AND lower(a.type) = 'cram'
+            AND a.status = 'completed'
+        GROUP BY
+            a.project,
+            sg.type,
+            sg.technology;
         """
 
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'sequencing_group_ids'
         )
@@ -577,46 +558,43 @@ GROUP BY
     ) -> dict[
         ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
     ]:
-        _query = """
-SELECT
-    a.project,
-    a.id as analysis_id,
-    sg.id as sequencing_group_id,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COALESCE(a.output, ao.output, of.path) as output,
-    a.timestamp_completed
-FROM
-    analysis a
-    LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-    LEFT JOIN analysis_outputs ao ON a.id = ao.analysis_id
-    LEFT JOIN output_file of ON ao.file_id = of.id
-    LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
-    INNER JOIN (
+        _query = t"""
         SELECT
-            asg.sequencing_group_id,
-            MAX(a.timestamp_completed) as max_timestamp
-        FROM analysis a
-        INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-        WHERE a.type='CRAM'
-        AND a.status='COMPLETED'
-        AND a.project IN :projects
-        GROUP BY asg.sequencing_group_id
-    ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
-    AND a.timestamp_completed = max_timestamps.max_timestamp
-WHERE
-    a.project IN :projects
-    AND sg.type IN :sequencing_types
-    AND a.type = 'CRAM'
-    AND a.status = 'COMPLETED';
+            a.project,
+            a.id as analysis_id,
+            sg.id as sequencing_group_id,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COALESCE(a.output, ao.output, of.path) as output,
+            a.timestamp_completed
+        FROM
+            analysis a
+            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+            LEFT JOIN analysis_outputs ao ON a.id = ao.analysis_id
+            LEFT JOIN output_file of ON ao.file_id = of.id
+            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
+            INNER JOIN (
+                SELECT
+                    asg.sequencing_group_id,
+                    MAX(a.timestamp_completed) as max_timestamp
+                FROM analysis a
+                INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+                WHERE LOWER(a.type) = 'cram'
+                AND a.status='completed'
+                AND a.project = ANY({project_ids})
+                GROUP BY asg.sequencing_group_id
+            ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
+            AND a.timestamp_completed = max_timestamps.max_timestamp
+        WHERE
+            a.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+            AND a.type = 'CRAM'
+            AND a.status = 'completed';
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
 
         cram_timestamps_by_project_id_and_seq_fields: dict[
             ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
@@ -641,44 +619,41 @@ WHERE
     async def _latest_annotate_dataset_by_project_id_and_seq_type(
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeKey, AnalysisRow]:
-        _query = """
-SELECT
-    a.project,
-    JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) as sequencing_type,
-    a.id,
-    a.output,
-    a.timestamp_completed
-FROM analysis a
-INNER JOIN (
-    SELECT
-        project,
-        MAX(timestamp_completed) as max_timestamp,
-        JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) as sequencing_type
-    FROM analysis
-    WHERE
-        status = 'COMPLETED'
-        AND type = 'CUSTOM'
-        AND JSON_EXTRACT(meta, '$.stage') = 'AnnotateDataset'
-        AND JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) IN :sequencing_types
-    GROUP BY project, JSON_EXTRACT(meta, '$.sequencing_type')
-) max_timestamps ON a.project = max_timestamps.project
-AND a.timestamp_completed = max_timestamps.max_timestamp
-AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) = max_timestamps.sequencing_type
-WHERE
-    a.type = 'CUSTOM'
-    AND a.status = 'COMPLETED'
-    AND a.project IN :projects
-    AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) IN :sequencing_types
-    AND JSON_EXTRACT(a.meta, '$.stage') = 'AnnotateDataset';
-    -- JSON_UNQUOTE is necessary to compare JSON values with IN operator
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.meta ->> 'sequencing_type' as sequencing_type,
+            a.id,
+            a.output,
+            a.timestamp_completed
+        FROM analysis a
+        INNER JOIN (
+            SELECT
+                project,
+                MAX(timestamp_completed) as max_timestamp,
+                meta ->> 'sequencing_type' as sequencing_type
+            FROM analysis
+            WHERE
+                status = 'completed'
+                AND lower(type) = 'custom'
+                AND meta ->> 'stage' = 'AnnotateDataset'
+                AND meta ->> 'sequencing_type' = ANY({sequencing_types})
+            GROUP BY project, meta ->> 'sequencing_type'
+        ) max_timestamps ON a.project = max_timestamps.project
+        AND a.timestamp_completed = max_timestamps.max_timestamp
+        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
+        WHERE
+            LOWER(a.type) = 'custom'
+            AND a.status = 'completed'
+            AND a.project = ANY({project_ids})
+            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types})
+            AND a.meta ->> 'stage' = 'AnnotateDataset';
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         latest_annotate_dataset_by_project_id_and_seq_type: dict[
             ProjectSeqTypeKey, AnalysisRow
         ] = {}
@@ -692,40 +667,38 @@ WHERE
     async def _latest_es_indices_by_project_id_and_seq_type_and_stage(
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeStageKey, AnalysisRow]:
-        _query = """
-SELECT
-    a.project,
-    JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) as sequencing_type,
-    a.id,
-    JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.stage')) as stage,
-    a.output,
-    a.timestamp_completed
-FROM analysis a
-INNER JOIN (
-    SELECT
-        project,
-        MAX(timestamp_completed) as max_timestamp,
-        JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) as sequencing_type,
-        JSON_UNQUOTE(JSON_EXTRACT(meta, '$.stage')) as stage
-    FROM analysis
-    WHERE type='es-index'
-    AND status='COMPLETED'
-    GROUP BY project, JSON_EXTRACT(meta, '$.sequencing_type'), JSON_EXTRACT(meta, '$.stage')
-) max_timestamps ON a.project = max_timestamps.project
-AND a.timestamp_completed = max_timestamps.max_timestamp
-AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) = max_timestamps.sequencing_type
-AND JSON_EXTRACT(a.meta, '$.stage') = max_timestamps.stage
-WHERE
-    a.project IN :projects
-    AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) in :sequencing_types;
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.meta ->> 'sequencing_type' as sequencing_type,
+            a.id,
+            a.meta ->> 'stage' as stage,
+            a.output,
+            a.timestamp_completed
+        FROM analysis a
+        INNER JOIN (
+            SELECT
+                project,
+                MAX(timestamp_completed) as max_timestamp,
+                meta ->> 'sequencing_type' as sequencing_type,
+                meta ->> 'stage' as stage
+            FROM analysis
+            WHERE LOWER(type) = 'es-index'
+            AND status = 'completed'
+            GROUP BY project, meta ->> 'sequencing_type', meta ->> 'stage'
+        ) max_timestamps ON a.project = max_timestamps.project
+        AND a.timestamp_completed = max_timestamps.max_timestamp
+        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
+        AND a.meta ->> 'stage' = max_timestamps.stage
+        WHERE
+            a.project = ANY({project_ids})
+            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types});
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         latest_es_indices_by_project_id_and_seq_type_and_stage: dict[
             ProjectSeqTypeStageKey, AnalysisRow
         ] = {}
@@ -742,48 +715,45 @@ WHERE
     async def _sequencing_group_details_by_project_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]]:
-        _query = """
-SELECT
-    f.project,
-    sg.type as sequencing_type,
-    sg.platform as sequencing_platform,
-    sg.technology as sequencing_technology,
-    s.type as sample_type,
-    f.id as family_id,
-    fext.external_id as family_external_id,
-    fp.participant_id as participant_id,
-    pext.external_id as participant_external_id,
-    s.id as sample_id,
-    sext.external_id as sample_external_ids,
-    sg.id as sequencing_group_id
-FROM
-    family f
-    LEFT JOIN family_participant fp ON f.id = fp.family_id
-    LEFT JOIN family_external_id fext ON f.id = fext.family_id
-    LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
-    LEFT JOIN sample s ON fp.participant_id = s.participant_id
-    LEFT JOIN sample_external_id sext ON s.id = sext.sample_id
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    f.project IN :projects
-    AND sg.type IN :sequencing_types
-ORDER BY
-    f.project,
-    sg.type,
-    sg.platform,
-    sg.technology,
-    s.type,
-    f.id,
-    fp.participant_id,
-    sg.id;
+
+        _query = t"""
+        SELECT
+            f.project,
+            sg.type as sequencing_type,
+            sg.platform as sequencing_platform,
+            sg.technology as sequencing_technology,
+            s.type as sample_type,
+            f.id as family_id,
+            fext.external_id as family_external_id,
+            fp.participant_id as participant_id,
+            pext.external_id as participant_external_id,
+            s.id as sample_id,
+            sext.external_id as sample_external_ids,
+            sg.id as sequencing_group_id
+        FROM
+            family f
+            LEFT JOIN family_participant fp ON f.id = fp.family_id
+            LEFT JOIN family_external_id fext ON f.id = fext.family_id
+            LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
+            LEFT JOIN sample s ON fp.participant_id = s.participant_id
+            LEFT JOIN sample_external_id sext ON s.id = sext.sample_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            f.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        ORDER BY
+            f.project,
+            sg.type,
+            sg.platform,
+            sg.technology,
+            s.type,
+            f.id,
+            fp.participant_id,
+            sg.id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         sequencing_group_details_by_project_id_and_seq_fields: dict[
             ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]
         ] = {}
@@ -815,38 +785,36 @@ ORDER BY
         self, project_ids: list[ProjectId]
     ) -> dict[ProjectSeqGroupKey, StripyReportRow]:
         """Get stripy web report links"""
-        _query = """
-SELECT
-    a.project,
-    a.id,
-    coalesce(a.output, ao.output, of.path) as output,
-    a.timestamp_completed,
-    asg.sequencing_group_id,
-    JSON_EXTRACT(a.meta, '$.outliers_detected') as outliers_detected,
-    JSON_QUERY(a.meta, '$.outlier_loci') as outlier_loci
-FROM analysis a
-LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
-LEFT JOIN output_file of on of.id = ao.file_id
-LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-INNER JOIN (
-    SELECT
-        asg.sequencing_group_id,
-        MAX(a.id) as max_analysis_id
-    FROM analysis a
-    LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-    WHERE type='web'
-    AND status='COMPLETED'
-    AND project IN :projects
-    AND JSON_EXTRACT(meta, '$.stage') = 'Stripy'
-    GROUP BY asg.sequencing_group_id
-) latest_analysis ON a.id = latest_analysis.max_analysis_id;
+        _query = t"""
+        SELECT
+            a.project,
+            a.id,
+            coalesce(a.output, ao.output, of.path) as output,
+            a.timestamp_completed,
+            asg.sequencing_group_id,
+            a.meta -> 'outliers_detected' as outliers_detected,
+            a.meta -> 'outlier_loci' as outlier_loci
+        FROM analysis a
+        LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
+        LEFT JOIN output_file of on of.id = ao.file_id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+        INNER JOIN (
+            SELECT
+                asg.sequencing_group_id,
+                MAX(a.id) as max_analysis_id
+            FROM analysis a
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+            WHERE LOWER(type) = 'web'
+            AND status = 'completed'
+            AND project = ANY({project_ids})
+            AND LOWER(meta ->> 'stage') = 'stripy'
+            GROUP BY asg.sequencing_group_id
+        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         stripy_reports: dict[ProjectSeqGroupKey, StripyReportRow] = {}
         for row in _query_results:
             key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])
@@ -864,36 +832,35 @@ INNER JOIN (
         self, project_ids: list[ProjectId]
     ) -> dict[ProjectSeqGroupKey, AnalysisRow]:
         """Get mito web report links"""
-        _query = """
-SELECT
-    a.project,
-    a.id,
-    coalesce(a.output, ao.output, of.path) as output,
-    a.timestamp_completed,
-    asg.sequencing_group_id
-FROM analysis a
-LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
-LEFT JOIN output_file of on of.id = ao.file_id
-LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-INNER JOIN (
-    SELECT
-        asg.sequencing_group_id,
-        MAX(a.id) as max_analysis_id
-    FROM analysis a
-    LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-    WHERE type='web'
-    AND status='COMPLETED'
-    AND project IN :projects
-    AND JSON_EXTRACT(meta, '$.stage') = 'MitoReport'
-    GROUP BY asg.sequencing_group_id
-) latest_analysis ON a.id = latest_analysis.max_analysis_id;
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.id,
+            coalesce(a.output, ao.output, out_file.path) as output,
+            a.timestamp_completed,
+            asg.sequencing_group_id
+        FROM analysis a
+        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
+        LEFT JOIN output_file out_file on out_file.id = ao.file_id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+        INNER JOIN (
+            SELECT
+                asg.sequencing_group_id,
+                MAX(a.id) as max_analysis_id
+            FROM analysis a
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+            WHERE LOWER(type) = 'web'
+            AND status = 'completed'
+            AND project = ANY({project_ids})
+            AND LOWER(meta ->> 'stage') = 'mitoreport'
+            GROUP BY asg.sequencing_group_id
+        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         mito_reports: dict[ProjectSeqGroupKey, AnalysisRow] = {}
         for row in _query_results:
             key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -403,6 +403,8 @@ class ProjectInsightsDb(DbBase):
     async def _total_families_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             f.project,
@@ -416,7 +418,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             f.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             f.project,
             sg.type,
@@ -434,6 +436,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             p.project,
@@ -446,7 +449,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             p.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             p.project,
             sg.type,
@@ -464,6 +467,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             s.project,
@@ -475,7 +479,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             s.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             s.project,
             sg.type,
@@ -493,6 +497,8 @@ class ProjectInsightsDb(DbBase):
     async def _total_sequencing_groups_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             s.project,
@@ -504,7 +510,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sample s on s.id = sg.sample_id
         WHERE
             s.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             s.project,
             sg.type,
@@ -523,7 +529,8 @@ class ProjectInsightsDb(DbBase):
         project_ids: list[ProjectId],
         sequencing_types: list[SequencingType],
     ) -> dict[ProjectSeqTypeTechnologyKey, list[SequencingGroupInternalId]]:
-        # TODO check CRAM or cram
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -536,8 +543,8 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
         WHERE
             a.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
-            AND lower(a.type) = 'cram'
+            AND sg.type = ANY({sequencing_types_param})
+            AND a.type = 'cram'
             AND a.status = 'completed'
         GROUP BY
             a.project,
@@ -558,6 +565,8 @@ class ProjectInsightsDb(DbBase):
     ) -> dict[
         ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
     ]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -579,7 +588,7 @@ class ProjectInsightsDb(DbBase):
                     MAX(a.timestamp_completed) as max_timestamp
                 FROM analysis a
                 INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-                WHERE LOWER(a.type) = 'cram'
+                WHERE a.type = 'cram'
                 AND a.status='completed'
                 AND a.project = ANY({project_ids})
                 GROUP BY asg.sequencing_group_id
@@ -587,8 +596,8 @@ class ProjectInsightsDb(DbBase):
             AND a.timestamp_completed = max_timestamps.max_timestamp
         WHERE
             a.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
-            AND a.type = 'CRAM'
+            AND sg.type = ANY({sequencing_types_param})
+            AND a.type = 'cram'
             AND a.status = 'completed';
         """
 
@@ -620,6 +629,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeKey, AnalysisRow]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -636,19 +646,19 @@ class ProjectInsightsDb(DbBase):
             FROM analysis
             WHERE
                 status = 'completed'
-                AND lower(type) = 'custom'
-                AND meta ->> 'stage' = 'AnnotateDataset'
-                AND meta ->> 'sequencing_type' = ANY({sequencing_types})
+                AND type = 'custom'
+                AND LOWER(meta ->> 'stage') = 'annotatedataset'
+                AND LOWER(meta ->> 'sequencing_type') = ANY({sequencing_types_param})
             GROUP BY project, meta ->> 'sequencing_type'
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
+        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
         WHERE
-            LOWER(a.type) = 'custom'
+            a.type = 'custom'
             AND a.status = 'completed'
             AND a.project = ANY({project_ids})
-            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types})
-            AND a.meta ->> 'stage' = 'AnnotateDataset';
+            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param})
+            AND LOWER(a.meta ->> 'stage') = 'annotatedataset';
         """
 
         _query_results = await (
@@ -668,6 +678,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeStageKey, AnalysisRow]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -684,16 +695,16 @@ class ProjectInsightsDb(DbBase):
                 meta ->> 'sequencing_type' as sequencing_type,
                 meta ->> 'stage' as stage
             FROM analysis
-            WHERE LOWER(type) = 'es-index'
+            WHERE type = 'es-index'
             AND status = 'completed'
-            GROUP BY project, meta ->> 'sequencing_type', meta ->> 'stage'
+            GROUP BY project, sequencing_type, stage
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
-        AND a.meta ->> 'stage' = max_timestamps.stage
+        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
+        AND LOWER(a.meta ->> 'stage') = LOWER(max_timestamps.stage)
         WHERE
             a.project = ANY({project_ids})
-            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types});
+            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param});
         """
 
         _query_results = await (
@@ -716,6 +727,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             f.project,
@@ -740,7 +752,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             f.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         ORDER BY
             f.project,
             sg.type,
@@ -804,7 +816,7 @@ class ProjectInsightsDb(DbBase):
                 MAX(a.id) as max_analysis_id
             FROM analysis a
             LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-            WHERE LOWER(type) = 'web'
+            WHERE type = 'web'
             AND status = 'completed'
             AND project = ANY({project_ids})
             AND LOWER(meta ->> 'stage') = 'stripy'
@@ -850,7 +862,7 @@ class ProjectInsightsDb(DbBase):
                 MAX(a.id) as max_analysis_id
             FROM analysis a
             LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
-            WHERE LOWER(type) = 'web'
+            WHERE type = 'web'
             AND status = 'completed'
             AND project = ANY({project_ids})
             AND LOWER(meta ->> 'stage') = 'mitoreport'

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Any, NamedTuple
 
 from databases.interfaces import Record
-from psycopg import sql
 
 from db.python.enum_tables import SequencingPlatformTable as SeqPlatformTable
 from db.python.enum_tables import SequencingTechnologyTable as SeqTechTable

--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -312,7 +312,7 @@ class SequencingGroupLayer(BaseLayer):
                     'Upserting sequencing-groups with assays requires a sample_id to be set for every sequencing-group'
                 )
 
-            await slayer.upsert_assays(assays, open_transaction=False)
+            await slayer.upsert_assays(assays)
 
         to_insert = [sg for sg in sequencing_groups if not sg.id]
         to_update = []

--- a/pytest.toml
+++ b/pytest.toml
@@ -15,7 +15,8 @@ python_files = [
     "test_external_id.py",
     "test_comment.py",
     "test_meta_table.py",
-    "test_enum_tables.py"
+    "test_enum_tables.py",
+    "test_project_insights.py"
 ]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/test/test_project_insights.py
+++ b/test/test_project_insights.py
@@ -1,3 +1,6 @@
+import pytest
+
+from db.python.connect import Connection
 from db.python.layers import (
     AssayLayer,
     ParticipantLayer,
@@ -12,7 +15,6 @@ from models.models import (
     SampleUpsertInternal,
     SequencingGroupUpsertInternal,
 )
-from test.testbase import DbIsolatedTest, run_as_sync
 
 
 default_assay_meta = {
@@ -70,20 +72,22 @@ def get_test_participant():
     )
 
 
-class TestProjectInsights(DbIsolatedTest):
+class TestProjectInsights:
     """Test project insights class containing project insights endpoints"""
 
     maxDiff = None
 
-    @run_as_sync
-    async def setUp(self) -> None:
-        super().setUp()
-        self.partl = ParticipantLayer(self.connection)
-        self.pil = ProjectInsightsLayer(self.connection)
-        self.sampl = SampleLayer(self.connection)
-        self.seql = AssayLayer(self.connection)
+    @pytest.fixture(autouse=True)
+    async def set_up(self, connection_with_project: Connection) -> None:
+        self.partl = ParticipantLayer(connection_with_project)
+        self.pil = ProjectInsightsLayer(connection_with_project)
+        self.sampl = SampleLayer(connection_with_project)
+        self.seql = AssayLayer(connection_with_project)
+        self.project_name = connection_with_project.project.name
+        self.project_id = connection_with_project.project_id
 
-    @run_as_sync
+    @pytest.mark.project_roles(['writer'])
+    @pytest.mark.asyncio
     async def test_project_insights_summary(self):
         """Test getting the summaries for all available projects"""
 
@@ -110,9 +114,10 @@ class TestProjectInsights(DbIsolatedTest):
             ),
         ]
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
-    @run_as_sync
+    @pytest.mark.project_roles(['writer'])
+    @pytest.mark.asyncio
     async def test_project_insights_details(self):
         """Test getting the details for all available projects"""
 


### PR DESCRIPTION
This PR migrate project insights queries to use PostgreSQL syntax.
There aren't many test cases for this work. But the existing two testcases invoke almost all the DB functions.
In addition, all the new queries were manually tested.  

