### PR TITLE
fixed analysis outputs duplication

### DIFF
--- a/db/migrations/20260120061420_create_tables.sql
+++ b/db/migrations/20260120061420_create_tables.sql
@@ -52,14 +52,6 @@ CREATE TABLE analysis_outputs (
     )
 );
 
-CREATE UNIQUE INDEX uq_analysis_outputs_file
-    ON analysis_outputs (analysis_id, file_id)
-    WHERE file_id IS NOT NULL;
-
-CREATE UNIQUE INDEX uq_analysis_outputs_output
-    ON analysis_outputs (analysis_id, output)
-    WHERE output IS NOT NULL;
-
 
 
 -- analysis_runner table

--- a/db/migrations/20260120061420_create_tables.sql
+++ b/db/migrations/20260120061420_create_tables.sql
@@ -52,6 +52,14 @@ CREATE TABLE analysis_outputs (
     )
 );
 
+CREATE UNIQUE INDEX uq_analysis_outputs_file
+    ON analysis_outputs (analysis_id, file_id)
+    WHERE file_id IS NOT NULL;
+
+CREATE UNIQUE INDEX uq_analysis_outputs_output
+    ON analysis_outputs (analysis_id, output)
+    WHERE output IS NOT NULL;
+
 
 
 -- analysis_runner table

--- a/db/migrations/20260120061617_add_indexes_and_fks.sql
+++ b/db/migrations/20260120061617_add_indexes_and_fks.sql
@@ -21,8 +21,8 @@ ALTER TABLE analysis_cohort ADD CONSTRAINT fk_analysis_cohort_analysis_id FOREIG
 ALTER TABLE analysis_cohort ADD CONSTRAINT fk_analysis_cohort_audit_log_id FOREIGN KEY (audit_log_id) REFERENCES audit_log(id);
 
 
-CREATE UNIQUE INDEX idx_analysis_outputs_analysis_file ON analysis_outputs(analysis_id, file_id, json_structure);
-CREATE UNIQUE INDEX idx_analysis_outputs_analysis_output ON analysis_outputs(analysis_id, output, json_structure);
+CREATE UNIQUE INDEX idx_analysis_outputs_analysis_file ON analysis_outputs(analysis_id, file_id, COALESCE(json_structure, ''));
+CREATE UNIQUE INDEX idx_analysis_outputs_analysis_output ON analysis_outputs(analysis_id, output, COALESCE(json_structure, ''));
 CREATE INDEX idx_analysis_outputs_file_id ON analysis_outputs(file_id);
 CREATE INDEX idx_analysis_outputs_audit_log_id ON analysis_outputs(audit_log_id);
 

--- a/db/python/tables/output_file.py
+++ b/db/python/tables/output_file.py
@@ -3,7 +3,6 @@ from urllib.parse import urlparse
 
 from fastapi.concurrency import run_in_threadpool
 from google.cloud.storage import Blob
-from psycopg import sql
 
 from db.python.tables.base import DbBase
 from models.models.output_file import OutputFileInternal, RecursiveDict

--- a/db/python/tables/output_file.py
+++ b/db/python/tables/output_file.py
@@ -142,10 +142,15 @@ class OutputFileTable(DbBase):
         Create analysis files from JSON
         """
         files = await self.find_files_from_dict(json_dict=json_dict)  # type: ignore [arg-type]
-        file_ids: list[int] = []
-        outputs: list[str] = []
 
         async with self.connection.transaction():
+            # Delete all existing analysis_outputs for this analysis
+            # before re-inserting the current set. This ensures idempotency
+            # and correctly handles key renames, primary/secondary moves, etc.
+            await self.connection.pg_connection.execute(
+                t'DELETE FROM analysis_outputs WHERE analysis_id = {analysis_id}'
+            )
+
             if 'main_files' in files:
                 for primary_file in files['main_files']:
                     parent_file_id = await self.create_or_update_output_file(
@@ -183,46 +188,6 @@ class OutputFileTable(DbBase):
                                         else secondary_file['basename']
                                     ),
                                 )
-                                if secondary_file_id:
-                                    file_ids.append(secondary_file_id)
-                                else:
-                                    outputs.append(secondary_file['basename'])
-                    if parent_file_id:
-                        file_ids.append(parent_file_id)
-                    else:
-                        outputs.append(primary_file['basename'])
-
-            # check that only the files in this json_dict should be in the analysis. Remove what isn't in this dict.
-            if not file_ids and not outputs:
-                # If both file_ids and outputs are empty, don't execute the query
-                pass
-
-            # Delete analysis outputs not in the current set of file_ids or outputs
-            update_analysis_outputs = t"""
-                DELETE FROM analysis_outputs
-                WHERE analysis_id = {analysis_id}"""
-
-            # Add the OR condition to include file_ids or outputs
-            conditions = []
-
-            # Add file_id condition if file_ids is not empty
-            if file_ids:
-                # Add file_ids to query parameters
-                conditions.append(t'file_id IS NOT NULL AND file_id <> ALL({file_ids})')
-
-            # Add output condition if outputs is not empty
-            if outputs:
-                # Add outputs to query parameters
-                conditions.append(t'output IS NOT NULL AND output <> ALL({outputs})')
-
-            # Join the conditions with OR since either can be valid
-            if conditions:
-                update_analysis_outputs += (
-                    t' AND ({sql.SQL(" OR ").join(conditions):q})'
-                )
-
-            # Execute the query only if either file_ids or outputs were provided
-            await self.connection.pg_connection.execute(update_analysis_outputs)
 
     async def find_files_from_dict(
         self,


### PR DESCRIPTION
## Problem
The analysis_outputs table had no unique constraints handling NULL values for `json_structure`, which caused two bugs:

`ON CONFLICT DO NOTHING` was a no-op — Since there was no unique constraint to conflict on, every `INSERT` always succeeded. Calling update multiple times on the same analysis created duplicate rows.

Stale rows persisted on key renames/moves — The cleanup `DELETE` logic only checked whether a `file_id` was still referenced, not whether its `json_structure` path had changed. Renaming a key (e.g. "vcf" → "variant_calls") or moving a file between primary/secondary left ghost rows with the old `json_structure`.

## Changes
### Schema
- Added UNIQUE partial index on `(analysis_id, file_id)` where `file_id IS NOT NULL`
- Added UNIQUE partial index on `(analysis_id, output)` where `output IS NOT NULL`

### Application Logic
- Replaced the insert-then-selective-delete approach with delete-all-then-insert within the existing transaction
- The old approach built up `file_ids` and `outputs` lists, then ran a complex `DELETE ... WHERE file_id <> ALL(...)` query that couldn't detect `json_structure` changes
- The new approach simply deletes all `analysis_outputs` rows for the analysis first, then re-inserts - this is atomic (wrapped in a transaction), idempotent, and correctly handles all edge cases

Scenario | Before | After
-- | -- | --
Same update called twice | Duplicate rows | Idempotent ✅
Rename a JSON key | Old + new rows coexist | Only new row ✅
Move primary → secondary | Old row persists | Clean update ✅
Move secondary → primary | Old row persists | Clean update ✅
Remove a file | ✅ Already worked | ✅ Still works
Add a file | Duplicates on retry | Idempotent ✅