### PR TITLE
Set 1003 generic filter text case insensitive comparison

### DIFF
--- a/db/python/filters/generic.py
+++ b/db/python/filters/generic.py
@@ -124,7 +124,7 @@ class GenericFilter[T](SMBase):
         # CASEFOLD(value) and the column query is also wrapped in CASEFOLD
         original_gf: GenericFilter[T] = self
         gf: GenericFilter[T] = self.copy_with_casefolded_strings()
-        value_type = infer_pg_type_from_filter(self)
+        value_type = self.infer_pg_type_from_filter()
 
         original_column_query = (
             column
@@ -242,6 +242,56 @@ class GenericFilter[T](SMBase):
 
         return self.transform(casefold_if_str, map_array_values=True)
 
+    def infer_pg_type_from_filter(self) -> str | None:
+        """
+        Infer the SQL cast type from actual values in the filter
+
+        In order for these values to work you could just check the
+        type of the first non-None value, but to be thorough we will enforce
+        that all values in the filter (excluding isnull) are of the same type.
+
+        This does require trust in the user to apply an appropriate filter
+        for the column key value type e.g. for the json column "meta" and a row value {'favnum': int}
+        We hope that a filter would be appropriately applied like
+        meta={'favnum': GenericFilter(eq=5)} <- we'll infer the type as integer from the value 5
+        and not
+        meta={'favnum': GenericFilter(eq='five')} <- we'll infer the type as text
+
+        If the casting of any value fails, the database will raise an error.
+
+        If the type cannot be inferred, None is returned
+        """
+        # Collect all non-None comparison values
+        sample_values: list[Any] = []
+        for k, v in self.__dict__.items():
+            if k == 'isnull' or v is None:
+                continue
+            if isinstance(v, list):
+                sample_values.extend(v)
+            else:
+                sample_values.append(v)
+
+        # Infer type non-None values
+        cast_types: set[str] = set()
+        for v in sample_values:
+            if isinstance(v, bool):
+                cast_types.add('bool')
+            elif isinstance(v, (int, float)):
+                cast_types.add('numeric')
+            elif isinstance(v, Enum):
+                cast_types.add('enum')
+            elif isinstance(v, (datetime.datetime, datetime.date)):
+                cast_types.add('timestamp')
+            elif isinstance(v, str):
+                cast_types.add('text')
+
+        if len(cast_types) > 1:
+            raise ValueError(
+                f'Mixed types in filter values: {cast_types}. All values in a filter must be of the same type.'
+            )
+
+        return cast_types.pop() if cast_types else None
+
 
 GenericMetaFilter = dict[str, GenericFilter[Any]]
 
@@ -346,57 +396,6 @@ class GenericFilterModel:
         return sql.SQL(' AND ').join(filters_rm_none)
 
 
-def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str | None:
-    """
-    Infer the SQL cast type from actual values in the filter
-
-    In order for these values to work you could just check the
-    type of the first non-None value, but to be thorough we will enforce
-    that all values in the filter (excluding isnull) are of the same type.
-
-    This does require trust in the user to apply an appropriate filter
-    for the column key value type e.g. for the json column "meta" and a row value {'favnum': int}
-    We hope that a filter would be appropriately applied like
-    meta={'favnum': GenericFilter(eq=5)} <- we'll infer the type as integer from the value 5
-    and not
-    meta={'favnum': GenericFilter(eq='five')} <- we'll infer the type as text
-
-    If the casting of any value fails, the database will raise an error.
-
-    If the type cannot be inferred, None is returned
-    """
-    # Collect all non-None comparison values
-    sample_values: list[Any] = []
-    for k, v in value.__dict__.items():
-        if k == 'isnull' or v is None:
-            continue
-        if isinstance(v, list):
-            sample_values.extend(v)
-        else:
-            sample_values.append(v)
-
-    # Infer type non-None values
-    cast_types: set[str] = set()
-    for v in sample_values:
-        if isinstance(v, bool):
-            cast_types.add('bool')
-        elif isinstance(v, (int, float)):
-            cast_types.add('numeric')
-        elif isinstance(v, Enum):
-            cast_types.add('enum')
-        elif isinstance(v, (datetime.datetime, datetime.date)):
-            cast_types.add('timestamp')
-        elif isinstance(v, str):
-            cast_types.add('text')
-
-    if len(cast_types) > 1:
-        raise ValueError(
-            f'Mixed types in filter values: {cast_types}. All values in a filter must be of the same type.'
-        )
-
-    return cast_types.pop() if cast_types else None
-
-
 def prepare_query_from_dict_field(
     filter_: dict[str, Any],
     column_name: str | Template,
@@ -420,7 +419,22 @@ def prepare_query_from_dict_field(
 
         # In the case where an 'isnull' filter is applied and the type
         # cannot be inferred, we will default to text
-        pg_type = infer_pg_type_from_filter(value) or 'text'
+        pg_type = value.infer_pg_type_from_filter() or 'text'
+
+        if pg_type == 'enum':
+            raise ValueError(
+                f'Unsupported type "enum" for dict field filter. '
+                f'Enum types are not supported in dict field filters because the database cannot infer the correct enum type to cast to.'
+            )
+
+        # Validate that the pg_type is supported for dict field queries
+        # The `returning {pg_type}` clause only works with numeric, bool, or text
+        supported_types = {'numeric', 'bool', 'text'}
+        if pg_type not in supported_types:
+            raise ValueError(
+                f'Unsupported type {pg_type!r} for dict field filter. '
+                f'Supported types are: {", ".join(sorted(supported_types))}'
+            )
 
         _inner_query = value.to_sql(t"json_value(a, '$' returning {pg_type:i})")
 

--- a/db/python/filters/generic.py
+++ b/db/python/filters/generic.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
 from collections.abc import Callable, Sequence
-from datetime import date, datetime
 from enum import Enum
 from string.templatelib import Template
 from typing import Any, TypeVar
@@ -102,7 +101,7 @@ class GenericFilter[T](SMBase):
         """Override to ensure we can hash this object"""
         return hash(self.get_hashable_value())
 
-    def to_sql(self, column: str | Template) -> Template | None:
+    def to_sql(self, column: str | Template) -> Template | None:  # noqa: PLR0912
         """
         Convert to SQL, and avoid SQL injection.
 
@@ -232,7 +231,7 @@ class GenericFilter[T](SMBase):
             isnull=self.isnull,
         )
 
-    def copy_with_casefolded_strings(self) -> 'GenericFilter[T]':
+    def copy_with_casefolded_strings(self) -> GenericFilter[T]:
         # Use transform to apply casefold to all string values in the filter
         def casefold_if_str(value: Any) -> Any:
             # StrEnum return True to isinstance(value, str) but we don't
@@ -385,7 +384,7 @@ def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str | None:
             cast_types.add('numeric')
         elif isinstance(v, Enum):
             cast_types.add('enum')
-        elif isinstance(v, (datetime, date)):
+        elif isinstance(v, (datetime.datetime, datetime.date)):
             cast_types.add('timestamp')
         elif isinstance(v, str):
             cast_types.add('text')

--- a/db/python/filters/generic.py
+++ b/db/python/filters/generic.py
@@ -101,7 +101,7 @@ class GenericFilter[T](SMBase):
         """Override to ensure we can hash this object"""
         return hash(self.get_hashable_value())
 
-    def to_sql(self, column: str | Template) -> Template | None:  # noqa: PLR0912
+    def to_sql(self, column: str | Template) -> Template | None:
         """
         Convert to SQL, and avoid SQL injection.
 
@@ -122,9 +122,17 @@ class GenericFilter[T](SMBase):
         # We are going to do a check on all of the filter fields
         # if their type is str, make sure that the value is set to
         # CASEFOLD(value) and the column query is also wrapped in CASEFOLD
-        original_gf: GenericFilter[T] = self
-        gf: GenericFilter[T] = self.copy_with_casefolded_strings()
-        value_type = self.infer_pg_type_from_filter()
+        pg_type = self.infer_pg_type_from_filter()
+
+        def wrap_val(val: T | str):
+            if pg_type == 'text':
+                return t'CASEFOLD({val})'
+            return t'{val}'
+
+        def wrap_val_list(val_list: list[T]):
+            if pg_type == 'text':
+                return t'(SELECT CASEFOLD(val) FROM unnest({val_list}::text[]) AS val)'
+            return t'{val_list}'
 
         original_column_query = (
             column
@@ -134,66 +142,59 @@ class GenericFilter[T](SMBase):
 
         # Add CASEFOLD to the column query if any of the fields are strings
         column_query = original_column_query
-        if value_type == 'text':
+        if pg_type == 'text':
             column_query = t'CASEFOLD({original_column_query:q})'
 
-        if gf.eq is not None:
-            if isinstance(gf.eq, sql.Composable):
-                filters.append(t'{column_query:q} = {gf.eq:q}')
-            else:
-                filters.append(t'{column_query:q} = {gf.eq}')
-        if gf.neq is not None:
-            if isinstance(gf.neq, sql.Composable):
-                filters.append(t'{column_query:q} IS DISTINCT FROM {gf.neq:q}')
-            else:
-                filters.append(t'{column_query:q} IS DISTINCT FROM {gf.neq}')
-        if gf.in_ is not None:
-            if not isinstance(gf.in_, list):
+        if self.eq is not None:
+            filters.append(t'{column_query:q} = {wrap_val(self.eq):q}')
+        if self.neq is not None:
+            filters.append(t'{column_query:q} IS DISTINCT FROM {wrap_val(self.neq):q}')
+        if self.in_ is not None:
+            if not isinstance(self.in_, list):
                 raise ValueError('IN filter must be a list')
 
             # in an empty list is always false
-            if len(gf.in_) == 0:
+            if len(self.in_) == 0:
                 return t'FALSE'
 
             # Converting the list a query string will work for Any type
             # in GenericFilter.in_ including a sql.Composed value
-            in_value = sql.SQL('ARRAY[') + sql.SQL(',').join(gf.in_) + sql.SQL(']')
-            filters.append(t'{column_query:q} = ANY({in_value:q})')
+            filters.append(t'{column_query:q} = ANY({wrap_val_list(self.in_):q})')
 
-        if gf.nin is not None and len(gf.nin) > 0:
-            if not isinstance(gf.nin, list):
+        if self.nin is not None and len(self.nin) > 0:
+            if not isinstance(self.nin, list):
                 raise ValueError('NIN filter must be a list')
 
             # Converting the list to a query string will work for Any type
             # in GenericFilter.nin including a sql.Composed value
-            nin_value = sql.SQL('ARRAY[') + sql.SQL(',').join(gf.nin) + sql.SQL(']')
 
             # Include NULLs here as the user would expect to recieve nulls in the
             # results when they are trying to exclude certain values
             filters.append(
-                t'({column_query:q} IS NULL OR NOT ({column_query:q} = ANY({nin_value:q})))'
+                t'({column_query:q} IS NULL OR NOT ({column_query:q} = ANY({wrap_val_list(self.nin):q})))'
             )
-        if gf.gt is not None:
-            filters.append(t'{column_query:q} > {gf.gt}')
-        if gf.gte is not None:
-            filters.append(t'{column_query:q} >= {gf.gte}')
-        if gf.lt is not None:
-            filters.append(t'{column_query:q} < {gf.lt}')
-        if gf.lte is not None:
-            filters.append(t'{column_query:q} <= {gf.lte}')
-        if gf.contains is not None:
-            search_term = escape_like_term(str(original_gf.contains))
+
+        if self.gt is not None:
+            filters.append(t'{column_query:q} > {self.gt}')
+        if self.gte is not None:
+            filters.append(t'{column_query:q} >= {self.gte}')
+        if self.lt is not None:
+            filters.append(t'{column_query:q} < {self.lt}')
+        if self.lte is not None:
+            filters.append(t'{column_query:q} <= {self.lte}')
+        if self.contains is not None:
+            search_term = wrap_val(escape_like_term(str(self.contains)))
             filters.append(
-                t"{original_column_query:q} ILIKE '%' || {search_term} || '%'"
+                t"{original_column_query:q} ILIKE '%' || {search_term:q} || '%'"
             )
-        if gf.icontains is not None:
-            search_term = escape_like_term(str(original_gf.icontains))
-            filters.append(t"{column_query:q} ILIKE '%' || {search_term} || '%'")
-        if gf.startswith is not None:
-            search_term = escape_like_term(str(original_gf.startswith))
-            filters.append(t"{column_query:q} ILIKE {search_term} || '%'")
-        if gf.isnull is not None:
-            if gf.isnull:
+        if self.icontains is not None:
+            search_term = wrap_val(escape_like_term(str(self.icontains)))
+            filters.append(t"{column_query:q} ILIKE '%' || {search_term:q} || '%'")
+        if self.startswith is not None:
+            search_term = wrap_val(escape_like_term(str(self.startswith)))
+            filters.append(t"{column_query:q} ILIKE {search_term:q} || '%'")
+        if self.isnull is not None:
+            if self.isnull:
                 filters.append(t'{column_query:q} IS NULL')
             else:
                 filters.append(t'{column_query:q} IS NOT NULL')
@@ -204,23 +205,15 @@ class GenericFilter[T](SMBase):
 
         return sql.SQL(' AND ').join(filters_rm_none)
 
-    def transform(
-        self, func: Callable[[T], X], map_array_values: bool = False
-    ) -> GenericFilter[X]:
+    def transform(self, func: Callable[[T], X]) -> GenericFilter[X]:
         """
         Apply a function to each value in the filter
         """
-
-        def list_transform(lst: Sequence[T]) -> Sequence[X]:
-            if map_array_values:
-                return list(map(func, lst))
-            return func(lst)  # type: ignore
-
         return GenericFilter(
             eq=func(self.eq) if self.eq is not None else None,
             neq=func(self.neq) if self.neq is not None else None,
-            in_=list_transform(self.in_) if self.in_ is not None else None,
-            nin=list_transform(self.nin) if self.nin is not None else None,
+            in_=list(map(func, self.in_)) if self.in_ else None,
+            nin=list(map(func, self.nin)) if self.nin else None,
             gt=func(self.gt) if self.gt is not None else None,
             gte=func(self.gte) if self.gte is not None else None,
             lt=func(self.lt) if self.lt is not None else None,
@@ -230,17 +223,6 @@ class GenericFilter[T](SMBase):
             startswith=func(self.startswith) if self.startswith is not None else None,
             isnull=self.isnull,
         )
-
-    def copy_with_casefolded_strings(self) -> GenericFilter[T]:
-        # Use transform to apply casefold to all string values in the filter
-        def casefold_if_str(value: Any) -> Any:
-            # StrEnum return True to isinstance(value, str) but we don't
-            # want to casefold them, so we check for Enum first
-            if not isinstance(value, Enum) and isinstance(value, str):
-                return sql.SQL(f'CASEFOLD(') + sql.Literal(str(value)) + sql.SQL(')')
-            return value
-
-        return self.transform(casefold_if_str, map_array_values=True)
 
     def infer_pg_type_from_filter(self) -> str | None:
         """

--- a/db/python/filters/generic.py
+++ b/db/python/filters/generic.py
@@ -157,23 +157,17 @@ class GenericFilter[T](SMBase):
             if len(self.in_) == 0:
                 return t'FALSE'
 
-            # Converting the list a query string will work for Any type
-            # in GenericFilter.in_ including a sql.Composed value
             filters.append(t'{column_query:q} = ANY({wrap_val_list(self.in_):q})')
 
         if self.nin is not None and len(self.nin) > 0:
             if not isinstance(self.nin, list):
                 raise ValueError('NIN filter must be a list')
 
-            # Converting the list to a query string will work for Any type
-            # in GenericFilter.nin including a sql.Composed value
-
             # Include NULLs here as the user would expect to recieve nulls in the
             # results when they are trying to exclude certain values
             filters.append(
                 t'({column_query:q} IS NULL OR NOT ({column_query:q} = ANY({wrap_val_list(self.nin):q})))'
             )
-
         if self.gt is not None:
             filters.append(t'{column_query:q} > {self.gt}')
         if self.gte is not None:
@@ -189,10 +183,12 @@ class GenericFilter[T](SMBase):
             )
         if self.icontains is not None:
             search_term = wrap_val(escape_like_term(str(self.icontains)))
-            filters.append(t"{column_query:q} ILIKE '%' || {search_term:q} || '%'")
+            filters.append(
+                t"{original_column_query:q} ILIKE '%' || {search_term:q} || '%'"
+            )
         if self.startswith is not None:
             search_term = wrap_val(escape_like_term(str(self.startswith)))
-            filters.append(t"{column_query:q} ILIKE {search_term:q} || '%'")
+            filters.append(t"{original_column_query:q} ILIKE {search_term:q} || '%'")
         if self.isnull is not None:
             if self.isnull:
                 filters.append(t'{column_query:q} IS NULL')
@@ -210,17 +206,17 @@ class GenericFilter[T](SMBase):
         Apply a function to each value in the filter
         """
         return GenericFilter(
-            eq=func(self.eq) if self.eq is not None else None,
-            neq=func(self.neq) if self.neq is not None else None,
+            eq=func(self.eq) if self.eq else None,
+            neq=func(self.neq) if self.neq else None,
             in_=list(map(func, self.in_)) if self.in_ else None,
             nin=list(map(func, self.nin)) if self.nin else None,
-            gt=func(self.gt) if self.gt is not None else None,
-            gte=func(self.gte) if self.gte is not None else None,
-            lt=func(self.lt) if self.lt is not None else None,
-            lte=func(self.lte) if self.lte is not None else None,
-            contains=func(self.contains) if self.contains is not None else None,
-            icontains=func(self.icontains) if self.icontains is not None else None,
-            startswith=func(self.startswith) if self.startswith is not None else None,
+            gt=func(self.gt) if self.gt else None,
+            gte=func(self.gte) if self.gte else None,
+            lt=func(self.lt) if self.lt else None,
+            lte=func(self.lte) if self.lte else None,
+            contains=func(self.contains) if self.contains else None,
+            icontains=func(self.icontains) if self.icontains else None,
+            startswith=func(self.startswith) if self.startswith else None,
             isnull=self.isnull,
         )
 

--- a/db/python/filters/generic.py
+++ b/db/python/filters/generic.py
@@ -1,5 +1,7 @@
 import dataclasses
+import datetime
 from collections.abc import Callable, Sequence
+from datetime import date, datetime
 from enum import Enum
 from string.templatelib import Template
 from typing import Any, TypeVar
@@ -116,54 +118,83 @@ class GenericFilter[T](SMBase):
         """
         filters: list[Template | None] = []
 
-        column_query = (
+        # MARIADB BACKWARDS COMPATIBILITY:
+        # Goal: Make all string comparisions case insensitive
+        # We are going to do a check on all of the filter fields
+        # if their type is str, make sure that the value is set to
+        # CASEFOLD(value) and the column query is also wrapped in CASEFOLD
+        original_gf: GenericFilter[T] = self
+        gf: GenericFilter[T] = self.copy_with_casefolded_strings()
+        value_type = infer_pg_type_from_filter(self)
+
+        original_column_query = (
             column
             if isinstance(column, Template)
             else t'{sql.Identifier(*column.split(".")):i}'
         )
 
-        if self.eq is not None:
-            filters.append(t'{column_query:q} = {self.eq}')
-        if self.neq is not None:
-            filters.append(t'{column_query:q} IS DISTINCT FROM {self.neq}')
-        if self.in_ is not None:
-            if not isinstance(self.in_, list):
+        # Add CASEFOLD to the column query if any of the fields are strings
+        column_query = original_column_query
+        if value_type == 'text':
+            column_query = t'CASEFOLD({original_column_query:q})'
+
+        if gf.eq is not None:
+            if isinstance(gf.eq, sql.Composable):
+                filters.append(t'{column_query:q} = {gf.eq:q}')
+            else:
+                filters.append(t'{column_query:q} = {gf.eq}')
+        if gf.neq is not None:
+            if isinstance(gf.neq, sql.Composable):
+                filters.append(t'{column_query:q} IS DISTINCT FROM {gf.neq:q}')
+            else:
+                filters.append(t'{column_query:q} IS DISTINCT FROM {gf.neq}')
+        if gf.in_ is not None:
+            if not isinstance(gf.in_, list):
                 raise ValueError('IN filter must be a list')
 
             # in an empty list is always false
-            if len(self.in_) == 0:
+            if len(gf.in_) == 0:
                 return t'FALSE'
 
-            filters.append(t'{column_query:q} = ANY({self.in_})')
+            # Converting the list a query string will work for Any type
+            # in GenericFilter.in_ including a sql.Composed value
+            in_value = sql.SQL('ARRAY[') + sql.SQL(',').join(gf.in_) + sql.SQL(']')
+            filters.append(t'{column_query:q} = ANY({in_value:q})')
 
-        if self.nin is not None and len(self.nin) > 0:
-            if not isinstance(self.nin, list):
+        if gf.nin is not None and len(gf.nin) > 0:
+            if not isinstance(gf.nin, list):
                 raise ValueError('NIN filter must be a list')
+
+            # Converting the list to a query string will work for Any type
+            # in GenericFilter.nin including a sql.Composed value
+            nin_value = sql.SQL('ARRAY[') + sql.SQL(',').join(gf.nin) + sql.SQL(']')
 
             # Include NULLs here as the user would expect to recieve nulls in the
             # results when they are trying to exclude certain values
             filters.append(
-                t'({column_query:q} IS NULL OR NOT ({column_query:q} = ANY({self.nin})))'
+                t'({column_query:q} IS NULL OR NOT ({column_query:q} = ANY({nin_value:q})))'
             )
-        if self.gt is not None:
-            filters.append(t'{column_query:q} > {self.gt}')
-        if self.gte is not None:
-            filters.append(t'{column_query:q} >= {self.gte}')
-        if self.lt is not None:
-            filters.append(t'{column_query:q} < {self.lt}')
-        if self.lte is not None:
-            filters.append(t'{column_query:q} <= {self.lte}')
-        if self.contains is not None:
-            search_term = escape_like_term(str(self.contains))
-            filters.append(t"{column_query:q} LIKE '%' || {search_term} || '%'")
-        if self.icontains is not None:
-            search_term = escape_like_term(str(self.icontains))
+        if gf.gt is not None:
+            filters.append(t'{column_query:q} > {gf.gt}')
+        if gf.gte is not None:
+            filters.append(t'{column_query:q} >= {gf.gte}')
+        if gf.lt is not None:
+            filters.append(t'{column_query:q} < {gf.lt}')
+        if gf.lte is not None:
+            filters.append(t'{column_query:q} <= {gf.lte}')
+        if gf.contains is not None:
+            search_term = escape_like_term(str(original_gf.contains))
+            filters.append(
+                t"{original_column_query:q} ILIKE '%' || {search_term} || '%'"
+            )
+        if gf.icontains is not None:
+            search_term = escape_like_term(str(original_gf.icontains))
             filters.append(t"{column_query:q} ILIKE '%' || {search_term} || '%'")
-        if self.startswith is not None:
-            search_term = escape_like_term(str(self.startswith))
-            filters.append(t"{column_query:q} LIKE {search_term} || '%'")
-        if self.isnull is not None:
-            if self.isnull:
+        if gf.startswith is not None:
+            search_term = escape_like_term(str(original_gf.startswith))
+            filters.append(t"{column_query:q} ILIKE {search_term} || '%'")
+        if gf.isnull is not None:
+            if gf.isnull:
                 filters.append(t'{column_query:q} IS NULL')
             else:
                 filters.append(t'{column_query:q} IS NOT NULL')
@@ -174,24 +205,43 @@ class GenericFilter[T](SMBase):
 
         return sql.SQL(' AND ').join(filters_rm_none)
 
-    def transform(self, func: Callable[[T], X]) -> GenericFilter[X]:
+    def transform(
+        self, func: Callable[[T], X], map_array_values: bool = False
+    ) -> GenericFilter[X]:
         """
         Apply a function to each value in the filter
         """
+
+        def list_transform(lst: Sequence[T]) -> Sequence[X]:
+            if map_array_values:
+                return list(map(func, lst))
+            return func(lst)  # type: ignore
+
         return GenericFilter(
-            eq=func(self.eq) if self.eq else None,
-            neq=func(self.neq) if self.neq else None,
-            in_=list(map(func, self.in_)) if self.in_ else None,
-            nin=list(map(func, self.nin)) if self.nin else None,
-            gt=func(self.gt) if self.gt else None,
-            gte=func(self.gte) if self.gte else None,
-            lt=func(self.lt) if self.lt else None,
-            lte=func(self.lte) if self.lte else None,
-            contains=func(self.contains) if self.contains else None,
-            icontains=func(self.icontains) if self.icontains else None,
-            startswith=func(self.startswith) if self.startswith else None,
+            eq=func(self.eq) if self.eq is not None else None,
+            neq=func(self.neq) if self.neq is not None else None,
+            in_=list_transform(self.in_) if self.in_ is not None else None,
+            nin=list_transform(self.nin) if self.nin is not None else None,
+            gt=func(self.gt) if self.gt is not None else None,
+            gte=func(self.gte) if self.gte is not None else None,
+            lt=func(self.lt) if self.lt is not None else None,
+            lte=func(self.lte) if self.lte is not None else None,
+            contains=func(self.contains) if self.contains is not None else None,
+            icontains=func(self.icontains) if self.icontains is not None else None,
+            startswith=func(self.startswith) if self.startswith is not None else None,
             isnull=self.isnull,
         )
+
+    def copy_with_casefolded_strings(self) -> 'GenericFilter[T]':
+        # Use transform to apply casefold to all string values in the filter
+        def casefold_if_str(value: Any) -> Any:
+            # StrEnum return True to isinstance(value, str) but we don't
+            # want to casefold them, so we check for Enum first
+            if not isinstance(value, Enum) and isinstance(value, str):
+                return sql.SQL(f'CASEFOLD(') + sql.Literal(str(value)) + sql.SQL(')')
+            return value
+
+        return self.transform(casefold_if_str, map_array_values=True)
 
 
 GenericMetaFilter = dict[str, GenericFilter[Any]]
@@ -297,7 +347,7 @@ class GenericFilterModel:
         return sql.SQL(' AND ').join(filters_rm_none)
 
 
-def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str:
+def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str | None:
     """
     Infer the SQL cast type from actual values in the filter
 
@@ -313,6 +363,8 @@ def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str:
     meta={'favnum': GenericFilter(eq='five')} <- we'll infer the type as text
 
     If the casting of any value fails, the database will raise an error.
+
+    If the type cannot be inferred, None is returned
     """
     # Collect all non-None comparison values
     sample_values: list[Any] = []
@@ -331,7 +383,11 @@ def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str:
             cast_types.add('bool')
         elif isinstance(v, (int, float)):
             cast_types.add('numeric')
-        else:
+        elif isinstance(v, Enum):
+            cast_types.add('enum')
+        elif isinstance(v, (datetime, date)):
+            cast_types.add('timestamp')
+        elif isinstance(v, str):
             cast_types.add('text')
 
     if len(cast_types) > 1:
@@ -339,7 +395,7 @@ def infer_pg_type_from_filter(value: GenericFilter[Any]) -> str:
             f'Mixed types in filter values: {cast_types}. All values in a filter must be of the same type.'
         )
 
-    return cast_types.pop() if cast_types else 'text'
+    return cast_types.pop() if cast_types else None
 
 
 def prepare_query_from_dict_field(
@@ -363,7 +419,9 @@ def prepare_query_from_dict_field(
         if not isinstance(value, GenericFilter):
             raise ValueError(f'Filter {column_name} must be a GenericFilter')
 
-        pg_type = infer_pg_type_from_filter(value)
+        # In the case where an 'isnull' filter is applied and the type
+        # cannot be inferred, we will default to text
+        pg_type = infer_pg_type_from_filter(value) or 'text'
 
         _inner_query = value.to_sql(t"json_value(a, '$' returning {pg_type:i})")
 

--- a/test/test_generic_filters.py
+++ b/test/test_generic_filters.py
@@ -103,9 +103,11 @@ class TestGenericFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0]['test_string'] == 'test'
         assert results[0]['test_int'] == 100
+        assert results[1]['test_string'] == 'Test'
+        assert results[1]['test_int'] == 200
 
     async def test_override_with_expression(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -132,12 +134,14 @@ class TestGenericFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        # Should match 'test', 'contains_test', 'testprefix'
-        assert len(results) == 3
+        # Should match 'test', 'contains_test', 'testprefix', 'Test', 'TestPrefix' but not 'Test' and 'TestPrefix' because of case sensitivity
+        assert len(results) == 5
         assert {r['test_string'] for r in results} == {
             'test',
             'contains_test',
             'testprefix',
+            'Test',
+            'TestPrefix',
         }
 
     async def test_malicious_contains(
@@ -185,8 +189,11 @@ class TestGenericFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0]['test_string'] == 'test'
+        assert results[0]['test_int'] == 100
+        assert results[1]['test_string'] == 'Test'
+        assert results[1]['test_int'] == 200
 
     async def test_in_multiple(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -297,9 +304,9 @@ class TestGenericFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        # Should exclude only 'test'
-        assert len(results) == 8
-        assert all(r['test_string'] != 'test' for r in results)
+        # Should exclude only 'test' and 'Test'
+        assert len(results) == 7
+        assert all(r['test_string'] not in ('test', 'Test') for r in results)
 
     async def test_startswith(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -310,9 +317,9 @@ class TestGenericFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        # Should match 'test', 'testprefix'
-        assert len(results) == 2
-        assert {r['test_string'] for r in results} == {'test', 'testprefix'}
+        # Should match 'test', 'testprefix', 'Test', 'TestPrefix'
+        assert len(results) == 4
+        assert {r['test_string'].casefold() for r in results} == {'test', 'testprefix'}
 
     async def test_isnull_true(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -644,9 +651,11 @@ class TestGenericFilters:
             query = t'select * from test_generic_filters tgf where {where_clause:q} order by id'
             results = await (await conn.execute(query)).fetchall()
 
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0]['test_string'] == 'test'
         assert results[0]['test_int'] == 100
+        assert results[1]['test_string'] == 'Test'
+        assert results[1]['test_int'] == 200
 
 
 @pytest.mark.asyncio
@@ -662,8 +671,9 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0]['test_dict']['metastr'] == 'test'
+        assert results[1]['test_dict']['metastr'] == 'Test'
 
     async def test_dict_field_neq(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -674,7 +684,7 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 8
+        assert len(results) == 7
 
         # Find the result with NULL test_dict and check that it is included in the results
         assert sum(r['test_dict'] is None for r in results) == 1
@@ -686,7 +696,7 @@ class TestGenericDictFilters:
         meta_vals = [
             r['test_dict'].get('metastr') for r in results if r['test_dict'] is not None
         ]
-        assert all(val != 'test' for val in meta_vals)
+        assert all(val not in ('test', 'Test') for val in meta_vals)
 
     async def test_dict_field_contains(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -699,11 +709,13 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 3
+        assert len(results) == 5
         assert {r['test_dict']['metastr'] for r in results} == {
             'test',
             'contains_test',
             'testprefix',
+            'Test',
+            'TestPrefix',
         }
 
     async def test_dict_field_icontains(
@@ -730,8 +742,13 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 2
-        assert {r['test_dict']['metastr'] for r in results} == {'test', 'testprefix'}
+        assert len(results) == 4
+        assert {r['test_dict']['metastr'] for r in results} == {
+            'test',
+            'testprefix',
+            'Test',
+            'TestPrefix',
+        }
 
     async def test_dict_field_in(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -744,8 +761,12 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 2
-        assert {r['test_dict']['metastr'] for r in results} == {'test', 'another'}
+        assert len(results) == 3
+        assert {r['test_dict']['metastr'] for r in results} == {
+            'test',
+            'another',
+            'Test',
+        }
 
     async def test_dict_field_nin(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -758,7 +779,7 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 7
+        assert len(results) == 6
 
         # Check that the result with NULL test_dict is included in the results
         assert sum(r['test_dict'] is None for r in results) == 1
@@ -770,7 +791,7 @@ class TestGenericDictFilters:
         meta_vals = [
             r['test_dict'].get('metastr') for r in results if r['test_dict'] is not None
         ]
-        assert all(val not in ['test', 'another'] for val in meta_vals)
+        assert all(val not in ('test', 'another', 'Test') for val in meta_vals)
 
     async def test_dict_field_nin_isnull_false(
         self, test_data: AsyncConnectionPool[AsyncConnection[DictRow]]
@@ -783,9 +804,10 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 5
+        assert len(results) == 4
         assert all(
-            r['test_dict'].get('metastr') not in ['test', 'another'] for r in results
+            r['test_dict'].get('metastr') not in ('test', 'another', 'Test')
+            for r in results
         )
 
     async def test_dict_field_int_eq(
@@ -1025,9 +1047,9 @@ class TestGenericDictFilters:
         async with test_data.connection() as conn:
             results = await execute_filter(conn, filter_)
 
-        assert len(results) == 1
+        assert len(results) == 2
         for r in results:
-            assert r['test_dict']['metastr'].startswith('test')
+            assert r['test_dict']['metastr'].lower().startswith('test')
             assert 100 <= r['test_dict']['metaint'] < 300
 
     async def test_dict_field_with_enum_and_regular_filters(


### PR DESCRIPTION
As described in the ticket for SET-1003, Mariadb was automatically doing very flexible, case ignoring string comparisons. 

This update to the GenericFilter makes all string comparisons `ILIKE` or `CASEFOLD(value)` to replicate that pre-exiting functionality after the move to Postgres.

The tests have been updated accordingly.