### PR TITLE
[SET-989] refactor project insights layering

### DIFF
--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -665,7 +665,6 @@ class ParticipantLayer(BaseLayer):
                 await slayer.upsert_samples(
                     participant.samples,
                     project=project,
-                    open_transaction=False,
                 )
 
             if participant.phenotypes:

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, NamedTuple
 
 from databases.interfaces import Record
+from psycopg import sql
 
 from db.python.enum_tables import SequencingPlatformTable as SeqPlatformTable
 from db.python.enum_tables import SequencingTechnologyTable as SeqTechTable
@@ -642,17 +643,17 @@ class ProjectInsightsDb(DbBase):
             SELECT
                 project,
                 MAX(timestamp_completed) as max_timestamp,
-                meta ->> 'sequencing_type' as sequencing_type
+                LOWER(meta ->> 'sequencing_type') as sequencing_type
             FROM analysis
             WHERE
                 status = 'completed'
                 AND type = 'custom'
                 AND LOWER(meta ->> 'stage') = 'annotatedataset'
                 AND LOWER(meta ->> 'sequencing_type') = ANY({sequencing_types_param})
-            GROUP BY project, meta ->> 'sequencing_type'
+            GROUP BY project, LOWER(meta ->> 'sequencing_type')
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
+        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
         WHERE
             a.type = 'custom'
             AND a.status = 'completed'
@@ -692,16 +693,16 @@ class ProjectInsightsDb(DbBase):
             SELECT
                 project,
                 MAX(timestamp_completed) as max_timestamp,
-                meta ->> 'sequencing_type' as sequencing_type,
-                meta ->> 'stage' as stage
+                LOWER(meta ->> 'sequencing_type') as sequencing_type,
+                LOWER(meta ->> 'stage') as stage
             FROM analysis
             WHERE type = 'es-index'
             AND status = 'completed'
-            GROUP BY project, sequencing_type, stage
+            GROUP BY project, LOWER(meta ->> 'sequencing_type'), LOWER(meta ->> 'stage')
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
-        AND LOWER(a.meta ->> 'stage') = LOWER(max_timestamps.stage)
+        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
+        AND LOWER(a.meta ->> 'stage') = max_timestamps.stage
         WHERE
             a.project = ANY({project_ids})
             AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param});
@@ -763,6 +764,7 @@ class ProjectInsightsDb(DbBase):
             fp.participant_id,
             sg.id;
         """
+
         _query_results = await (
             await self.connection.pg_connection.execute(_query)
         ).fetchall()
@@ -807,15 +809,15 @@ class ProjectInsightsDb(DbBase):
             a.meta -> 'outliers_detected' as outliers_detected,
             a.meta -> 'outlier_loci' as outlier_loci
         FROM analysis a
-        LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
+        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
         LEFT JOIN output_file of on of.id = ao.file_id
-        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
         INNER JOIN (
             SELECT
                 asg.sequencing_group_id,
                 MAX(a.id) as max_analysis_id
             FROM analysis a
-            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
             WHERE type = 'web'
             AND status = 'completed'
             AND project = ANY({project_ids})

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -929,7 +929,7 @@ class ProjectInsightsDb(DbBase):
         self, project_names: list[str], sequencing_types: list[str]
     ):
         """Combines the results of the above queries into a response"""
-        projects = self._connection.get_and_check_access_to_projects_for_names(
+        projects = self.connection.get_and_check_access_to_projects_for_names(
             project_names=project_names, allowed_roles=ReadAccessRoles
         )
         project_ids: list[ProjectId] = [project.id for project in projects]
@@ -971,7 +971,7 @@ class ProjectInsightsDb(DbBase):
             + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
         )
 
-        sequencing_technologies = await SeqTechTable(self._connection).get()
+        sequencing_technologies = await SeqTechTable(self.connection).get()
         # Get all possible combinations of the projects, sequencing types, and sequencing technologies
         combinations = itertools.product(
             projects, sequencing_types, sequencing_technologies
@@ -1030,7 +1030,7 @@ class ProjectInsightsDb(DbBase):
         self, project_names: list[str], sequencing_types: list[str]
     ):
         """Combines the results of the queries above into a response"""
-        projects = self._connection.get_and_check_access_to_projects_for_names(
+        projects = self.connection.get_and_check_access_to_projects_for_names(
             project_names=project_names, allowed_roles=ReadAccessRoles
         )
         project_ids: list[ProjectId] = [project.id for project in projects]
@@ -1062,8 +1062,8 @@ class ProjectInsightsDb(DbBase):
             + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
         )
 
-        sequencing_platforms = await SeqPlatformTable(self._connection).get()
-        sequencing_technologies = await SeqTechTable(self._connection).get()
+        sequencing_platforms = await SeqPlatformTable(self.connection).get()
+        sequencing_technologies = await SeqTechTable(self.connection).get()
 
         # Get all possible combinations of the projects, sequencing types, platforms, and technologies
         combinations = itertools.product(

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -152,7 +152,7 @@ class ProjectInsightsDb(DbBase):
         return external_ids_value
 
     def parse_project_seqtype_technology_keyed_rows(
-        self, rows: list[Record], value_field: str
+        self, rows: list[dict[Any, Any]], value_field: str
     ) -> dict[ProjectSeqTypeTechnologyKey, Any]:
         """
         Parse rows that are keyed by project, sequencing type, and sequencing technology
@@ -167,13 +167,7 @@ class ProjectInsightsDb(DbBase):
                 row['sequencing_type'],
                 row['sequencing_technology'],
             )
-            if value_field == 'sequencing_group_ids':
-                parsed_rows[key] = [int(sgid) for sgid in row[value_field].split(',')]
-            else:
-                try:
-                    parsed_rows[key] = row[value_field]
-                except KeyError:
-                    parsed_rows[key] = None
+            parsed_rows[key] = row.get(value_field)
         return parsed_rows
 
     async def _get_sequencing_groups_by_analysis_ids(
@@ -182,26 +176,25 @@ class ProjectInsightsDb(DbBase):
         """Get sequencing groups for a list of analysis ids"""
         if not analysis_ids:
             return {}
-        _query = """
-SELECT
-    analysis_id,
-    GROUP_CONCAT(sequencing_group_id) as sequencing_group_ids
-FROM analysis_sequencing_group
-WHERE analysis_id IN :analysis_ids
-GROUP BY analysis_id;
+        _query = t"""
+        SELECT
+            analysis_id,
+            ARRAY_AGG(sequencing_group_id) as sequencing_group_ids
+        FROM analysis_sequencing_group
+        WHERE analysis_id = ANY({analysis_ids})
+        GROUP BY analysis_id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'analysis_ids': analysis_ids,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
         sequencing_groups_by_analysis_id: dict[
             AnalysisId, list[SequencingGroupInternalId]
         ] = {}
         for row in _query_results:
-            sequencing_groups_by_analysis_id[row['analysis_id']] = [
-                int(sgid) for sgid in row['sequencing_group_ids'].split(',')
+            sequencing_groups_by_analysis_id[row['analysis_id']] = row[
+                'sequencing_group_ids'
             ]
 
         return sequencing_groups_by_analysis_id
@@ -410,33 +403,29 @@ GROUP BY analysis_id;
     async def _total_families_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    f.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT f.id) as num_families
-FROM
-    family f
-    LEFT JOIN family_participant fp ON f.id = fp.family_id
-    LEFT JOIN sample s ON fp.participant_id = s.participant_id
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    f.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    f.project,
-    sg.type,
-    sg.technology;
+        _query = t"""
+        SELECT
+            f.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT f.id) as num_families
+        FROM
+            family f
+            LEFT JOIN family_participant fp ON f.id = fp.family_id
+            LEFT JOIN sample s ON fp.participant_id = s.participant_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            f.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            f.project,
+            sg.type,
+            sg.technology;
         """
 
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_families'
         )
@@ -444,31 +433,29 @@ GROUP BY
     async def _total_participants_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    p.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT p.id) as num_participants
-FROM
-    participant p
-    LEFT JOIN sample s ON p.id = s.participant_id
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    p.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    p.project,
-    sg.type,
-    sg.technology;
+
+        _query = t"""
+        SELECT
+            p.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT p.id) as num_participants
+        FROM
+            participant p
+            LEFT JOIN sample s ON p.id = s.participant_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            p.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            p.project,
+            sg.type,
+            sg.technology;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_participants'
         )
@@ -476,30 +463,29 @@ GROUP BY
     async def _total_samples_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    s.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT s.id) as num_samples
-FROM
-    sample s
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    s.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    s.project,
-    sg.type,
-    sg.technology;
+
+        _query = t"""
+        SELECT
+            s.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT s.id) as num_samples
+        FROM
+            sample s
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            s.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            s.project,
+            sg.type,
+            sg.technology;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_samples'
         )
@@ -507,30 +493,27 @@ GROUP BY
     async def _total_sequencing_groups_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-        _query = """
-SELECT
-    s.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COUNT(DISTINCT sg.id) as num_sgs
-FROM
-    sequencing_group sg
-    LEFT JOIN sample s on s.id = sg.sample_id
-WHERE
-    s.project IN :projects
-    AND sg.type IN :sequencing_types
-GROUP BY
-    s.project,
-    sg.type,
-    sg.technology;
+        _query = t"""
+        SELECT
+            s.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT sg.id) as num_sgs
+        FROM
+            sequencing_group sg
+            LEFT JOIN sample s on s.id = sg.sample_id
+        WHERE
+            s.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        GROUP BY
+            s.project,
+            sg.type,
+            sg.technology;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'num_sgs'
         )
@@ -540,34 +523,32 @@ GROUP BY
         project_ids: list[ProjectId],
         sequencing_types: list[SequencingType],
     ) -> dict[ProjectSeqTypeTechnologyKey, list[SequencingGroupInternalId]]:
-        _query = """
-SELECT
-    a.project,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    GROUP_CONCAT(DISTINCT asg.sequencing_group_id) as sequencing_group_ids
-FROM
-    analysis a
-    LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-    LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
-WHERE
-    a.project IN :projects
-    AND sg.type IN :sequencing_types
-    AND a.type = 'CRAM'
-    AND a.status = 'COMPLETED'
-GROUP BY
-    a.project,
-    sg.type,
-    sg.technology;
+        # TODO check CRAM or cram
+        _query = t"""
+        SELECT
+            a.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            ARRAY_AGG(DISTINCT asg.sequencing_group_id) as sequencing_group_ids
+        FROM
+            analysis a
+            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
+        WHERE
+            a.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+            AND lower(a.type) = 'cram'
+            AND a.status = 'completed'
+        GROUP BY
+            a.project,
+            sg.type,
+            sg.technology;
         """
 
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
         return self.parse_project_seqtype_technology_keyed_rows(
             _query_results, 'sequencing_group_ids'
         )
@@ -577,46 +558,43 @@ GROUP BY
     ) -> dict[
         ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
     ]:
-        _query = """
-SELECT
-    a.project,
-    a.id as analysis_id,
-    sg.id as sequencing_group_id,
-    sg.type as sequencing_type,
-    sg.technology as sequencing_technology,
-    COALESCE(a.output, ao.output, of.path) as output,
-    a.timestamp_completed
-FROM
-    analysis a
-    LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-    LEFT JOIN analysis_outputs ao ON a.id = ao.analysis_id
-    LEFT JOIN output_file of ON ao.file_id = of.id
-    LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
-    INNER JOIN (
+        _query = t"""
         SELECT
-            asg.sequencing_group_id,
-            MAX(a.timestamp_completed) as max_timestamp
-        FROM analysis a
-        INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-        WHERE a.type='CRAM'
-        AND a.status='COMPLETED'
-        AND a.project IN :projects
-        GROUP BY asg.sequencing_group_id
-    ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
-    AND a.timestamp_completed = max_timestamps.max_timestamp
-WHERE
-    a.project IN :projects
-    AND sg.type IN :sequencing_types
-    AND a.type = 'CRAM'
-    AND a.status = 'COMPLETED';
+            a.project,
+            a.id as analysis_id,
+            sg.id as sequencing_group_id,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COALESCE(a.output, ao.output, of.path) as output,
+            a.timestamp_completed
+        FROM
+            analysis a
+            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+            LEFT JOIN analysis_outputs ao ON a.id = ao.analysis_id
+            LEFT JOIN output_file of ON ao.file_id = of.id
+            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
+            INNER JOIN (
+                SELECT
+                    asg.sequencing_group_id,
+                    MAX(a.timestamp_completed) as max_timestamp
+                FROM analysis a
+                INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+                WHERE LOWER(a.type) = 'cram'
+                AND a.status='completed'
+                AND a.project = ANY({project_ids})
+                GROUP BY asg.sequencing_group_id
+            ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
+            AND a.timestamp_completed = max_timestamps.max_timestamp
+        WHERE
+            a.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+            AND a.type = 'CRAM'
+            AND a.status = 'completed';
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
 
         cram_timestamps_by_project_id_and_seq_fields: dict[
             ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
@@ -641,44 +619,41 @@ WHERE
     async def _latest_annotate_dataset_by_project_id_and_seq_type(
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeKey, AnalysisRow]:
-        _query = """
-SELECT
-    a.project,
-    JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) as sequencing_type,
-    a.id,
-    a.output,
-    a.timestamp_completed
-FROM analysis a
-INNER JOIN (
-    SELECT
-        project,
-        MAX(timestamp_completed) as max_timestamp,
-        JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) as sequencing_type
-    FROM analysis
-    WHERE
-        status = 'COMPLETED'
-        AND type = 'CUSTOM'
-        AND JSON_EXTRACT(meta, '$.stage') = 'AnnotateDataset'
-        AND JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) IN :sequencing_types
-    GROUP BY project, JSON_EXTRACT(meta, '$.sequencing_type')
-) max_timestamps ON a.project = max_timestamps.project
-AND a.timestamp_completed = max_timestamps.max_timestamp
-AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) = max_timestamps.sequencing_type
-WHERE
-    a.type = 'CUSTOM'
-    AND a.status = 'COMPLETED'
-    AND a.project IN :projects
-    AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) IN :sequencing_types
-    AND JSON_EXTRACT(a.meta, '$.stage') = 'AnnotateDataset';
-    -- JSON_UNQUOTE is necessary to compare JSON values with IN operator
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.meta ->> 'sequencing_type' as sequencing_type,
+            a.id,
+            a.output,
+            a.timestamp_completed
+        FROM analysis a
+        INNER JOIN (
+            SELECT
+                project,
+                MAX(timestamp_completed) as max_timestamp,
+                meta ->> 'sequencing_type' as sequencing_type
+            FROM analysis
+            WHERE
+                status = 'completed'
+                AND lower(type) = 'custom'
+                AND meta ->> 'stage' = 'AnnotateDataset'
+                AND meta ->> 'sequencing_type' = ANY({sequencing_types})
+            GROUP BY project, meta ->> 'sequencing_type'
+        ) max_timestamps ON a.project = max_timestamps.project
+        AND a.timestamp_completed = max_timestamps.max_timestamp
+        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
+        WHERE
+            LOWER(a.type) = 'custom'
+            AND a.status = 'completed'
+            AND a.project = ANY({project_ids})
+            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types})
+            AND a.meta ->> 'stage' = 'AnnotateDataset';
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         latest_annotate_dataset_by_project_id_and_seq_type: dict[
             ProjectSeqTypeKey, AnalysisRow
         ] = {}
@@ -692,40 +667,38 @@ WHERE
     async def _latest_es_indices_by_project_id_and_seq_type_and_stage(
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeStageKey, AnalysisRow]:
-        _query = """
-SELECT
-    a.project,
-    JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) as sequencing_type,
-    a.id,
-    JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.stage')) as stage,
-    a.output,
-    a.timestamp_completed
-FROM analysis a
-INNER JOIN (
-    SELECT
-        project,
-        MAX(timestamp_completed) as max_timestamp,
-        JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) as sequencing_type,
-        JSON_UNQUOTE(JSON_EXTRACT(meta, '$.stage')) as stage
-    FROM analysis
-    WHERE type='es-index'
-    AND status='COMPLETED'
-    GROUP BY project, JSON_EXTRACT(meta, '$.sequencing_type'), JSON_EXTRACT(meta, '$.stage')
-) max_timestamps ON a.project = max_timestamps.project
-AND a.timestamp_completed = max_timestamps.max_timestamp
-AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) = max_timestamps.sequencing_type
-AND JSON_EXTRACT(a.meta, '$.stage') = max_timestamps.stage
-WHERE
-    a.project IN :projects
-    AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) in :sequencing_types;
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.meta ->> 'sequencing_type' as sequencing_type,
+            a.id,
+            a.meta ->> 'stage' as stage,
+            a.output,
+            a.timestamp_completed
+        FROM analysis a
+        INNER JOIN (
+            SELECT
+                project,
+                MAX(timestamp_completed) as max_timestamp,
+                meta ->> 'sequencing_type' as sequencing_type,
+                meta ->> 'stage' as stage
+            FROM analysis
+            WHERE LOWER(type) = 'es-index'
+            AND status = 'completed'
+            GROUP BY project, meta ->> 'sequencing_type', meta ->> 'stage'
+        ) max_timestamps ON a.project = max_timestamps.project
+        AND a.timestamp_completed = max_timestamps.max_timestamp
+        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
+        AND a.meta ->> 'stage' = max_timestamps.stage
+        WHERE
+            a.project = ANY({project_ids})
+            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types});
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         latest_es_indices_by_project_id_and_seq_type_and_stage: dict[
             ProjectSeqTypeStageKey, AnalysisRow
         ] = {}
@@ -742,48 +715,45 @@ WHERE
     async def _sequencing_group_details_by_project_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]]:
-        _query = """
-SELECT
-    f.project,
-    sg.type as sequencing_type,
-    sg.platform as sequencing_platform,
-    sg.technology as sequencing_technology,
-    s.type as sample_type,
-    f.id as family_id,
-    fext.external_id as family_external_id,
-    fp.participant_id as participant_id,
-    pext.external_id as participant_external_id,
-    s.id as sample_id,
-    sext.external_id as sample_external_ids,
-    sg.id as sequencing_group_id
-FROM
-    family f
-    LEFT JOIN family_participant fp ON f.id = fp.family_id
-    LEFT JOIN family_external_id fext ON f.id = fext.family_id
-    LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
-    LEFT JOIN sample s ON fp.participant_id = s.participant_id
-    LEFT JOIN sample_external_id sext ON s.id = sext.sample_id
-    LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-WHERE
-    f.project IN :projects
-    AND sg.type IN :sequencing_types
-ORDER BY
-    f.project,
-    sg.type,
-    sg.platform,
-    sg.technology,
-    s.type,
-    f.id,
-    fp.participant_id,
-    sg.id;
+
+        _query = t"""
+        SELECT
+            f.project,
+            sg.type as sequencing_type,
+            sg.platform as sequencing_platform,
+            sg.technology as sequencing_technology,
+            s.type as sample_type,
+            f.id as family_id,
+            fext.external_id as family_external_id,
+            fp.participant_id as participant_id,
+            pext.external_id as participant_external_id,
+            s.id as sample_id,
+            sext.external_id as sample_external_ids,
+            sg.id as sequencing_group_id
+        FROM
+            family f
+            LEFT JOIN family_participant fp ON f.id = fp.family_id
+            LEFT JOIN family_external_id fext ON f.id = fext.family_id
+            LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
+            LEFT JOIN sample s ON fp.participant_id = s.participant_id
+            LEFT JOIN sample_external_id sext ON s.id = sext.sample_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            f.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types})
+        ORDER BY
+            f.project,
+            sg.type,
+            sg.platform,
+            sg.technology,
+            s.type,
+            f.id,
+            fp.participant_id,
+            sg.id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-                'sequencing_types': sequencing_types,
-            },
-        )
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         sequencing_group_details_by_project_id_and_seq_fields: dict[
             ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]
         ] = {}
@@ -815,38 +785,36 @@ ORDER BY
         self, project_ids: list[ProjectId]
     ) -> dict[ProjectSeqGroupKey, StripyReportRow]:
         """Get stripy web report links"""
-        _query = """
-SELECT
-    a.project,
-    a.id,
-    coalesce(a.output, ao.output, of.path) as output,
-    a.timestamp_completed,
-    asg.sequencing_group_id,
-    JSON_EXTRACT(a.meta, '$.outliers_detected') as outliers_detected,
-    JSON_QUERY(a.meta, '$.outlier_loci') as outlier_loci
-FROM analysis a
-LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
-LEFT JOIN output_file of on of.id = ao.file_id
-LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-INNER JOIN (
-    SELECT
-        asg.sequencing_group_id,
-        MAX(a.id) as max_analysis_id
-    FROM analysis a
-    LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-    WHERE type='web'
-    AND status='COMPLETED'
-    AND project IN :projects
-    AND JSON_EXTRACT(meta, '$.stage') = 'Stripy'
-    GROUP BY asg.sequencing_group_id
-) latest_analysis ON a.id = latest_analysis.max_analysis_id;
+        _query = t"""
+        SELECT
+            a.project,
+            a.id,
+            coalesce(a.output, ao.output, of.path) as output,
+            a.timestamp_completed,
+            asg.sequencing_group_id,
+            a.meta -> 'outliers_detected' as outliers_detected,
+            a.meta -> 'outlier_loci' as outlier_loci
+        FROM analysis a
+        LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
+        LEFT JOIN output_file of on of.id = ao.file_id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+        INNER JOIN (
+            SELECT
+                asg.sequencing_group_id,
+                MAX(a.id) as max_analysis_id
+            FROM analysis a
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
+            WHERE LOWER(type) = 'web'
+            AND status = 'completed'
+            AND project = ANY({project_ids})
+            AND LOWER(meta ->> 'stage') = 'stripy'
+            GROUP BY asg.sequencing_group_id
+        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         stripy_reports: dict[ProjectSeqGroupKey, StripyReportRow] = {}
         for row in _query_results:
             key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])
@@ -864,36 +832,35 @@ INNER JOIN (
         self, project_ids: list[ProjectId]
     ) -> dict[ProjectSeqGroupKey, AnalysisRow]:
         """Get mito web report links"""
-        _query = """
-SELECT
-    a.project,
-    a.id,
-    coalesce(a.output, ao.output, of.path) as output,
-    a.timestamp_completed,
-    asg.sequencing_group_id
-FROM analysis a
-LEFT JOIN analysis_outputs ao on a.id=ao.analysis_id
-LEFT JOIN output_file of on of.id = ao.file_id
-LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-INNER JOIN (
-    SELECT
-        asg.sequencing_group_id,
-        MAX(a.id) as max_analysis_id
-    FROM analysis a
-    LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-    WHERE type='web'
-    AND status='COMPLETED'
-    AND project IN :projects
-    AND JSON_EXTRACT(meta, '$.stage') = 'MitoReport'
-    GROUP BY asg.sequencing_group_id
-) latest_analysis ON a.id = latest_analysis.max_analysis_id;
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.id,
+            coalesce(a.output, ao.output, out_file.path) as output,
+            a.timestamp_completed,
+            asg.sequencing_group_id
+        FROM analysis a
+        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
+        LEFT JOIN output_file out_file on out_file.id = ao.file_id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+        INNER JOIN (
+            SELECT
+                asg.sequencing_group_id,
+                MAX(a.id) as max_analysis_id
+            FROM analysis a
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+            WHERE LOWER(type) = 'web'
+            AND status = 'completed'
+            AND project = ANY({project_ids})
+            AND LOWER(meta ->> 'stage') = 'mitoreport'
+            GROUP BY asg.sequencing_group_id
+        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
         """
-        _query_results = await self.connection.fetch_all(
-            _query,
-            {
-                'projects': project_ids,
-            },
-        )
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
         mito_reports: dict[ProjectSeqGroupKey, AnalysisRow] = {}
         for row in _query_results:
             key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -2,15 +2,13 @@
 import asyncio
 import itertools
 import json
-from datetime import datetime
-from typing import Any, NamedTuple
+from typing import Any
 
-from databases.interfaces import Record
-
+from db.python.connect import Connection
 from db.python.enum_tables import SequencingPlatformTable as SeqPlatformTable
 from db.python.enum_tables import SequencingTechnologyTable as SeqTechTable
 from db.python.layers.base import BaseLayer
-from db.python.tables.base import DbBase
+from db.python.tables.project_insights import ProjectInsightsDb
 from models.models import (
     AnalysisStatsInternal,
     ProjectInsightsDetailsInternal,
@@ -18,69 +16,20 @@ from models.models import (
 )
 from models.models.project import Project, ProjectId, ReadAccessRoles
 from models.models.sequencing_group import SequencingGroupInternalId
+from models.utils.project_insights import (
+    AnalysisId,
+    AnalysisRow,
+    ProjectSeqGroupKey,
+    ProjectSeqTypeKey,
+    ProjectSeqTypeStageKey,
+    ProjectSeqTypeTechnologyKey,
+    SequencingGroupDetailRow,
+    SequencingPlatform,
+    SequencingTechnology,
+    SequencingType,
+    StripyReportRow,
+)
 from models.utils.sequencing_group_id_format import sequencing_group_id_format
-
-
-AnalysisId = int
-SequencingType = str
-SequencingTechnology = str
-SequencingPlatform = str
-
-
-# This layer has a lot of different queries, so we'll define some namedtuples to help us keep track of the keys
-class ProjectSeqTypeKey(NamedTuple):  # noqa: D101
-    project: ProjectId
-    sequencing_type: SequencingType
-
-
-class ProjectSeqTypeTechnologyKey(NamedTuple):  # noqa: D101
-    project: ProjectId
-    sequencing_type: SequencingType
-    sequencing_technology: SequencingTechnology
-
-
-class ProjectSeqTypeTechnologyPlatformKey(NamedTuple):  # noqa: D101
-    project: ProjectId
-    sequencing_type: SequencingType
-    sequencing_technology: SequencingTechnology
-    sequencing_platform: SequencingPlatform
-
-
-class ProjectSeqTypeStageKey(NamedTuple):  # noqa: D101
-    project: ProjectId
-    sequencing_type: SequencingType
-    stage: str
-
-
-class ProjectSeqGroupKey(NamedTuple):  # noqa: D101
-    project: ProjectId
-    sequencing_group_id: SequencingGroupInternalId
-
-
-# Namedtuples for the rows returned by the queries
-class AnalysisRow(NamedTuple):  # noqa: D101
-    id: AnalysisId
-    output: str
-    timestamp_completed: datetime
-
-
-class SequencingGroupDetailRow(NamedTuple):  # noqa: D101
-    family_id: int
-    family_external_id: str
-    participant_id: int
-    participant_external_id: str
-    sample_id: int
-    sample_external_ids: list[str]
-    sample_type: str
-    sequencing_group_id: SequencingGroupInternalId
-
-
-class StripyReportRow(NamedTuple):  # noqa: D101
-    id: AnalysisId
-    output: str
-    outliers_detected: bool
-    outlier_loci: str
-    timestamp_completed: datetime
 
 
 SV_INDEX_SEQ_TYPE_STAGE_MAP = {
@@ -92,6 +41,10 @@ SV_INDEX_SEQ_TYPE_STAGE_MAP = {
 class ProjectInsightsLayer(BaseLayer):
     """Project Insights layer - business logic for the project insights dashboards"""
 
+    def __init__(self, connection: Connection):
+        super().__init__(connection)
+        self.pidb = ProjectInsightsDb(connection=connection)
+
     async def get_project_insights_summary(
         self,
         project_names: list[str],
@@ -100,8 +53,7 @@ class ProjectInsightsLayer(BaseLayer):
         """
         Get summary and analysis stats for a list of projects
         """
-        pidb = ProjectInsightsDb(self.connection)
-        return await pidb.get_project_insights_summary(
+        return await self.collect_project_insights_summary(
             project_names=project_names, sequencing_types=sequencing_types
         )
 
@@ -113,91 +65,268 @@ class ProjectInsightsLayer(BaseLayer):
         """
         Get extensive sequencing group details for a list of projects
         """
-        pidb = ProjectInsightsDb(self.connection)
-        return await pidb.get_project_insights_details(
+        return await self.collect_project_insights_details(
             project_names=project_names, sequencing_types=sequencing_types
         )
 
-
-class ProjectInsightsDb(DbBase):
-    """
-    Db layer for project insights summary and details routes
-
-    Used to get the summary and details for the projects stats dashboard
-        - Summary
-            - One row per project, sequencing type, and technology (platform not needed for now)
-            - Total families, participants, samples, sequencing groups, CRAMs, and latest analyses
-        - Details
-            - One row per sequencing group
-            - Only for sequencing groups that belong to participants with a family record
-            - Gets web report links for each sequencing group
-            - Checks if the sequencing group is in the latest completed analyses
-                (CRAM, AnnotateDataset, SNV es-index, SV/gCNV es-index)
-            - Get the family, participant, sample, and sequencing group details
-    """
-
-    # Helper functions
-    def get_analysis_row(self, row: Record) -> AnalysisRow:
-        """Parse a table row returned by fetch_all into an AnalysisRow object"""
-        return AnalysisRow(
-            id=row['id'],
-            output=row['output'],
-            timestamp_completed=row['timestamp_completed'],
+    def get_latest_grouped_analyses(
+        self,
+        project: Project,
+        sequencing_type: SequencingType,
+        sequencing_technology: SequencingTechnology,
+        latest_annotate_dataset_by_project_id_and_seq_type: dict[
+            ProjectSeqTypeKey, AnalysisRow
+        ],
+        latest_es_indices_by_project_id_and_seq_type_and_stage: dict[
+            ProjectSeqTypeStageKey, AnalysisRow
+        ],
+    ):
+        """Returns the latest grouped analyses for a project, sequencing type, and technology"""
+        if sequencing_technology == 'short-read':
+            latest_annotate_dataset_row = (
+                latest_annotate_dataset_by_project_id_and_seq_type.get(
+                    ProjectSeqTypeKey(project.id, sequencing_type)
+                )
+            )
+            latest_snv_es_index_row = (
+                latest_es_indices_by_project_id_and_seq_type_and_stage.get(
+                    ProjectSeqTypeStageKey(project.id, sequencing_type, 'MtToEs')
+                )
+            )
+            latest_sv_es_index_row = (
+                latest_es_indices_by_project_id_and_seq_type_and_stage.get(
+                    ProjectSeqTypeStageKey(
+                        project.id,
+                        sequencing_type,
+                        SV_INDEX_SEQ_TYPE_STAGE_MAP.get(sequencing_type),
+                    )
+                )
+            )
+        else:
+            latest_annotate_dataset_row = None
+            latest_snv_es_index_row = None
+            latest_sv_es_index_row = None
+        return (
+            latest_annotate_dataset_row,
+            latest_snv_es_index_row,
+            latest_sv_es_index_row,
         )
 
-    def convert_to_external_ids(self, external_ids_value: str | list[str]) -> list[str]:
-        """Converts a string or list of strings to a list of strings"""
-        if isinstance(external_ids_value, str):
-            return [external_ids_value]
-        return external_ids_value
+    # Main functions
+    async def collect_project_insights_summary(
+        self, project_names: list[str], sequencing_types: list[str]
+    ):
+        """Combines the results of the above queries into a response"""
+        projects = self.connection.get_and_check_access_to_projects_for_names(
+            project_names=project_names, allowed_roles=ReadAccessRoles
+        )
+        project_ids: list[ProjectId] = [project.id for project in projects]
 
-    def parse_project_seqtype_technology_keyed_rows(
-        self, rows: list[dict[Any, Any]], value_field: str
-    ) -> dict[ProjectSeqTypeTechnologyKey, Any]:
-        """
-        Parse rows that are keyed by project, sequencing type, and sequencing technology
-        """
-        parsed_rows: dict[
-            ProjectSeqTypeTechnologyKey,
-            dict[str, Any] | list[SequencingGroupInternalId],
-        ] = {}
-        for row in rows:
-            key = ProjectSeqTypeTechnologyKey(
-                row['project'],
-                row['sequencing_type'],
-                row['sequencing_technology'],
+        (
+            total_families_by_project_id_and_seq_fields,
+            total_participants_by_project_id_and_seq_fields,
+            total_samples_by_project_id_and_seq_fields,
+            total_sequencing_groups_by_project_id_and_seq_fields,
+            crams_by_project_id_and_seq_fields,
+            latest_annotate_dataset_by_project_id_and_seq_type,
+            latest_es_indices_by_project_id_and_seq_type_and_stage,  # keyed by (project_id, sequencing_type, stage)
+        ) = await asyncio.gather(
+            self.pidb.total_families_by_project_id_and_seq_fields(
+                project_ids, sequencing_types
+            ),
+            self.pidb.total_participants_by_project_id_and_seq_fields(
+                project_ids, sequencing_types
+            ),
+            self.pidb.total_samples_by_project_id_and_seq_fields(
+                project_ids, sequencing_types
+            ),
+            self.pidb.total_sequencing_groups_by_project_id_and_seq_fields(
+                project_ids, sequencing_types
+            ),
+            self.pidb.crams_by_project_id_and_seq_fields(project_ids, sequencing_types),
+            self.pidb.latest_annotate_dataset_by_project_id_and_seq_type(
+                project_ids, sequencing_types
+            ),
+            self.pidb.latest_es_indices_by_project_id_and_seq_type_and_stage(
+                project_ids,
+                sequencing_types,
+            ),
+        )
+
+        # Get the sequencing groups for each of the analyses in the grouped analyses rows
+        analysis_sequencing_groups = await self.get_analysis_sequencing_groups(
+            list(latest_annotate_dataset_by_project_id_and_seq_type.values())
+            + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
+        )
+
+        sequencing_technologies = await SeqTechTable(self.connection).get()
+        # Get all possible combinations of the projects, sequencing types, and sequencing technologies
+        combinations = itertools.product(
+            projects, sequencing_types, sequencing_technologies
+        )
+
+        response = []
+        for project, seq_type, seq_tech in combinations:
+            rowkey = ProjectSeqTypeTechnologyKey(project.id, seq_type, seq_tech)
+
+            total_sequencing_groups = (
+                total_sequencing_groups_by_project_id_and_seq_fields.get(rowkey, 0)
             )
-            parsed_rows[key] = row.get(value_field)
-        return parsed_rows
+            if total_sequencing_groups == 0:
+                continue
 
-    async def _get_sequencing_groups_by_analysis_ids(
-        self, analysis_ids: list[AnalysisId]
-    ) -> dict[AnalysisId, list[SequencingGroupInternalId]]:
-        """Get sequencing groups for a list of analysis ids"""
-        if not analysis_ids:
-            return {}
-        _query = t"""
-        SELECT
-            analysis_id,
-            ARRAY_AGG(sequencing_group_id) as sequencing_group_ids
-        FROM analysis_sequencing_group
-        WHERE analysis_id = ANY({analysis_ids})
-        GROUP BY analysis_id;
-        """
+            crams_in_project_with_sequencing_fields = (
+                crams_by_project_id_and_seq_fields.get(rowkey, [])
+            )
+            (
+                latest_annotate_dataset_row,
+                latest_snv_es_index_row,
+                latest_sv_es_index_row,
+            ) = self.get_latest_grouped_analyses(
+                project,
+                seq_type,
+                seq_tech,
+                latest_annotate_dataset_by_project_id_and_seq_type,
+                latest_es_indices_by_project_id_and_seq_type_and_stage,
+            )
 
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
+            total_families_by_project_id_and_seq_fields.setdefault(rowkey, 0)
+            total_participants_by_project_id_and_seq_fields.setdefault(rowkey, 0)
+            total_samples_by_project_id_and_seq_fields.setdefault(rowkey, 0)
 
-        sequencing_groups_by_analysis_id: dict[
-            AnalysisId, list[SequencingGroupInternalId]
-        ] = {}
-        for row in _query_results:
-            sequencing_groups_by_analysis_id[row['analysis_id']] = row[
-                'sequencing_group_ids'
-            ]
+            response.append(
+                self.get_insights_summary_internal_row(
+                    summary_row_key=rowkey,
+                    project=project,
+                    total_families=total_families_by_project_id_and_seq_fields[rowkey],
+                    total_participants=total_participants_by_project_id_and_seq_fields[
+                        rowkey
+                    ],
+                    total_samples=total_samples_by_project_id_and_seq_fields[rowkey],
+                    total_sequencing_groups=total_sequencing_groups,
+                    crams=crams_in_project_with_sequencing_fields,
+                    analysis_sequencing_groups=analysis_sequencing_groups,
+                    latest_annotate_dataset_analysis=latest_annotate_dataset_row,
+                    latest_snv_es_index_analysis=latest_snv_es_index_row,
+                    latest_sv_es_index_analysis=latest_sv_es_index_row,
+                )
+            )
 
-        return sequencing_groups_by_analysis_id
+        return response
+
+    async def collect_project_insights_details(
+        self, project_names: list[str], sequencing_types: list[str]
+    ):
+        """Combines the results of the queries above into a response"""
+        projects = self.connection.get_and_check_access_to_projects_for_names(
+            project_names=project_names, allowed_roles=ReadAccessRoles
+        )
+        project_ids: list[ProjectId] = [project.id for project in projects]
+
+        (
+            sequencing_group_details_by_project_id_and_seq_fields,
+            crams_by_project_id_and_seq_fields,
+            latest_annotate_dataset_by_project_id_and_seq_type,
+            latest_es_indices_by_project_id_and_seq_type_and_stage,
+            sequencing_group_stripy_reports,
+            sequencing_group_mito_reports,
+        ) = await asyncio.gather(
+            self.pidb.sequencing_group_details_by_project_and_seq_fields(
+                project_ids, sequencing_types
+            ),
+            self.pidb.sg_crams_by_project_id_and_seq_fields(
+                project_ids, sequencing_types
+            ),
+            self.pidb.latest_annotate_dataset_by_project_id_and_seq_type(
+                project_ids, sequencing_types
+            ),
+            self.pidb.latest_es_indices_by_project_id_and_seq_type_and_stage(
+                project_ids, sequencing_types
+            ),
+            self.pidb.details_stripy_reports(project_ids),
+            self.pidb.details_mito_reports(project_ids),
+        )
+        # Get the sequencing groups for each of the analyses in the grouped analyses rows
+        analysis_sequencing_groups = await self.get_analysis_sequencing_groups(
+            list(latest_annotate_dataset_by_project_id_and_seq_type.values())
+            + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
+        )
+
+        sequencing_platforms = await SeqPlatformTable(self.connection).get()
+        sequencing_technologies = await SeqTechTable(self.connection).get()
+
+        # Get all possible combinations of the projects, sequencing types, platforms, and technologies
+        combinations = itertools.product(
+            projects, sequencing_types, sequencing_platforms, sequencing_technologies
+        )
+
+        response = []
+        for (
+            project,
+            seq_type,
+            seq_platform,
+            seq_tech,
+        ) in combinations:
+            details_rows: list[SequencingGroupDetailRow]
+            if not (
+                details_rows
+                := sequencing_group_details_by_project_id_and_seq_fields.get(
+                    (project.id, seq_type, seq_platform, seq_tech)
+                )
+            ):
+                continue
+
+            sequencing_groups_crams: dict[SequencingGroupInternalId, AnalysisRow] = (
+                crams_by_project_id_and_seq_fields.get(
+                    (project.id, seq_type, seq_tech), {}
+                )
+            )
+            (
+                latest_annotate_dataset_row,
+                latest_snv_es_index_row,
+                latest_sv_es_index_row,
+            ) = self.get_latest_grouped_analyses(
+                project,
+                seq_type,
+                seq_tech,
+                latest_annotate_dataset_by_project_id_and_seq_type,
+                latest_es_indices_by_project_id_and_seq_type_and_stage,
+            )
+
+            for details_row in details_rows:
+                if not details_row:
+                    continue
+                sg_id = details_row.sequencing_group_id
+                response.append(
+                    self.get_insights_details_internal_row(
+                        project=project,
+                        sequencing_type=seq_type,
+                        sequencing_platform=seq_platform,
+                        sequencing_technology=seq_tech,
+                        sequencing_group_details=details_row,
+                        sequencing_group_cram=sequencing_groups_crams.get(sg_id),
+                        analysis_sequencing_groups=analysis_sequencing_groups,
+                        latest_annotate_dataset_id=(
+                            latest_annotate_dataset_row.id
+                            if latest_annotate_dataset_row
+                            else None
+                        ),
+                        latest_snv_es_index_id=(
+                            latest_snv_es_index_row.id
+                            if latest_snv_es_index_row
+                            else None
+                        ),
+                        latest_sv_es_index_id=(
+                            latest_sv_es_index_row.id
+                            if latest_sv_es_index_row
+                            else None
+                        ),
+                        stripy_reports=sequencing_group_stripy_reports,
+                        mito_reports=sequencing_group_mito_reports,
+                    )
+                )
+
+        return response
 
     async def get_analysis_sequencing_groups(
         self, grouped_analysis_rows: list[AnalysisRow]
@@ -208,95 +337,9 @@ class ProjectInsightsDb(DbBase):
         analyses_to_query_sequencing_groups: list[AnalysisId] = []
         for row in grouped_analysis_rows:
             analyses_to_query_sequencing_groups.append(row.id)
-
-        return await self._get_sequencing_groups_by_analysis_ids(
+        analyses_to_query_sequencing_groups = [4, 5]
+        return await self.pidb.get_sequencing_groups_by_analysis_ids(
             analyses_to_query_sequencing_groups
-        )
-
-    def get_report_url(
-        self,
-        project_name: str,
-        sequencing_group_id: SequencingGroupInternalId,
-        output: str,
-        stage: str,
-    ):
-        """Converts an analysis output gs path to a web report link"""
-        sg_id = sequencing_group_id_format(sequencing_group_id)
-        if 'main-web' in output:
-            url_base = 'https://main-web.populationgenomics.org.au'
-        else:
-            url_base = 'https://test-web.populationgenomics.org.au'
-
-        if stage == 'Stripy':
-            return f'{url_base}/{project_name}/stripy/{sg_id}.stripy.html'
-        if stage == 'MitoReport':
-            return f'{url_base}/{project_name}/mito/mitoreport-{sg_id}/index.html'
-        return None
-
-    def get_sg_web_report_links(
-        self,
-        sequencing_group_stripy_reports: dict[ProjectSeqGroupKey, StripyReportRow],
-        sequencing_group_mito_reports: dict[ProjectSeqGroupKey, AnalysisRow],
-        project: Project,
-        sequencing_group_id: SequencingGroupInternalId,
-    ):
-        """
-        Get the web report links for a sequencing group
-        """
-        report_links: dict[str, dict[str, Any]] = {}
-        report_key = ProjectSeqGroupKey(project.id, sequencing_group_id)
-
-        if stripy_report := sequencing_group_stripy_reports.get(report_key):
-            report_links['stripy'] = {
-                'url': self.get_report_url(
-                    project.name, sequencing_group_id, stripy_report.output, 'Stripy'
-                ),
-                'outliers_detected': stripy_report.outliers_detected,
-                'outlier_loci': (
-                    json.loads(stripy_report.outlier_loci)
-                    if stripy_report.outlier_loci
-                    else None
-                ),
-                'timestamp_completed': stripy_report.timestamp_completed.isoformat()
-                if stripy_report.timestamp_completed
-                else None,
-            }
-
-        if mito_report := sequencing_group_mito_reports.get(report_key):
-            report_links['mito'] = {
-                'url': self.get_report_url(
-                    project.name, sequencing_group_id, mito_report.output, 'MitoReport'
-                ),
-                'timestamp_completed': mito_report.timestamp_completed.isoformat()
-                if mito_report.timestamp_completed
-                else None,
-            }
-
-        return report_links
-
-    def get_cram_record(self, cram_row: AnalysisRow | None):
-        """Get the CRAM record for a sequencing group"""
-        return {
-            'id': cram_row.id if cram_row else None,
-            'output': cram_row.output if cram_row else None,
-            'timestamp_completed': cram_row.timestamp_completed.strftime('%d-%m-%y')
-            if cram_row
-            else None,
-        }
-
-    def get_analysis_stats_internal_from_record(
-        self,
-        analysis_row: AnalysisRow | None,
-        analysis_sequencing_groups: dict[AnalysisId, list[SequencingGroupInternalId]],
-    ) -> AnalysisStatsInternal | None:
-        """Transforms an analysis row record into an AnalysisStatsInternal object"""
-        if not analysis_row:
-            return None
-        return AnalysisStatsInternal(
-            id=analysis_row.id,
-            name=analysis_row.output,
-            sg_count=len(analysis_sequencing_groups.get(analysis_row.id, [])),
-            timestamp=analysis_row.timestamp_completed,
         )
 
     def get_insights_summary_internal_row(  # noqa: PLR0913
@@ -399,741 +442,94 @@ class ProjectInsightsDb(DbBase):
             web_reports=web_reports,
         )
 
-    # Project Insights Summary queries
-    async def _total_families_by_project_id_and_seq_fields(
-        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            f.project,
-            sg.type as sequencing_type,
-            sg.technology as sequencing_technology,
-            COUNT(DISTINCT f.id) as num_families
-        FROM
-            family f
-            LEFT JOIN family_participant fp ON f.id = fp.family_id
-            LEFT JOIN sample s ON fp.participant_id = s.participant_id
-            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-        WHERE
-            f.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-        GROUP BY
-            f.project,
-            sg.type,
-            sg.technology;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_families'
-        )
-
-    async def _total_participants_by_project_id_and_seq_fields(
-        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            p.project,
-            sg.type as sequencing_type,
-            sg.technology as sequencing_technology,
-            COUNT(DISTINCT p.id) as num_participants
-        FROM
-            participant p
-            LEFT JOIN sample s ON p.id = s.participant_id
-            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-        WHERE
-            p.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-        GROUP BY
-            p.project,
-            sg.type,
-            sg.technology;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_participants'
-        )
-
-    async def _total_samples_by_project_id_and_seq_fields(
-        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            s.project,
-            sg.type as sequencing_type,
-            sg.technology as sequencing_technology,
-            COUNT(DISTINCT s.id) as num_samples
-        FROM
-            sample s
-            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-        WHERE
-            s.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-        GROUP BY
-            s.project,
-            sg.type,
-            sg.technology;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-
-        return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_samples'
-        )
-
-    async def _total_sequencing_groups_by_project_id_and_seq_fields(
-        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            s.project,
-            sg.type as sequencing_type,
-            sg.technology as sequencing_technology,
-            COUNT(DISTINCT sg.id) as num_sgs
-        FROM
-            sequencing_group sg
-            LEFT JOIN sample s on s.id = sg.sample_id
-        WHERE
-            s.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-        GROUP BY
-            s.project,
-            sg.type,
-            sg.technology;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_sgs'
-        )
-
-    async def _crams_by_project_id_and_seq_fields(
+    def get_analysis_stats_internal_from_record(
         self,
-        project_ids: list[ProjectId],
-        sequencing_types: list[SequencingType],
-    ) -> dict[ProjectSeqTypeTechnologyKey, list[SequencingGroupInternalId]]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            a.project,
-            sg.type as sequencing_type,
-            sg.technology as sequencing_technology,
-            ARRAY_AGG(DISTINCT asg.sequencing_group_id) as sequencing_group_ids
-        FROM
-            analysis a
-            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
-        WHERE
-            a.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-            AND a.type = 'cram'
-            AND a.status = 'completed'
-        GROUP BY
-            a.project,
-            sg.type,
-            sg.technology;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-
-        return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'sequencing_group_ids'
+        analysis_row: AnalysisRow | None,
+        analysis_sequencing_groups: dict[AnalysisId, list[SequencingGroupInternalId]],
+    ) -> AnalysisStatsInternal | None:
+        """Transforms an analysis row record into an AnalysisStatsInternal object"""
+        if not analysis_row:
+            return None
+        return AnalysisStatsInternal(
+            id=analysis_row.id,
+            name=analysis_row.output,
+            sg_count=len(analysis_sequencing_groups.get(analysis_row.id, [])),
+            timestamp=analysis_row.timestamp_completed,
         )
 
-    async def _sg_crams_by_project_id_and_seq_fields(
-        self, project_ids: list[ProjectId], sequencing_types: list[str]
-    ) -> dict[
-        ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
-    ]:
+    def get_cram_record(self, cram_row: AnalysisRow | None):
+        """Get the CRAM record for a sequencing group"""
+        return {
+            'id': cram_row.id if cram_row else None,
+            'output': cram_row.output if cram_row else None,
+            'timestamp_completed': cram_row.timestamp_completed.strftime('%d-%m-%y')
+            if cram_row
+            else None,
+        }
 
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            a.project,
-            a.id as analysis_id,
-            sg.id as sequencing_group_id,
-            sg.type as sequencing_type,
-            sg.technology as sequencing_technology,
-            COALESCE(a.output, ao.output, of.path) as output,
-            a.timestamp_completed
-        FROM
-            analysis a
-            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-            LEFT JOIN analysis_outputs ao ON a.id = ao.analysis_id
-            LEFT JOIN output_file of ON ao.file_id = of.id
-            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
-            INNER JOIN (
-                SELECT
-                    asg.sequencing_group_id,
-                    MAX(a.timestamp_completed) as max_timestamp
-                FROM analysis a
-                INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-                WHERE a.type = 'cram'
-                AND a.status='completed'
-                AND a.project = ANY({project_ids})
-                GROUP BY asg.sequencing_group_id
-            ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
-            AND a.timestamp_completed = max_timestamps.max_timestamp
-        WHERE
-            a.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-            AND a.type = 'cram'
-            AND a.status = 'completed';
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-
-        cram_timestamps_by_project_id_and_seq_fields: dict[
-            ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
-        ] = {}
-        for row in _query_results:
-            key = ProjectSeqTypeTechnologyKey(
-                row['project'],
-                row['sequencing_type'],
-                row['sequencing_technology'],
-            )
-            sg_id = row['sequencing_group_id']
-            cram_row = AnalysisRow(
-                id=row['analysis_id'],
-                output=row['output'],
-                timestamp_completed=row['timestamp_completed'],
-            )
-            if key not in cram_timestamps_by_project_id_and_seq_fields:
-                cram_timestamps_by_project_id_and_seq_fields[key] = {}
-            cram_timestamps_by_project_id_and_seq_fields[key][sg_id] = cram_row
-        return cram_timestamps_by_project_id_and_seq_fields
-
-    async def _latest_annotate_dataset_by_project_id_and_seq_type(
-        self, project_ids: list[ProjectId], sequencing_types: list[str]
-    ) -> dict[ProjectSeqTypeKey, AnalysisRow]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            a.project,
-            a.meta ->> 'sequencing_type' as sequencing_type,
-            a.id,
-            a.output,
-            a.timestamp_completed
-        FROM analysis a
-        INNER JOIN (
-            SELECT
-                project,
-                MAX(timestamp_completed) as max_timestamp,
-                LOWER(meta ->> 'sequencing_type') as sequencing_type
-            FROM analysis
-            WHERE
-                status = 'completed'
-                AND type = 'custom'
-                AND LOWER(meta ->> 'stage') = 'annotatedataset'
-                AND LOWER(meta ->> 'sequencing_type') = ANY({sequencing_types_param})
-            GROUP BY project, LOWER(meta ->> 'sequencing_type')
-        ) max_timestamps ON a.project = max_timestamps.project
-        AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
-        WHERE
-            a.type = 'custom'
-            AND a.status = 'completed'
-            AND a.project = ANY({project_ids})
-            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param})
-            AND LOWER(a.meta ->> 'stage') = 'annotatedataset';
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        latest_annotate_dataset_by_project_id_and_seq_type: dict[
-            ProjectSeqTypeKey, AnalysisRow
-        ] = {}
-        for row in _query_results:
-            key = ProjectSeqTypeKey(row['project'], row['sequencing_type'])
-            latest_annotate_dataset_by_project_id_and_seq_type[key] = (
-                self.get_analysis_row(row)
-            )
-        return latest_annotate_dataset_by_project_id_and_seq_type
-
-    async def _latest_es_indices_by_project_id_and_seq_type_and_stage(
-        self, project_ids: list[ProjectId], sequencing_types: list[str]
-    ) -> dict[ProjectSeqTypeStageKey, AnalysisRow]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            a.project,
-            a.meta ->> 'sequencing_type' as sequencing_type,
-            a.id,
-            a.meta ->> 'stage' as stage,
-            a.output,
-            a.timestamp_completed
-        FROM analysis a
-        INNER JOIN (
-            SELECT
-                project,
-                MAX(timestamp_completed) as max_timestamp,
-                LOWER(meta ->> 'sequencing_type') as sequencing_type,
-                LOWER(meta ->> 'stage') as stage
-            FROM analysis
-            WHERE type = 'es-index'
-            AND status = 'completed'
-            GROUP BY project, LOWER(meta ->> 'sequencing_type'), LOWER(meta ->> 'stage')
-        ) max_timestamps ON a.project = max_timestamps.project
-        AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
-        AND LOWER(a.meta ->> 'stage') = max_timestamps.stage
-        WHERE
-            a.project = ANY({project_ids})
-            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param});
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        latest_es_indices_by_project_id_and_seq_type_and_stage: dict[
-            ProjectSeqTypeStageKey, AnalysisRow
-        ] = {}
-        for row in _query_results:
-            key = ProjectSeqTypeStageKey(
-                row['project'], row['sequencing_type'], row['stage']
-            )
-            latest_es_indices_by_project_id_and_seq_type_and_stage[key] = (
-                self.get_analysis_row(row)
-            )
-        return latest_es_indices_by_project_id_and_seq_type_and_stage
-
-    # Project Insights details queries
-    async def _sequencing_group_details_by_project_and_seq_fields(
-        self, project_ids: list[ProjectId], sequencing_types: list[str]
-    ) -> dict[ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]]:
-
-        sequencing_types_param = [st.lower() for st in sequencing_types]
-        _query = t"""
-        SELECT
-            f.project,
-            sg.type as sequencing_type,
-            sg.platform as sequencing_platform,
-            sg.technology as sequencing_technology,
-            s.type as sample_type,
-            f.id as family_id,
-            fext.external_id as family_external_id,
-            fp.participant_id as participant_id,
-            pext.external_id as participant_external_id,
-            s.id as sample_id,
-            sext.external_id as sample_external_ids,
-            sg.id as sequencing_group_id
-        FROM
-            family f
-            LEFT JOIN family_participant fp ON f.id = fp.family_id
-            LEFT JOIN family_external_id fext ON f.id = fext.family_id
-            LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
-            LEFT JOIN sample s ON fp.participant_id = s.participant_id
-            LEFT JOIN sample_external_id sext ON s.id = sext.sample_id
-            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
-        WHERE
-            f.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types_param})
-        ORDER BY
-            f.project,
-            sg.type,
-            sg.platform,
-            sg.technology,
-            s.type,
-            f.id,
-            fp.participant_id,
-            sg.id;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        sequencing_group_details_by_project_id_and_seq_fields: dict[
-            ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]
-        ] = {}
-        for row in _query_results:
-            key = ProjectSeqTypeTechnologyPlatformKey(
-                row['project'],
-                row['sequencing_type'],
-                row['sequencing_platform'],
-                row['sequencing_technology'],
-            )
-            if key not in sequencing_group_details_by_project_id_and_seq_fields:
-                sequencing_group_details_by_project_id_and_seq_fields[key] = []
-            sequencing_group_details_by_project_id_and_seq_fields[key].append(
-                SequencingGroupDetailRow(
-                    family_id=row['family_id'],
-                    family_external_id=row['family_external_id'],
-                    participant_id=row['participant_id'],
-                    participant_external_id=row['participant_external_id'],
-                    sample_id=row['sample_id'],
-                    sample_external_ids=row['sample_external_ids'],
-                    sample_type=row['sample_type'],
-                    sequencing_group_id=row['sequencing_group_id'],
-                )
-            )
-
-        return sequencing_group_details_by_project_id_and_seq_fields
-
-    async def _details_stripy_reports(
-        self, project_ids: list[ProjectId]
-    ) -> dict[ProjectSeqGroupKey, StripyReportRow]:
-        """Get stripy web report links"""
-        _query = t"""
-        SELECT
-            a.project,
-            a.id,
-            coalesce(a.output, ao.output, of.path) as output,
-            a.timestamp_completed,
-            asg.sequencing_group_id,
-            a.meta -> 'outliers_detected' as outliers_detected,
-            a.meta -> 'outlier_loci' as outlier_loci
-        FROM analysis a
-        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
-        LEFT JOIN output_file of on of.id = ao.file_id
-        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
-        INNER JOIN (
-            SELECT
-                asg.sequencing_group_id,
-                MAX(a.id) as max_analysis_id
-            FROM analysis a
-            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
-            WHERE type = 'web'
-            AND status = 'completed'
-            AND project = ANY({project_ids})
-            AND LOWER(meta ->> 'stage') = 'stripy'
-            GROUP BY asg.sequencing_group_id
-        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        stripy_reports: dict[ProjectSeqGroupKey, StripyReportRow] = {}
-        for row in _query_results:
-            key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])
-            stripy_reports[key] = StripyReportRow(
-                id=row['id'],
-                output=row['output'],
-                outliers_detected=row['outliers_detected'],
-                outlier_loci=row['outlier_loci'],
-                timestamp_completed=row['timestamp_completed'],
-            )
-
-        return stripy_reports
-
-    async def _details_mito_reports(
-        self, project_ids: list[ProjectId]
-    ) -> dict[ProjectSeqGroupKey, AnalysisRow]:
-        """Get mito web report links"""
-
-        _query = t"""
-        SELECT
-            a.project,
-            a.id,
-            coalesce(a.output, ao.output, out_file.path) as output,
-            a.timestamp_completed,
-            asg.sequencing_group_id
-        FROM analysis a
-        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
-        LEFT JOIN output_file out_file on out_file.id = ao.file_id
-        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
-        INNER JOIN (
-            SELECT
-                asg.sequencing_group_id,
-                MAX(a.id) as max_analysis_id
-            FROM analysis a
-            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
-            WHERE type = 'web'
-            AND status = 'completed'
-            AND project = ANY({project_ids})
-            AND LOWER(meta ->> 'stage') = 'mitoreport'
-            GROUP BY asg.sequencing_group_id
-        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
-        """
-
-        _query_results = await (
-            await self.connection.pg_connection.execute(_query)
-        ).fetchall()
-        mito_reports: dict[ProjectSeqGroupKey, AnalysisRow] = {}
-        for row in _query_results:
-            key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])
-            mito_reports[key] = self.get_analysis_row(row)
-
-        return mito_reports
-
-    def get_latest_grouped_analyses(
+    def get_report_url(
         self,
-        project: Project,
-        sequencing_type: SequencingType,
-        sequencing_technology: SequencingTechnology,
-        latest_annotate_dataset_by_project_id_and_seq_type: dict[
-            ProjectSeqTypeKey, AnalysisRow
-        ],
-        latest_es_indices_by_project_id_and_seq_type_and_stage: dict[
-            ProjectSeqTypeStageKey, AnalysisRow
-        ],
+        project_name: str,
+        sequencing_group_id: SequencingGroupInternalId,
+        output: str,
+        stage: str,
     ):
-        """Returns the latest grouped analyses for a project, sequencing type, and technology"""
-        if sequencing_technology == 'short-read':
-            latest_annotate_dataset_row = (
-                latest_annotate_dataset_by_project_id_and_seq_type.get(
-                    ProjectSeqTypeKey(project.id, sequencing_type)
-                )
-            )
-            latest_snv_es_index_row = (
-                latest_es_indices_by_project_id_and_seq_type_and_stage.get(
-                    ProjectSeqTypeStageKey(project.id, sequencing_type, 'MtToEs')
-                )
-            )
-            latest_sv_es_index_row = (
-                latest_es_indices_by_project_id_and_seq_type_and_stage.get(
-                    ProjectSeqTypeStageKey(
-                        project.id,
-                        sequencing_type,
-                        SV_INDEX_SEQ_TYPE_STAGE_MAP.get(sequencing_type),
-                    )
-                )
-            )
+        """Converts an analysis output gs path to a web report link"""
+        sg_id = sequencing_group_id_format(sequencing_group_id)
+        if 'main-web' in output:
+            url_base = 'https://main-web.populationgenomics.org.au'
         else:
-            latest_annotate_dataset_row = None
-            latest_snv_es_index_row = None
-            latest_sv_es_index_row = None
-        return (
-            latest_annotate_dataset_row,
-            latest_snv_es_index_row,
-            latest_sv_es_index_row,
-        )
+            url_base = 'https://test-web.populationgenomics.org.au'
 
-    # Main functions
-    async def get_project_insights_summary(
-        self, project_names: list[str], sequencing_types: list[str]
+        if stage == 'Stripy':
+            return f'{url_base}/{project_name}/stripy/{sg_id}.stripy.html'
+        if stage == 'MitoReport':
+            return f'{url_base}/{project_name}/mito/mitoreport-{sg_id}/index.html'
+        return None
+
+    def get_sg_web_report_links(
+        self,
+        sequencing_group_stripy_reports: dict[ProjectSeqGroupKey, StripyReportRow],
+        sequencing_group_mito_reports: dict[ProjectSeqGroupKey, AnalysisRow],
+        project: Project,
+        sequencing_group_id: SequencingGroupInternalId,
     ):
-        """Combines the results of the above queries into a response"""
-        projects = self.connection.get_and_check_access_to_projects_for_names(
-            project_names=project_names, allowed_roles=ReadAccessRoles
-        )
-        project_ids: list[ProjectId] = [project.id for project in projects]
+        """
+        Get the web report links for a sequencing group
+        """
+        report_links: dict[str, dict[str, Any]] = {}
+        report_key = ProjectSeqGroupKey(project.id, sequencing_group_id)
 
-        (
-            total_families_by_project_id_and_seq_fields,
-            total_participants_by_project_id_and_seq_fields,
-            total_samples_by_project_id_and_seq_fields,
-            total_sequencing_groups_by_project_id_and_seq_fields,
-            crams_by_project_id_and_seq_fields,
-            latest_annotate_dataset_by_project_id_and_seq_type,
-            latest_es_indices_by_project_id_and_seq_type_and_stage,  # keyed by (project_id, sequencing_type, stage)
-        ) = await asyncio.gather(
-            self._total_families_by_project_id_and_seq_fields(
-                project_ids, sequencing_types
-            ),
-            self._total_participants_by_project_id_and_seq_fields(
-                project_ids, sequencing_types
-            ),
-            self._total_samples_by_project_id_and_seq_fields(
-                project_ids, sequencing_types
-            ),
-            self._total_sequencing_groups_by_project_id_and_seq_fields(
-                project_ids, sequencing_types
-            ),
-            self._crams_by_project_id_and_seq_fields(project_ids, sequencing_types),
-            self._latest_annotate_dataset_by_project_id_and_seq_type(
-                project_ids, sequencing_types
-            ),
-            self._latest_es_indices_by_project_id_and_seq_type_and_stage(
-                project_ids,
-                sequencing_types,
-            ),
-        )
+        if stripy_report := sequencing_group_stripy_reports.get(report_key):
+            report_links['stripy'] = {
+                'url': self.get_report_url(
+                    project.name, sequencing_group_id, stripy_report.output, 'Stripy'
+                ),
+                'outliers_detected': stripy_report.outliers_detected,
+                'outlier_loci': (
+                    json.loads(stripy_report.outlier_loci)
+                    if stripy_report.outlier_loci
+                    else None
+                ),
+                'timestamp_completed': stripy_report.timestamp_completed.isoformat()
+                if stripy_report.timestamp_completed
+                else None,
+            }
 
-        # Get the sequencing groups for each of the analyses in the grouped analyses rows
-        analysis_sequencing_groups = await self.get_analysis_sequencing_groups(
-            list(latest_annotate_dataset_by_project_id_and_seq_type.values())
-            + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
-        )
+        if mito_report := sequencing_group_mito_reports.get(report_key):
+            report_links['mito'] = {
+                'url': self.get_report_url(
+                    project.name, sequencing_group_id, mito_report.output, 'MitoReport'
+                ),
+                'timestamp_completed': mito_report.timestamp_completed.isoformat()
+                if mito_report.timestamp_completed
+                else None,
+            }
 
-        sequencing_technologies = await SeqTechTable(self.connection).get()
-        # Get all possible combinations of the projects, sequencing types, and sequencing technologies
-        combinations = itertools.product(
-            projects, sequencing_types, sequencing_technologies
-        )
+        return report_links
 
-        response = []
-        for project, seq_type, seq_tech in combinations:
-            rowkey = ProjectSeqTypeTechnologyKey(project.id, seq_type, seq_tech)
-
-            total_sequencing_groups = (
-                total_sequencing_groups_by_project_id_and_seq_fields.get(rowkey, 0)
-            )
-            if total_sequencing_groups == 0:
-                continue
-
-            crams_in_project_with_sequencing_fields = (
-                crams_by_project_id_and_seq_fields.get(rowkey, [])
-            )
-            (
-                latest_annotate_dataset_row,
-                latest_snv_es_index_row,
-                latest_sv_es_index_row,
-            ) = self.get_latest_grouped_analyses(
-                project,
-                seq_type,
-                seq_tech,
-                latest_annotate_dataset_by_project_id_and_seq_type,
-                latest_es_indices_by_project_id_and_seq_type_and_stage,
-            )
-
-            total_families_by_project_id_and_seq_fields.setdefault(rowkey, 0)
-            total_participants_by_project_id_and_seq_fields.setdefault(rowkey, 0)
-            total_samples_by_project_id_and_seq_fields.setdefault(rowkey, 0)
-
-            response.append(
-                self.get_insights_summary_internal_row(
-                    summary_row_key=rowkey,
-                    project=project,
-                    total_families=total_families_by_project_id_and_seq_fields[rowkey],
-                    total_participants=total_participants_by_project_id_and_seq_fields[
-                        rowkey
-                    ],
-                    total_samples=total_samples_by_project_id_and_seq_fields[rowkey],
-                    total_sequencing_groups=total_sequencing_groups,
-                    crams=crams_in_project_with_sequencing_fields,
-                    analysis_sequencing_groups=analysis_sequencing_groups,
-                    latest_annotate_dataset_analysis=latest_annotate_dataset_row,
-                    latest_snv_es_index_analysis=latest_snv_es_index_row,
-                    latest_sv_es_index_analysis=latest_sv_es_index_row,
-                )
-            )
-
-        return response
-
-    async def get_project_insights_details(
-        self, project_names: list[str], sequencing_types: list[str]
-    ):
-        """Combines the results of the queries above into a response"""
-        projects = self.connection.get_and_check_access_to_projects_for_names(
-            project_names=project_names, allowed_roles=ReadAccessRoles
-        )
-        project_ids: list[ProjectId] = [project.id for project in projects]
-
-        (
-            sequencing_group_details_by_project_id_and_seq_fields,
-            crams_by_project_id_and_seq_fields,
-            latest_annotate_dataset_by_project_id_and_seq_type,
-            latest_es_indices_by_project_id_and_seq_type_and_stage,
-            sequencing_group_stripy_reports,
-            sequencing_group_mito_reports,
-        ) = await asyncio.gather(
-            self._sequencing_group_details_by_project_and_seq_fields(
-                project_ids, sequencing_types
-            ),
-            self._sg_crams_by_project_id_and_seq_fields(project_ids, sequencing_types),
-            self._latest_annotate_dataset_by_project_id_and_seq_type(
-                project_ids, sequencing_types
-            ),
-            self._latest_es_indices_by_project_id_and_seq_type_and_stage(
-                project_ids, sequencing_types
-            ),
-            self._details_stripy_reports(project_ids),
-            self._details_mito_reports(project_ids),
-        )
-        # Get the sequencing groups for each of the analyses in the grouped analyses rows
-        analysis_sequencing_groups = await self.get_analysis_sequencing_groups(
-            list(latest_annotate_dataset_by_project_id_and_seq_type.values())
-            + list(latest_es_indices_by_project_id_and_seq_type_and_stage.values())
-        )
-
-        sequencing_platforms = await SeqPlatformTable(self.connection).get()
-        sequencing_technologies = await SeqTechTable(self.connection).get()
-
-        # Get all possible combinations of the projects, sequencing types, platforms, and technologies
-        combinations = itertools.product(
-            projects, sequencing_types, sequencing_platforms, sequencing_technologies
-        )
-
-        response = []
-        for (
-            project,
-            seq_type,
-            seq_platform,
-            seq_tech,
-        ) in combinations:
-            details_rows: list[SequencingGroupDetailRow]
-            if not (
-                details_rows
-                := sequencing_group_details_by_project_id_and_seq_fields.get(
-                    (project.id, seq_type, seq_platform, seq_tech)
-                )
-            ):
-                continue
-
-            sequencing_groups_crams: dict[SequencingGroupInternalId, AnalysisRow] = (
-                crams_by_project_id_and_seq_fields.get(
-                    (project.id, seq_type, seq_tech), {}
-                )
-            )
-            (
-                latest_annotate_dataset_row,
-                latest_snv_es_index_row,
-                latest_sv_es_index_row,
-            ) = self.get_latest_grouped_analyses(
-                project,
-                seq_type,
-                seq_tech,
-                latest_annotate_dataset_by_project_id_and_seq_type,
-                latest_es_indices_by_project_id_and_seq_type_and_stage,
-            )
-
-            for details_row in details_rows:
-                if not details_row:
-                    continue
-                sg_id = details_row.sequencing_group_id
-                response.append(
-                    self.get_insights_details_internal_row(
-                        project=project,
-                        sequencing_type=seq_type,
-                        sequencing_platform=seq_platform,
-                        sequencing_technology=seq_tech,
-                        sequencing_group_details=details_row,
-                        sequencing_group_cram=sequencing_groups_crams.get(sg_id),
-                        analysis_sequencing_groups=analysis_sequencing_groups,
-                        latest_annotate_dataset_id=(
-                            latest_annotate_dataset_row.id
-                            if latest_annotate_dataset_row
-                            else None
-                        ),
-                        latest_snv_es_index_id=(
-                            latest_snv_es_index_row.id
-                            if latest_snv_es_index_row
-                            else None
-                        ),
-                        latest_sv_es_index_id=(
-                            latest_sv_es_index_row.id
-                            if latest_sv_es_index_row
-                            else None
-                        ),
-                        stripy_reports=sequencing_group_stripy_reports,
-                        mito_reports=sequencing_group_mito_reports,
-                    )
-                )
-
-        return response
+    def convert_to_external_ids(self, external_ids_value: str | list[str]) -> list[str]:
+        """Converts a string or list of strings to a list of strings"""
+        if isinstance(external_ids_value, str):
+            return [external_ids_value]
+        return external_ids_value

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -403,6 +403,8 @@ class ProjectInsightsDb(DbBase):
     async def _total_families_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             f.project,
@@ -416,7 +418,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             f.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             f.project,
             sg.type,
@@ -434,6 +436,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             p.project,
@@ -446,7 +449,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             p.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             p.project,
             sg.type,
@@ -464,6 +467,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             s.project,
@@ -475,7 +479,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             s.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             s.project,
             sg.type,
@@ -493,6 +497,8 @@ class ProjectInsightsDb(DbBase):
     async def _total_sequencing_groups_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
     ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             s.project,
@@ -504,7 +510,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sample s on s.id = sg.sample_id
         WHERE
             s.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         GROUP BY
             s.project,
             sg.type,
@@ -523,7 +529,8 @@ class ProjectInsightsDb(DbBase):
         project_ids: list[ProjectId],
         sequencing_types: list[SequencingType],
     ) -> dict[ProjectSeqTypeTechnologyKey, list[SequencingGroupInternalId]]:
-        # TODO check CRAM or cram
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -536,8 +543,8 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
         WHERE
             a.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
-            AND lower(a.type) = 'cram'
+            AND sg.type = ANY({sequencing_types_param})
+            AND a.type = 'cram'
             AND a.status = 'completed'
         GROUP BY
             a.project,
@@ -558,6 +565,8 @@ class ProjectInsightsDb(DbBase):
     ) -> dict[
         ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
     ]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -579,7 +588,7 @@ class ProjectInsightsDb(DbBase):
                     MAX(a.timestamp_completed) as max_timestamp
                 FROM analysis a
                 INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
-                WHERE LOWER(a.type) = 'cram'
+                WHERE a.type = 'cram'
                 AND a.status='completed'
                 AND a.project = ANY({project_ids})
                 GROUP BY asg.sequencing_group_id
@@ -587,8 +596,8 @@ class ProjectInsightsDb(DbBase):
             AND a.timestamp_completed = max_timestamps.max_timestamp
         WHERE
             a.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
-            AND a.type = 'CRAM'
+            AND sg.type = ANY({sequencing_types_param})
+            AND a.type = 'cram'
             AND a.status = 'completed';
         """
 
@@ -620,6 +629,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeKey, AnalysisRow]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -636,19 +646,19 @@ class ProjectInsightsDb(DbBase):
             FROM analysis
             WHERE
                 status = 'completed'
-                AND lower(type) = 'custom'
-                AND meta ->> 'stage' = 'AnnotateDataset'
-                AND meta ->> 'sequencing_type' = ANY({sequencing_types})
+                AND type = 'custom'
+                AND LOWER(meta ->> 'stage') = 'annotatedataset'
+                AND LOWER(meta ->> 'sequencing_type') = ANY({sequencing_types_param})
             GROUP BY project, meta ->> 'sequencing_type'
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
+        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
         WHERE
-            LOWER(a.type) = 'custom'
+            a.type = 'custom'
             AND a.status = 'completed'
             AND a.project = ANY({project_ids})
-            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types})
-            AND a.meta ->> 'stage' = 'AnnotateDataset';
+            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param})
+            AND LOWER(a.meta ->> 'stage') = 'annotatedataset';
         """
 
         _query_results = await (
@@ -668,6 +678,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeStageKey, AnalysisRow]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             a.project,
@@ -684,16 +695,16 @@ class ProjectInsightsDb(DbBase):
                 meta ->> 'sequencing_type' as sequencing_type,
                 meta ->> 'stage' as stage
             FROM analysis
-            WHERE LOWER(type) = 'es-index'
+            WHERE type = 'es-index'
             AND status = 'completed'
-            GROUP BY project, meta ->> 'sequencing_type', meta ->> 'stage'
+            GROUP BY project, sequencing_type, stage
         ) max_timestamps ON a.project = max_timestamps.project
         AND a.timestamp_completed = max_timestamps.max_timestamp
-        AND a.meta ->> 'sequencing_type' = max_timestamps.sequencing_type
-        AND a.meta ->> 'stage' = max_timestamps.stage
+        AND LOWER(a.meta ->> 'sequencing_type') = LOWER(max_timestamps.sequencing_type)
+        AND LOWER(a.meta ->> 'stage') = LOWER(max_timestamps.stage)
         WHERE
             a.project = ANY({project_ids})
-            AND a.meta ->> 'sequencing_type' = ANY({sequencing_types});
+            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param});
         """
 
         _query_results = await (
@@ -716,6 +727,7 @@ class ProjectInsightsDb(DbBase):
         self, project_ids: list[ProjectId], sequencing_types: list[str]
     ) -> dict[ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]]:
 
+        sequencing_types_param = [st.lower() for st in sequencing_types]
         _query = t"""
         SELECT
             f.project,
@@ -740,7 +752,7 @@ class ProjectInsightsDb(DbBase):
             LEFT JOIN sequencing_group sg on sg.sample_id = s.id
         WHERE
             f.project = ANY({project_ids})
-            AND sg.type = ANY({sequencing_types})
+            AND sg.type = ANY({sequencing_types_param})
         ORDER BY
             f.project,
             sg.type,
@@ -804,7 +816,7 @@ class ProjectInsightsDb(DbBase):
                 MAX(a.id) as max_analysis_id
             FROM analysis a
             LEFT JOIN analysis_sequencing_group asg on asg.analysis_id=a.id
-            WHERE LOWER(type) = 'web'
+            WHERE type = 'web'
             AND status = 'completed'
             AND project = ANY({project_ids})
             AND LOWER(meta ->> 'stage') = 'stripy'
@@ -850,7 +862,7 @@ class ProjectInsightsDb(DbBase):
                 MAX(a.id) as max_analysis_id
             FROM analysis a
             LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
-            WHERE LOWER(type) = 'web'
+            WHERE type = 'web'
             AND status = 'completed'
             AND project = ANY({project_ids})
             AND LOWER(meta ->> 'stage') = 'mitoreport'

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Any, NamedTuple
 
 from databases.interfaces import Record
-from psycopg import sql
 
 from db.python.enum_tables import SequencingPlatformTable as SeqPlatformTable
 from db.python.enum_tables import SequencingTechnologyTable as SeqTechTable

--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -312,7 +312,7 @@ class SequencingGroupLayer(BaseLayer):
                     'Upserting sequencing-groups with assays requires a sample_id to be set for every sequencing-group'
                 )
 
-            await slayer.upsert_assays(assays, open_transaction=False)
+            await slayer.upsert_assays(assays)
 
         to_insert = [sg for sg in sequencing_groups if not sg.id]
         to_update = []

--- a/db/python/tables/project_insights.py
+++ b/db/python/tables/project_insights.py
@@ -1,0 +1,575 @@
+# mypy: disable-error-code="attr-defined,arg-type,index,call-overload"
+from typing import Any
+
+from db.python.tables.base import DbBase
+from models.models.project import ProjectId
+from models.models.sequencing_group import SequencingGroupInternalId
+from models.utils.project_insights import (
+    AnalysisId,
+    AnalysisRow,
+    ProjectSeqGroupKey,
+    ProjectSeqTypeKey,
+    ProjectSeqTypeStageKey,
+    ProjectSeqTypeTechnologyKey,
+    ProjectSeqTypeTechnologyPlatformKey,
+    SequencingGroupDetailRow,
+    SequencingType,
+    StripyReportRow,
+)
+
+
+class ProjectInsightsDb(DbBase):
+    """
+    Db layer for project insights summary and details routes
+
+    Used to get the summary and details for the projects stats dashboard
+        - Summary
+            - One row per project, sequencing type, and technology (platform not needed for now)
+            - Total families, participants, samples, sequencing groups, CRAMs, and latest analyses
+        - Details
+            - One row per sequencing group
+            - Only for sequencing groups that belong to participants with a family record
+            - Gets web report links for each sequencing group
+            - Checks if the sequencing group is in the latest completed analyses
+                (CRAM, AnnotateDataset, SNV es-index, SV/gCNV es-index)
+            - Get the family, participant, sample, and sequencing group details
+    """
+
+    async def get_sequencing_groups_by_analysis_ids(
+        self, analysis_ids: list[AnalysisId]
+    ) -> dict[AnalysisId, list[SequencingGroupInternalId]]:
+        """Get sequencing groups for a list of analysis ids"""
+        if not analysis_ids:
+            return {}
+        _query = t"""
+        SELECT
+            analysis_id,
+            ARRAY_AGG(sequencing_group_id) as sequencing_group_ids
+        FROM analysis_sequencing_group
+        WHERE analysis_id = ANY({analysis_ids})
+        GROUP BY analysis_id;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
+        sequencing_groups_by_analysis_id: dict[
+            AnalysisId, list[SequencingGroupInternalId]
+        ] = {}
+        for row in _query_results:
+            sequencing_groups_by_analysis_id[row['analysis_id']] = row[
+                'sequencing_group_ids'
+            ]
+
+        return sequencing_groups_by_analysis_id
+
+    # Project Insights Summary queries
+    async def total_families_by_project_id_and_seq_fields(
+        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
+    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            f.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT f.id) as num_families
+        FROM
+            family f
+            LEFT JOIN family_participant fp ON f.id = fp.family_id
+            LEFT JOIN sample s ON fp.participant_id = s.participant_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            f.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+        GROUP BY
+            f.project,
+            sg.type,
+            sg.technology;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        return self.parse_project_seqtype_technology_keyed_rows(
+            _query_results, 'num_families'
+        )
+
+    async def total_participants_by_project_id_and_seq_fields(
+        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
+    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            p.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT p.id) as num_participants
+        FROM
+            participant p
+            LEFT JOIN sample s ON p.id = s.participant_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            p.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+        GROUP BY
+            p.project,
+            sg.type,
+            sg.technology;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        return self.parse_project_seqtype_technology_keyed_rows(
+            _query_results, 'num_participants'
+        )
+
+    async def total_samples_by_project_id_and_seq_fields(
+        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
+    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            s.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT s.id) as num_samples
+        FROM
+            sample s
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            s.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+        GROUP BY
+            s.project,
+            sg.type,
+            sg.technology;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
+        return self.parse_project_seqtype_technology_keyed_rows(
+            _query_results, 'num_samples'
+        )
+
+    async def total_sequencing_groups_by_project_id_and_seq_fields(
+        self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
+    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            s.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COUNT(DISTINCT sg.id) as num_sgs
+        FROM
+            sequencing_group sg
+            LEFT JOIN sample s on s.id = sg.sample_id
+        WHERE
+            s.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+        GROUP BY
+            s.project,
+            sg.type,
+            sg.technology;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        return self.parse_project_seqtype_technology_keyed_rows(
+            _query_results, 'num_sgs'
+        )
+
+    async def crams_by_project_id_and_seq_fields(
+        self,
+        project_ids: list[ProjectId],
+        sequencing_types: list[SequencingType],
+    ) -> dict[ProjectSeqTypeTechnologyKey, list[SequencingGroupInternalId]]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            a.project,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            ARRAY_AGG(DISTINCT asg.sequencing_group_id) as sequencing_group_ids
+        FROM
+            analysis a
+            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
+        WHERE
+            a.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+            AND a.type = 'cram'
+            AND a.status = 'completed'
+        GROUP BY
+            a.project,
+            sg.type,
+            sg.technology;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
+        return self.parse_project_seqtype_technology_keyed_rows(
+            _query_results, 'sequencing_group_ids'
+        )
+
+    async def sg_crams_by_project_id_and_seq_fields(
+        self, project_ids: list[ProjectId], sequencing_types: list[str]
+    ) -> dict[
+        ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
+    ]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            a.project,
+            a.id as analysis_id,
+            sg.id as sequencing_group_id,
+            sg.type as sequencing_type,
+            sg.technology as sequencing_technology,
+            COALESCE(a.output, ao.output, of.path) as output,
+            a.timestamp_completed
+        FROM
+            analysis a
+            LEFT JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+            LEFT JOIN analysis_outputs ao ON a.id = ao.analysis_id
+            LEFT JOIN output_file of ON ao.file_id = of.id
+            LEFT JOIN sequencing_group sg ON sg.id = asg.sequencing_group_id
+            INNER JOIN (
+                SELECT
+                    asg.sequencing_group_id,
+                    MAX(a.timestamp_completed) as max_timestamp
+                FROM analysis a
+                INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+                WHERE a.type = 'cram'
+                AND a.status='completed'
+                AND a.project = ANY({project_ids})
+                GROUP BY asg.sequencing_group_id
+            ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
+            AND a.timestamp_completed = max_timestamps.max_timestamp
+        WHERE
+            a.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+            AND a.type = 'cram'
+            AND a.status = 'completed';
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+
+        cram_timestamps_by_project_id_and_seq_fields: dict[
+            ProjectSeqTypeTechnologyKey, dict[SequencingGroupInternalId, AnalysisRow]
+        ] = {}
+        for row in _query_results:
+            key = ProjectSeqTypeTechnologyKey(
+                row['project'],
+                row['sequencing_type'],
+                row['sequencing_technology'],
+            )
+            sg_id = row['sequencing_group_id']
+            cram_row = AnalysisRow(
+                id=row['analysis_id'],
+                output=row['output'],
+                timestamp_completed=row['timestamp_completed'],
+            )
+            if key not in cram_timestamps_by_project_id_and_seq_fields:
+                cram_timestamps_by_project_id_and_seq_fields[key] = {}
+            cram_timestamps_by_project_id_and_seq_fields[key][sg_id] = cram_row
+        return cram_timestamps_by_project_id_and_seq_fields
+
+    async def latest_annotate_dataset_by_project_id_and_seq_type(
+        self, project_ids: list[ProjectId], sequencing_types: list[str]
+    ) -> dict[ProjectSeqTypeKey, AnalysisRow]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            a.project,
+            a.meta ->> 'sequencing_type' as sequencing_type,
+            a.id,
+            a.output,
+            a.timestamp_completed
+        FROM analysis a
+        INNER JOIN (
+            SELECT
+                project,
+                MAX(timestamp_completed) as max_timestamp,
+                LOWER(meta ->> 'sequencing_type') as sequencing_type
+            FROM analysis
+            WHERE
+                status = 'completed'
+                AND type = 'custom'
+                AND LOWER(meta ->> 'stage') = 'annotatedataset'
+                AND LOWER(meta ->> 'sequencing_type') = ANY({sequencing_types_param})
+            GROUP BY project, LOWER(meta ->> 'sequencing_type')
+        ) max_timestamps ON a.project = max_timestamps.project
+        AND a.timestamp_completed = max_timestamps.max_timestamp
+        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
+        WHERE
+            a.type = 'custom'
+            AND a.status = 'completed'
+            AND a.project = ANY({project_ids})
+            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param})
+            AND LOWER(a.meta ->> 'stage') = 'annotatedataset';
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        latest_annotate_dataset_by_project_id_and_seq_type: dict[
+            ProjectSeqTypeKey, AnalysisRow
+        ] = {}
+        for row in _query_results:
+            key = ProjectSeqTypeKey(row['project'], row['sequencing_type'])
+            latest_annotate_dataset_by_project_id_and_seq_type[key] = (
+                self.get_analysis_row(row)
+            )
+        return latest_annotate_dataset_by_project_id_and_seq_type
+
+    async def latest_es_indices_by_project_id_and_seq_type_and_stage(
+        self, project_ids: list[ProjectId], sequencing_types: list[str]
+    ) -> dict[ProjectSeqTypeStageKey, AnalysisRow]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            a.project,
+            a.meta ->> 'sequencing_type' as sequencing_type,
+            a.id,
+            a.meta ->> 'stage' as stage,
+            a.output,
+            a.timestamp_completed
+        FROM analysis a
+        INNER JOIN (
+            SELECT
+                project,
+                MAX(timestamp_completed) as max_timestamp,
+                LOWER(meta ->> 'sequencing_type') as sequencing_type,
+                LOWER(meta ->> 'stage') as stage
+            FROM analysis
+            WHERE type = 'es-index'
+            AND status = 'completed'
+            GROUP BY project, LOWER(meta ->> 'sequencing_type'), LOWER(meta ->> 'stage')
+        ) max_timestamps ON a.project = max_timestamps.project
+        AND a.timestamp_completed = max_timestamps.max_timestamp
+        AND LOWER(a.meta ->> 'sequencing_type') = max_timestamps.sequencing_type
+        AND LOWER(a.meta ->> 'stage') = max_timestamps.stage
+        WHERE
+            a.project = ANY({project_ids})
+            AND LOWER(a.meta ->> 'sequencing_type') = ANY({sequencing_types_param});
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        latest_es_indices_by_project_id_and_seq_type_and_stage: dict[
+            ProjectSeqTypeStageKey, AnalysisRow
+        ] = {}
+        for row in _query_results:
+            key = ProjectSeqTypeStageKey(
+                row['project'], row['sequencing_type'], row['stage']
+            )
+            latest_es_indices_by_project_id_and_seq_type_and_stage[key] = (
+                self.get_analysis_row(row)
+            )
+        return latest_es_indices_by_project_id_and_seq_type_and_stage
+
+    # Project Insights details queries
+    async def sequencing_group_details_by_project_and_seq_fields(
+        self, project_ids: list[ProjectId], sequencing_types: list[str]
+    ) -> dict[ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]]:
+
+        sequencing_types_param = [st.lower() for st in sequencing_types]
+        _query = t"""
+        SELECT
+            f.project,
+            sg.type as sequencing_type,
+            sg.platform as sequencing_platform,
+            sg.technology as sequencing_technology,
+            s.type as sample_type,
+            f.id as family_id,
+            fext.external_id as family_external_id,
+            fp.participant_id as participant_id,
+            pext.external_id as participant_external_id,
+            s.id as sample_id,
+            sext.external_id as sample_external_ids,
+            sg.id as sequencing_group_id
+        FROM
+            family f
+            LEFT JOIN family_participant fp ON f.id = fp.family_id
+            LEFT JOIN family_external_id fext ON f.id = fext.family_id
+            LEFT JOIN participant_external_id pext ON fp.participant_id = pext.participant_id
+            LEFT JOIN sample s ON fp.participant_id = s.participant_id
+            LEFT JOIN sample_external_id sext ON s.id = sext.sample_id
+            LEFT JOIN sequencing_group sg on sg.sample_id = s.id
+        WHERE
+            f.project = ANY({project_ids})
+            AND sg.type = ANY({sequencing_types_param})
+        ORDER BY
+            f.project,
+            sg.type,
+            sg.platform,
+            sg.technology,
+            s.type,
+            f.id,
+            fp.participant_id,
+            sg.id;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        sequencing_group_details_by_project_id_and_seq_fields: dict[
+            ProjectSeqTypeTechnologyPlatformKey, list[SequencingGroupDetailRow]
+        ] = {}
+        for row in _query_results:
+            key = ProjectSeqTypeTechnologyPlatformKey(
+                row['project'],
+                row['sequencing_type'],
+                row['sequencing_platform'],
+                row['sequencing_technology'],
+            )
+            if key not in sequencing_group_details_by_project_id_and_seq_fields:
+                sequencing_group_details_by_project_id_and_seq_fields[key] = []
+            sequencing_group_details_by_project_id_and_seq_fields[key].append(
+                SequencingGroupDetailRow(
+                    family_id=row['family_id'],
+                    family_external_id=row['family_external_id'],
+                    participant_id=row['participant_id'],
+                    participant_external_id=row['participant_external_id'],
+                    sample_id=row['sample_id'],
+                    sample_external_ids=row['sample_external_ids'],
+                    sample_type=row['sample_type'],
+                    sequencing_group_id=row['sequencing_group_id'],
+                )
+            )
+
+        return sequencing_group_details_by_project_id_and_seq_fields
+
+    async def details_stripy_reports(
+        self, project_ids: list[ProjectId]
+    ) -> dict[ProjectSeqGroupKey, StripyReportRow]:
+        """Get stripy web report links"""
+        _query = t"""
+        SELECT
+            a.project,
+            a.id,
+            coalesce(a.output, ao.output, of.path) as output,
+            a.timestamp_completed,
+            asg.sequencing_group_id,
+            a.meta -> 'outliers_detected' as outliers_detected,
+            a.meta -> 'outlier_loci' as outlier_loci
+        FROM analysis a
+        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
+        LEFT JOIN output_file of on of.id = ao.file_id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+        INNER JOIN (
+            SELECT
+                asg.sequencing_group_id,
+                MAX(a.id) as max_analysis_id
+            FROM analysis a
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+            WHERE type = 'web'
+            AND status = 'completed'
+            AND project = ANY({project_ids})
+            AND LOWER(meta ->> 'stage') = 'stripy'
+            GROUP BY asg.sequencing_group_id
+        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        stripy_reports: dict[ProjectSeqGroupKey, StripyReportRow] = {}
+        for row in _query_results:
+            key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])
+            stripy_reports[key] = StripyReportRow(
+                id=row['id'],
+                output=row['output'],
+                outliers_detected=row['outliers_detected'],
+                outlier_loci=row['outlier_loci'],
+                timestamp_completed=row['timestamp_completed'],
+            )
+
+        return stripy_reports
+
+    async def details_mito_reports(
+        self, project_ids: list[ProjectId]
+    ) -> dict[ProjectSeqGroupKey, AnalysisRow]:
+        """Get mito web report links"""
+
+        _query = t"""
+        SELECT
+            a.project,
+            a.id,
+            coalesce(a.output, ao.output, out_file.path) as output,
+            a.timestamp_completed,
+            asg.sequencing_group_id
+        FROM analysis a
+        LEFT JOIN analysis_outputs ao on a.id = ao.analysis_id
+        LEFT JOIN output_file out_file on out_file.id = ao.file_id
+        LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+        INNER JOIN (
+            SELECT
+                asg.sequencing_group_id,
+                MAX(a.id) as max_analysis_id
+            FROM analysis a
+            LEFT JOIN analysis_sequencing_group asg on asg.analysis_id = a.id
+            WHERE type = 'web'
+            AND status = 'completed'
+            AND project = ANY({project_ids})
+            AND LOWER(meta ->> 'stage') = 'mitoreport'
+            GROUP BY asg.sequencing_group_id
+        ) latest_analysis ON a.id = latest_analysis.max_analysis_id;
+        """
+
+        _query_results = await (
+            await self.connection.pg_connection.execute(_query)
+        ).fetchall()
+        mito_reports: dict[ProjectSeqGroupKey, AnalysisRow] = {}
+        for row in _query_results:
+            key = ProjectSeqGroupKey(row['project'], row['sequencing_group_id'])
+            mito_reports[key] = self.get_analysis_row(row)
+
+        return mito_reports
+
+    # Helper functions
+    def get_analysis_row(self, row: dict[Any, Any]) -> AnalysisRow:
+        """Parse a table row returned by fetch_all into an AnalysisRow object"""
+        return AnalysisRow(
+            id=row['id'],
+            output=row['output'],
+            timestamp_completed=row['timestamp_completed'],
+        )
+
+    def parse_project_seqtype_technology_keyed_rows(
+        self, rows: list[dict[Any, Any]], value_field: str
+    ) -> dict[ProjectSeqTypeTechnologyKey, Any]:
+        """
+        Parse rows that are keyed by project, sequencing type, and sequencing technology
+        """
+        parsed_rows: dict[
+            ProjectSeqTypeTechnologyKey,
+            dict[str, Any] | list[SequencingGroupInternalId],
+        ] = {}
+        for row in rows:
+            key = ProjectSeqTypeTechnologyKey(
+                row['project'],
+                row['sequencing_type'],
+                row['sequencing_technology'],
+            )
+            parsed_rows[key] = row.get(value_field)
+        return parsed_rows

--- a/models/utils/project_insights.py
+++ b/models/utils/project_insights.py
@@ -4,12 +4,14 @@ from typing import NamedTuple
 from models.models import ProjectId
 from models.models.sequencing_group import SequencingGroupInternalId
 
+
 AnalysisId = int
 SequencingType = str
 SequencingTechnology = str
 SequencingPlatform = str
 
 # util data models for project insights queries
+
 
 # This layer has a lot of different queries, so we'll define some namedtuples to help us keep track of the keys
 class ProjectSeqTypeKey(NamedTuple):  # noqa: D101

--- a/models/utils/project_insights.py
+++ b/models/utils/project_insights.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from typing import NamedTuple
+
+from models.models import ProjectId
+from models.models.sequencing_group import SequencingGroupInternalId
+
+AnalysisId = int
+SequencingType = str
+SequencingTechnology = str
+SequencingPlatform = str
+
+# util data models for project insights queries
+
+# This layer has a lot of different queries, so we'll define some namedtuples to help us keep track of the keys
+class ProjectSeqTypeKey(NamedTuple):  # noqa: D101
+    project: ProjectId
+    sequencing_type: SequencingType
+
+
+class ProjectSeqTypeTechnologyKey(NamedTuple):  # noqa: D101
+    project: ProjectId
+    sequencing_type: SequencingType
+    sequencing_technology: SequencingTechnology
+
+
+class ProjectSeqTypeTechnologyPlatformKey(NamedTuple):  # noqa: D101
+    project: ProjectId
+    sequencing_type: SequencingType
+    sequencing_technology: SequencingTechnology
+    sequencing_platform: SequencingPlatform
+
+
+class ProjectSeqTypeStageKey(NamedTuple):  # noqa: D101
+    project: ProjectId
+    sequencing_type: SequencingType
+    stage: str
+
+
+class ProjectSeqGroupKey(NamedTuple):  # noqa: D101
+    project: ProjectId
+    sequencing_group_id: SequencingGroupInternalId
+
+
+# Namedtuples for the rows returned by the queries
+class AnalysisRow(NamedTuple):  # noqa: D101
+    id: AnalysisId
+    output: str
+    timestamp_completed: datetime
+
+
+class SequencingGroupDetailRow(NamedTuple):  # noqa: D101
+    family_id: int
+    family_external_id: str
+    participant_id: int
+    participant_external_id: str
+    sample_id: int
+    sample_external_ids: list[str]
+    sample_type: str
+    sequencing_group_id: SequencingGroupInternalId
+
+
+class StripyReportRow(NamedTuple):  # noqa: D101
+    id: AnalysisId
+    output: str
+    outliers_detected: bool
+    outlier_loci: str
+    timestamp_completed: datetime

--- a/pytest.toml
+++ b/pytest.toml
@@ -15,7 +15,8 @@ python_files = [
     "test_external_id.py",
     "test_comment.py",
     "test_meta_table.py",
-    "test_enum_tables.py"
+    "test_enum_tables.py",
+    "test_project_insights.py"
 ]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/test/test_project_insights.py
+++ b/test/test_project_insights.py
@@ -1,3 +1,6 @@
+import pytest
+
+from db.python.connect import Connection
 from db.python.layers import (
     AssayLayer,
     ParticipantLayer,
@@ -12,7 +15,6 @@ from models.models import (
     SampleUpsertInternal,
     SequencingGroupUpsertInternal,
 )
-from test.testbase import DbIsolatedTest, run_as_sync
 
 
 default_assay_meta = {
@@ -70,20 +72,22 @@ def get_test_participant():
     )
 
 
-class TestProjectInsights(DbIsolatedTest):
+class TestProjectInsights:
     """Test project insights class containing project insights endpoints"""
 
     maxDiff = None
 
-    @run_as_sync
-    async def setUp(self) -> None:
-        super().setUp()
-        self.partl = ParticipantLayer(self.connection)
-        self.pil = ProjectInsightsLayer(self.connection)
-        self.sampl = SampleLayer(self.connection)
-        self.seql = AssayLayer(self.connection)
+    @pytest.fixture(autouse=True)
+    async def set_up(self, connection_with_project: Connection) -> None:
+        self.partl = ParticipantLayer(connection_with_project)
+        self.pil = ProjectInsightsLayer(connection_with_project)
+        self.sampl = SampleLayer(connection_with_project)
+        self.seql = AssayLayer(connection_with_project)
+        self.project_name = connection_with_project.project.name
+        self.project_id = connection_with_project.project_id
 
-    @run_as_sync
+    @pytest.mark.project_roles(['writer'])
+    @pytest.mark.asyncio
     async def test_project_insights_summary(self):
         """Test getting the summaries for all available projects"""
 
@@ -110,9 +114,10 @@ class TestProjectInsights(DbIsolatedTest):
             ),
         ]
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
-    @run_as_sync
+    @pytest.mark.project_roles(['writer'])
+    @pytest.mark.asyncio
     async def test_project_insights_details(self):
         """Test getting the details for all available projects"""
 


### PR DESCRIPTION
This PR refactor the project insight-related model, business, and DB access logic into separate files. 
The previous implementation had all the model, business logic and DB querying on the same Python file. 
It is now separated into 3 different files (following the same pattern used in other entities in Metamist). 
No logic changes are introduced.

Tested the basic functionality of `project-insights-details` and `project-insights-summary` routes manually.
Also, the two tests in the `test_project_insights.py` pass. 