### PR TITLE
Call refresh_projects() only once per dependable_get_connection_getter call

### DIFF
--- a/api/utils/db.py
+++ b/api/utils/db.py
@@ -14,7 +14,7 @@ from api.settings import get_default_user
 from api.utils.gcp import email_from_id_token
 from db.python.connect import Connection, SMConnections
 from db.python.gcp_connect import BqConnection, PubSubConnection
-from models.models.project import ProjectMemberRole
+from models.models.project import Project, ProjectId, ProjectMemberRole
 
 
 EXPECTED_AUDIENCE = getenv('SM_OAUTHAUDIENCE')
@@ -161,17 +161,30 @@ async def dependable_get_connection_getter(
         meta.update(extra_values)
 
     pool = SMConnections.get_postgres_pool()
+    project_id_map: dict[ProjectId, Project] | None = None
+    project_name_map: dict[str, Project] | None = None
 
     @asynccontextmanager
     async def get_connection():
+        nonlocal project_id_map, project_name_map
         async with pool.connection() as connection:
-            yield await SMConnections.get_connection_no_project(
+            sm_connection = await SMConnections.get_connection_no_project(
                 connection,
                 author,
                 ar_guid=ar_guid,
                 meta=meta,
                 on_behalf_of=on_behalf_of,
+                project_id_map=project_id_map,
+                project_name_map=project_name_map,
             )
+
+            # Cache these maps for the next time this get_connection() is called
+            if project_id_map is None:
+                project_id_map = sm_connection.project_id_map
+            if project_name_map is None:
+                project_name_map = sm_connection.project_name_map
+
+            yield sm_connection
 
     return get_connection
 

--- a/db/python/connect.py
+++ b/db/python/connect.py
@@ -439,6 +439,8 @@ class SMConnections:
         ar_guid: str,
         meta: dict[str, str],
         on_behalf_of: str | None,
+        project_id_map: dict[ProjectId, Project] | None = None,
+        project_name_map: dict[str, Project] | None = None,
     ):
         """Get a db connection from a project and user"""
         # maybe it makes sense to perform permission checks here too
@@ -451,9 +453,10 @@ class SMConnections:
             on_behalf_of=on_behalf_of,
             ar_guid=ar_guid,
             meta=meta,
-            project_id_map={},
-            project_name_map={},
+            project_id_map=project_id_map or {},
+            project_name_map=project_name_map or {},
         )
 
-        await connection.refresh_projects()
+        if project_id_map is None or project_name_map is None:
+            await connection.refresh_projects()
         return connection


### PR DESCRIPTION
The `get_connection()` function returned by `dependable_get_connection_getter` is called repeatedly for related graphql resolvers. Caching the project maps in `dependable_get_connection_getter` avoids repeated calls to get the same information from `refresh_projects()` and speeds up this hot path.

But don't cache them for other `refresh_projects()` call sites for which it can be important to get a fresh list of projects.