### PR TITLE
Add dbmate migration for project-creators & members-admin groups

### DIFF
--- a/db/migrations/20260305092300_add_default_data.sql
+++ b/db/migrations/20260305092300_add_default_data.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+
+INSERT INTO "group" (name) VALUES ('project-creators'), ('members-admin');
+
+-- migrate:down
+
+DELETE FROM "group" WHERE name IN ('project-creators', 'members-admin');


### PR DESCRIPTION
Adds a migration for the remaining initial `INSERT INTO` I needed to be able to apply (more or less) the existing instructions to get a local database up and running. This corresponds to `2023-10-06_inbuilt-permissions` in the old _db/project.xml_.

I assume it's not appropriate to add to the existing _20260120061616_add_default_data.sql_ as it's already long-since been applied to most people's installations.

And I assume we're happy to do this via a dbmate migration…