### PR TITLE
Add test project name markers.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -298,6 +298,10 @@ async def seeded_db(
         if group not in valid_admin_groups:
             raise ValueError(f'Invalid admin group in marker: {group}')
 
+    # Get project name from marker, or default to test-project
+    project_name_marker = request.node.get_closest_marker('project_name')
+    project_name: list[str] = project_name_marker.args[0] if project_name_marker else 'test-project'
+
     async with db_pool.connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
             # Create groups for project creators and members admin
@@ -318,9 +322,9 @@ async def seeded_db(
             )
 
             # Create a test project and get its ID
-            await cur.execute("""
+            await cur.execute(t"""
                 INSERT INTO project (name, dataset, meta)
-                VALUES ('test-project', 'test-dataset', '{}')
+                VALUES ({project_name}, 'test-dataset', '{{}}')
                 RETURNING id
             """)
             row = await cur.fetchone()
@@ -422,6 +426,7 @@ async def connection(
 
 @pytest.fixture
 async def connection_with_project(
+    request: pytest.FixtureRequest,
     db_pool: AsyncConnectionPool[AsyncConnection[DictRow]],
     seeded_db: None,  # Fixture dependency - ensures database is seeded first  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
@@ -456,7 +461,10 @@ async def connection_with_project(
     await conn.refresh_projects()
 
     # Set the project to test-project
-    conn.update_project('test-project')
+    # Get project name from marker, or default to test-project
+    project_name_marker = request.node.get_closest_marker('project_name')
+    project_name: list[str] = project_name_marker.args[0] if project_name_marker else 'test-project'
+    conn.update_project(project_name)
 
     yield conn
 
@@ -472,4 +480,8 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         'markers',
         'admin_groups(groups: list[str]): Specify admin groups for the test user in the seeded db.',
+    )
+    config.addinivalue_line(
+        'markers',
+        'project_name(name: str): Specify the name of the test project in the seeded test db.',
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -460,8 +460,7 @@ async def connection_with_project(
     # Refresh projects to load the seeded test-project
     await conn.refresh_projects()
 
-    # Set the project to test-project
-    # Get project name from marker, or default to test-project
+    # Set the project to test-project, or get the name from marker if available
     project_name_marker = request.node.get_closest_marker('project_name')
     project_name: list[str] = project_name_marker.args[0] if project_name_marker else 'test-project'
     conn.update_project(project_name)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -300,7 +300,9 @@ async def seeded_db(
 
     # Get project name from marker, or default to test-project
     project_name_marker = request.node.get_closest_marker('project_name')
-    project_name: list[str] = project_name_marker.args[0] if project_name_marker else 'test-project'
+    project_name: list[str] = (
+        project_name_marker.args[0] if project_name_marker else 'test-project'
+    )
 
     async with db_pool.connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
@@ -462,7 +464,9 @@ async def connection_with_project(
 
     # Set the project to test-project, or get the name from marker if available
     project_name_marker = request.node.get_closest_marker('project_name')
-    project_name: list[str] = project_name_marker.args[0] if project_name_marker else 'test-project'
+    project_name: list[str] = (
+        project_name_marker.args[0] if project_name_marker else 'test-project'
+    )
     conn.update_project(project_name)
 
     yield conn


### PR DESCRIPTION
Adds the ability to set the name of the test project that the `connection_with_project` fixture uses.
This can be done using the `@pytest.mark.project_name(<name>)` decorator.