### PR TITLE
[SET-1032] Migrate billing tests to pytest

### DIFF
--- a/db/python/tables/bq/generic_bq_filter.py
+++ b/db/python/tables/bq/generic_bq_filter.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, TypeVar
@@ -8,6 +9,7 @@ from db.python.filters import GenericFilter
 
 
 T = TypeVar('T')
+NONFIELD_CHARS_REGEX = re.compile(r'[^a-zA-Z0-9_]')
 
 
 class GenericBQFilter(GenericFilter[T]):  # noqa: PLW1641
@@ -27,6 +29,20 @@ class GenericBQFilter(GenericFilter[T]):  # noqa: PLW1641
 
         # all attributes are equal
         return True
+
+    @staticmethod
+    def generate_field_name(name):
+        """
+        Replace any non \\w characters with an underscore
+
+        >>> GenericFilter.generate_field_name('foo')
+        'foo'
+        >>> GenericFilter.generate_field_name('foo.bar')
+        'foo_bar'
+        >>> GenericFilter.generate_field_name('$foo bar:>baz')
+        '_foo_bar__baz'
+        """  # noqa: D301
+        return NONFIELD_CHARS_REGEX.sub('_', name)
 
     def to_sql(
         self, column: str, column_name: str = None

--- a/pytest.toml
+++ b/pytest.toml
@@ -25,7 +25,16 @@ python_files = [
     "test_update_participant_family.py",
     "test_pedigree.py",
     "test_search.py",
-    "test_graphql.py"
+    "test_graphql.py",
+    "test_billing_samples.py",
+    "test_bq_billing_ar_batch.py",
+    "test_bq_billing_base.py",
+    "test_bq_billing_daily.py",
+    "test_bq_billing_daily_extended.py",
+    "test_bq_billing_gcp_daily.py",
+    "test_bq_billing_raw.py",
+    "test_bq_function_filter.py",
+    "test_bq_generic_filter.py"
 ]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/test/test_billing_samples.py
+++ b/test/test_billing_samples.py
@@ -6,25 +6,11 @@ from db.python.connect import Connection
 from db.python.tables.sample import SampleTable
 
 
-def get_mock_date(date_to_mock: datetime.date):
-    """
-    Patches the return value of date.today()
-    Additionally, the fromisoformat of the date class is configured to function as it would without mocking.
-    """
-
-    class MockDate(datetime.date):
-        @classmethod
-        def today(cls):
-            return date_to_mock
-
-    return MockDate
-
-
 @pytest.fixture
 def mock_fetchall(monkeypatch):
     """
-    This is a mockup function for fetch_all function on the Database object.
-    This returns one mockup of a query result that contains the the number of samples
+    This is a mockup function for fetchall function on the Database object.
+    This returns one mockup of a query result that contains the number of samples
     in a project for each month.
     """
 
@@ -39,6 +25,20 @@ def mock_fetchall(monkeypatch):
         monkeypatch.setattr(connection.pg_connection, 'execute', mock_execute)
 
     return _mock_fetchall
+
+
+def get_mock_date(date_to_mock: datetime.date):
+    """
+    Patches the return value of date.today()
+    Additionally, the fromisoformat of the date class is configured to function as it would without mocking.
+    """
+
+    class MockDate(datetime.date):
+        @classmethod
+        def today(cls):
+            return date_to_mock
+
+    return MockDate
 
 
 class TestMonthlySamplesPerProject:
@@ -68,7 +68,9 @@ class TestMonthlySamplesPerProject:
         )
 
         result = await self.sample_table.get_monthly_samples_count_per_project()
-        month_costs = result[0]
+        month_costs = result[
+            0
+        ]  # Retrieve the cost/month for the given test project ID.
 
         assert month_costs == {
             datetime.date(year=2025, month=2, day=1): 100,
@@ -83,6 +85,8 @@ class TestMonthlySamplesPerProject:
 
     @pytest.mark.asyncio
     async def test_only_this_month(self, monkeypatch, mock_fetchall):
+        """Tests the case wherein the only record in the database is the current month."""
+        # Set up sample count mocking.
 
         monkeypatch.setattr(
             'db.python.tables.sample.date', get_mock_date(datetime.date(2025, 9, 1))
@@ -95,5 +99,7 @@ class TestMonthlySamplesPerProject:
         )
 
         result = await self.sample_table.get_monthly_samples_count_per_project()
-        month_costs = result[0]
+        month_costs = result[
+            0
+        ]  # Retrieve the cost/month for the given test project ID.
         assert month_costs == {datetime.date(year=2025, month=9, day=1): 170}

--- a/test/test_billing_samples.py
+++ b/test/test_billing_samples.py
@@ -1,111 +1,99 @@
-from datetime import date
-from unittest import mock
+import datetime
 
+import pytest
+
+from db.python.connect import Connection
 from db.python.tables.sample import SampleTable
-from test.testbase import DbIsolatedTest, run_as_sync
 
 
-def mock_fetch_all_sample_count(fetch_all_return: list[dict[str, int]]):
+def get_mock_date(date_to_mock: datetime.date):
+    """
+    Patches the return value of date.today()
+    Additionally, the fromisoformat of the date class is configured to function as it would without mocking.
+    """
+
+    class MockDate(datetime.date):
+        @classmethod
+        def today(cls):
+            return date_to_mock
+
+    return MockDate
+
+
+@pytest.fixture
+def mock_fetchall(monkeypatch):
     """
     This is a mockup function for fetch_all function on the Database object.
     This returns one mockup of a query result that contains the the number of samples
     in a project for each month.
     """
 
-    def sample_count_mock(*_args, **_kwargs):
-        mock_rows = mock.AsyncMock(args={}, spec=['__iter__', '__next__'])
-        mock_rows.total_rows = len(fetch_all_return)
-        mock_rows.__iter__.return_value = fetch_all_return
+    def _mock_fetchall(connection, fetch_all_return: list[dict[str, int]]):
+        class MockCursor:
+            async def fetchall(self):
+                return fetch_all_return
 
-        return mock_rows
+        async def mock_execute(*args):
+            return MockCursor()
 
-    return sample_count_mock
+        monkeypatch.setattr(connection.pg_connection, 'execute', mock_execute)
 
-
-def mock_today(date_to_mock: date):
-    """
-    Returns a function decorator that patches the return value of date.today() before
-    the given test_fn is called.
-    Additionally, the fromisoformat of the date class is configured to function as it would
-    without mocking.
-    """
-
-    def today_decorator(test_fn):
-        async def test_fn_wrapper(self):
-            patcher = mock.patch('db.python.tables.sample.date')
-            mock_date = patcher.start()
-            mock_date.today.return_value = date_to_mock
-            # https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
-            mock_date.fromisoformat.side_effect = date.fromisoformat
-
-            await test_fn(self)
-
-            patcher.stop()
-
-        return test_fn_wrapper
-
-    return today_decorator
+    return _mock_fetchall
 
 
-class TestMonthlySamplesPerProject(DbIsolatedTest):
+class TestMonthlySamplesPerProject:
     """Tests for retrieving the accumulated samples per month."""
 
-    @run_as_sync
-    async def setUp(self) -> None:
-        super().setUp()
-
+    @pytest.fixture(autouse=True)
+    def set_up(self, connection_with_project: Connection):
+        self.connection = connection_with_project
         self.sample_table = SampleTable(self.connection)
 
-    @run_as_sync
-    @mock_today(date(year=2025, month=9, day=1))
-    async def test_standard_date_gaps(self):
+    @pytest.mark.asyncio
+    async def test_standard_date_gaps(self, mock_fetchall, monkeypatch):
         """Tests the case wherein there is multiple dates in the database, separated by a few months."""
+
+        monkeypatch.setattr(
+            'db.python.tables.sample.date', get_mock_date(datetime.date(2025, 9, 1))
+        )
+
         # Set up sample count mocking.
-        fetch_all_mock = mock_fetch_all_sample_count(
+        mock_fetchall(
+            self.connection,
             [
                 {'project': 0, 'year': 2025, 'month': 2, 'count': 100},
                 {'project': 0, 'year': 2025, 'month': 4, 'count': 150},
                 {'project': 0, 'year': 2025, 'month': 7, 'count': 170},
-            ]
+            ],
         )
-        self.sample_table.connection.fetch_all = mock.AsyncMock(
-            side_effect=fetch_all_mock
-        )
+
         result = await self.sample_table.get_monthly_samples_count_per_project()
+        month_costs = result[0]
 
-        month_costs = result[
-            0
-        ]  # Retrieve the cost/month for the given test project ID.
-        self.assertDictEqual(
-            month_costs,
-            {
-                date(year=2025, month=2, day=1): 100,
-                date(year=2025, month=3, day=1): 100,
-                date(year=2025, month=4, day=1): 250,
-                date(year=2025, month=5, day=1): 250,
-                date(year=2025, month=6, day=1): 250,
-                date(year=2025, month=7, day=1): 420,
-                date(year=2025, month=8, day=1): 420,
-                date(year=2025, month=9, day=1): 420,
-            },
+        assert month_costs == {
+            datetime.date(year=2025, month=2, day=1): 100,
+            datetime.date(year=2025, month=3, day=1): 100,
+            datetime.date(year=2025, month=4, day=1): 250,
+            datetime.date(year=2025, month=5, day=1): 250,
+            datetime.date(year=2025, month=6, day=1): 250,
+            datetime.date(year=2025, month=7, day=1): 420,
+            datetime.date(year=2025, month=8, day=1): 420,
+            datetime.date(year=2025, month=9, day=1): 420,
+        }
+
+    @pytest.mark.asyncio
+    async def test_only_this_month(self, monkeypatch, mock_fetchall):
+
+        monkeypatch.setattr(
+            'db.python.tables.sample.date', get_mock_date(datetime.date(2025, 9, 1))
         )
-
-    @run_as_sync
-    @mock_today(date(year=2025, month=9, day=1))
-    async def test_only_this_month(self):
-        """Tests the case wherein the only record in the database is the current month."""
-        # Set up sample count mocking.
-        fetch_all_mock = mock_fetch_all_sample_count(
+        mock_fetchall(
+            self.connection,
             [
                 {'project': 0, 'year': 2025, 'month': 9, 'count': 170},
-            ]
+            ],
         )
-        self.sample_table.connection.fetch_all = mock.AsyncMock(
-            side_effect=fetch_all_mock
-        )
-        result = await self.sample_table.get_monthly_samples_count_per_project()
 
-        month_costs = result[
-            0
-        ]  # Retrieve the cost/month for the given test project ID.
-        self.assertDictEqual(month_costs, {date(year=2025, month=9, day=1): 170})
+        result = await self.sample_table.get_monthly_samples_count_per_project()
+        month_costs = result[0]
+        assert month_costs == {datetime.date(year=2025, month=9, day=1): 170}

--- a/test/test_billing_samples.py
+++ b/test/test_billing_samples.py
@@ -33,7 +33,7 @@ def mock_fetchall(monkeypatch):
             async def fetchall(self):
                 return fetch_all_return
 
-        async def mock_execute(*args):
+        async def mock_execute(*_args):
             return MockCursor()
 
         monkeypatch.setattr(connection.pg_connection, 'execute', mock_execute)

--- a/test/test_bq_billing_ar_batch.py
+++ b/test/test_bq_billing_ar_batch.py
@@ -152,6 +152,10 @@ class TestBillingArBatchTable(BqTest):
         """Test get_ar_guid_by_batch_id"""
 
         batch_id = '1234567890'
+
+        # mock BigQuery result
+        self.bq_result._rows = []
+
         # test get_ar_guid_by_batch_id function
         _, _, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 

--- a/test/test_bq_billing_ar_batch.py
+++ b/test/test_bq_billing_ar_batch.py
@@ -1,23 +1,23 @@
 import datetime
 from typing import Any
-from unittest import mock
 
 import google.cloud.bigquery as bq
+import pytest
 
 from db.python.tables.bq.billing_ar_batch import BillingArBatchTable
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
 from db.python.utils import InternalError
 from models.models import BillingColumn, BillingTotalCostQueryModel
-from test.testbase import run_as_sync
 from test.testbqbase import BqTest
 
 
 class TestBillingArBatchTable(BqTest):
     """Test BillingArBatchTable and its methods"""
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def set_up(self):
+        super().set_up()
 
         # setup table object
         self.table_obj = BillingArBatchTable(self.connection)
@@ -50,17 +50,16 @@ class TestBillingArBatchTable(BqTest):
         filter_ = BillingArBatchTable._query_to_partitioned_filter(query)
 
         # BillingFilter has __eq__ method, so we can compare them directly
-        self.assertEqual(expected_filter, filter_)
+        assert expected_filter == filter_
 
     def test_error_no_connection(self):
         """Test No connection exception"""
 
-        with self.assertRaises(InternalError) as context:
+        with pytest.raises(InternalError) as exc_info:
             BillingArBatchTable(None)
 
-        self.assertTrue(
-            "No connection was provided to the table 'BillingArBatchTable'"
-            in str(context.exception)
+        assert "No connection was provided to the table 'BillingArBatchTable'" in str(
+            exc_info.value
         )
 
     def test_get_table_name(self):
@@ -75,56 +74,28 @@ class TestBillingArBatchTable(BqTest):
         # test get table name function
         table_name = self.table_obj.get_table_name()
 
-        self.assertEqual(given_table_name, table_name)
+        assert given_table_name == table_name
 
-    @run_as_sync
-    async def test_get_batches_by_ar_guid_no_data(self):
+    @pytest.mark.asyncio
+    async def test_get_batches_by_ar_guid_no_data(self, monkeypatch):
         """Test get_batches_by_ar_guid"""
 
         ar_guid = '1234567890'
 
         # mock BigQuery result
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get_batches_by_ar_guid function
         (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
             ar_guid
         )
 
-        self.assertEqual(None, start_day)
-        self.assertEqual(None, end_day)
-        self.assertEqual([], batch_ids)
+        assert start_day is None
+        assert end_day is None
+        assert batch_ids == []
 
-    @run_as_sync
-    async def test_get_batches_by_ar_guid_one_record(self):
-        """Test get_batches_by_ar_guid"""
-
-        ar_guid = '1234567890'
-        given_start_day = datetime.datetime(2023, 1, 1, 0, 0)
-        given_end_day = datetime.datetime(2023, 1, 1, 2, 3)
-
-        # mock BigQuery result
-        self.bq_result.result.return_value = [
-            mock.MagicMock(
-                spec=bq.Row,
-                start_day=given_start_day,
-                end_day=given_end_day,
-                batch_id='Batch1234',
-            )
-        ]
-
-        # test get_batches_by_ar_guid function
-        (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
-            ar_guid
-        )
-
-        self.assertEqual(given_start_day, start_day)
-        # end day is the last day + 1
-        self.assertEqual(given_end_day + datetime.timedelta(days=1), end_day)
-        self.assertEqual(['Batch1234'], batch_ids)
-
-    @run_as_sync
-    async def test_get_batches_by_ar_guid_two_record(self):
+    @pytest.mark.asyncio
+    async def test_get_batches_by_ar_guid_one_record(self, monkeypatch):
         """Test get_batches_by_ar_guid"""
 
         ar_guid = '1234567890'
@@ -132,62 +103,93 @@ class TestBillingArBatchTable(BqTest):
         given_end_day = datetime.datetime(2023, 1, 1, 2, 3)
 
         # mock BigQuery result
-        self.bq_result.result.return_value = [
-            mock.MagicMock(
-                spec=bq.Row,
-                start_day=given_start_day,
-                end_day=given_start_day,
-                batch_id='FirstBatch',
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    bq.Row(
+                        (given_start_day, given_end_day, 'Batch1234'),
+                        {'start_day': 0, 'end_day': 1, 'batch_id': 2},
+                    )
+                ]
             ),
-            mock.MagicMock(
-                spec=bq.Row,
-                start_day=given_start_day,
-                end_day=given_end_day,
-                batch_id='SecondBatch',
-            ),
-        ]
+        )
 
         # test get_batches_by_ar_guid function
         (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
             ar_guid
         )
 
-        self.assertEqual(given_start_day, start_day)
+        assert given_start_day == start_day
         # end day is the last day + 1
-        self.assertEqual(given_end_day + datetime.timedelta(days=1), end_day)
-        self.assertEqual(['FirstBatch', 'SecondBatch'], batch_ids)
+        assert given_end_day + datetime.timedelta(days=1) == end_day
+        assert batch_ids == ['Batch1234']
 
-    @run_as_sync
+    @pytest.mark.asyncio
+    async def test_get_batches_by_ar_guid_two_record(self, monkeypatch):
+        """Test get_batches_by_ar_guid"""
+
+        ar_guid = '1234567890'
+        given_start_day = datetime.datetime(2023, 1, 1, 0, 0)
+        given_end_day = datetime.datetime(2023, 1, 1, 2, 3)
+
+        row_1_values = (given_start_day, given_end_day, 'FirstBatch')
+        row_2_values = (given_start_day, given_end_day, 'SecondBatch')
+        row_keys = {'start_day': 0, 'end_day': 1, 'batch_id': 2}
+
+        # mock BigQuery result
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [bq.Row(row_1_values, row_keys), bq.Row(row_2_values, row_keys)]
+            ),
+        )
+
+        # test get_batches_by_ar_guid function
+        (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
+            ar_guid
+        )
+
+        assert given_start_day == start_day
+        # end day is the last day + 1
+        assert given_end_day + datetime.timedelta(days=1) == end_day
+        assert batch_ids == ['FirstBatch', 'SecondBatch']
+
+    @pytest.mark.asyncio
     async def test_get_ar_guid_by_batch_id_no_data(self):
         """Test get_ar_guid_by_batch_id"""
 
         batch_id = '1234567890'
-
-        # mock BigQuery result
-        self.bq_result.result.return_value = []
-
         # test get_ar_guid_by_batch_id function
         _, _, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 
-        self.assertEqual(None, ar_guid)
+        assert ar_guid is None
 
-    @run_as_sync
-    async def test_get_ar_guid_by_batch_id_one_rec(self):
+    @pytest.mark.asyncio
+    async def test_get_ar_guid_by_batch_id_one_rec(self, monkeypatch):
         """Test get_ar_guid_by_batch_id"""
 
         batch_id = '1234567890'
         expected_ar_guid = 'AR_GUID_1234'
 
         # mock BigQuery result
-        self.bq_result.result.return_value = [
-            {
-                'ar_guid': expected_ar_guid,
-                'start_day': datetime.datetime(2024, 1, 1, 0, 0),
-                'end_day': datetime.datetime(2024, 1, 2, 0, 0),
-            }
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    {
+                        'ar_guid': expected_ar_guid,
+                        'start_day': datetime.datetime(2024, 1, 1, 0, 0),
+                        'end_day': datetime.datetime(2024, 1, 2, 0, 0),
+                    }
+                ]
+            ),
+        )
 
         # test get_ar_guid_by_batch_id function
         _, _, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)
 
-        self.assertEqual(expected_ar_guid, ar_guid)
+        assert expected_ar_guid == ar_guid

--- a/test/test_bq_billing_ar_batch.py
+++ b/test/test_bq_billing_ar_batch.py
@@ -77,13 +77,13 @@ class TestBillingArBatchTable(BqTest):
         assert given_table_name == table_name
 
     @pytest.mark.asyncio
-    async def test_get_batches_by_ar_guid_no_data(self, monkeypatch):
+    async def test_get_batches_by_ar_guid_no_data(self):
         """Test get_batches_by_ar_guid"""
 
         ar_guid = '1234567890'
 
         # mock BigQuery result
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get_batches_by_ar_guid function
         (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
@@ -95,7 +95,7 @@ class TestBillingArBatchTable(BqTest):
         assert batch_ids == []
 
     @pytest.mark.asyncio
-    async def test_get_batches_by_ar_guid_one_record(self, monkeypatch):
+    async def test_get_batches_by_ar_guid_one_record(self):
         """Test get_batches_by_ar_guid"""
 
         ar_guid = '1234567890'
@@ -103,19 +103,12 @@ class TestBillingArBatchTable(BqTest):
         given_end_day = datetime.datetime(2023, 1, 1, 2, 3)
 
         # mock BigQuery result
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    bq.Row(
-                        (given_start_day, given_end_day, 'Batch1234'),
-                        {'start_day': 0, 'end_day': 1, 'batch_id': 2},
-                    )
-                ]
-            ),
-        )
-
+        self.bq_result._rows = [
+            bq.Row(
+                (given_start_day, given_end_day, 'Batch1234'),
+                {'start_day': 0, 'end_day': 1, 'batch_id': 2},
+            )
+        ]
         # test get_batches_by_ar_guid function
         (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
             ar_guid
@@ -127,7 +120,7 @@ class TestBillingArBatchTable(BqTest):
         assert batch_ids == ['Batch1234']
 
     @pytest.mark.asyncio
-    async def test_get_batches_by_ar_guid_two_record(self, monkeypatch):
+    async def test_get_batches_by_ar_guid_two_record(self):
         """Test get_batches_by_ar_guid"""
 
         ar_guid = '1234567890'
@@ -139,13 +132,10 @@ class TestBillingArBatchTable(BqTest):
         row_keys = {'start_day': 0, 'end_day': 1, 'batch_id': 2}
 
         # mock BigQuery result
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [bq.Row(row_1_values, row_keys), bq.Row(row_2_values, row_keys)]
-            ),
-        )
+        self.bq_result._rows = [
+            bq.Row(row_1_values, row_keys),
+            bq.Row(row_2_values, row_keys),
+        ]
 
         # test get_batches_by_ar_guid function
         (start_day, end_day, batch_ids) = await self.table_obj.get_batches_by_ar_guid(
@@ -168,26 +158,20 @@ class TestBillingArBatchTable(BqTest):
         assert ar_guid is None
 
     @pytest.mark.asyncio
-    async def test_get_ar_guid_by_batch_id_one_rec(self, monkeypatch):
+    async def test_get_ar_guid_by_batch_id_one_rec(self):
         """Test get_ar_guid_by_batch_id"""
 
         batch_id = '1234567890'
         expected_ar_guid = 'AR_GUID_1234'
 
         # mock BigQuery result
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    {
-                        'ar_guid': expected_ar_guid,
-                        'start_day': datetime.datetime(2024, 1, 1, 0, 0),
-                        'end_day': datetime.datetime(2024, 1, 2, 0, 0),
-                    }
-                ]
-            ),
-        )
+        self.bq_result._rows = [
+            {
+                'ar_guid': expected_ar_guid,
+                'start_day': datetime.datetime(2024, 1, 1, 0, 0),
+                'end_day': datetime.datetime(2024, 1, 2, 0, 0),
+            }
+        ]
 
         # test get_ar_guid_by_batch_id function
         _, _, ar_guid = await self.table_obj.get_ar_guid_by_batch_id(batch_id)

--- a/test/test_bq_billing_base.py
+++ b/test/test_bq_billing_base.py
@@ -55,13 +55,6 @@ def mock_execute_query_running_cost(query, *_args, **_kwargs):
     ]
 
 
-def mock_execute_query_empty(_query, *_args, **_kwargs):
-    """
-    Mock function returning an empty MockQueryJob.
-    """
-    return MockQueryJob(MockResult(rows=[], total_rows=0))
-
-
 def mock_execute_query_get_total_cost(_query, *_args, **_kwargs):
     """
     This is a mockup function for _execute_query function
@@ -560,8 +553,8 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        assert False is is_current_month
-        assert None is last_loaded_day
+        assert is_current_month is False
+        assert last_loaded_day is None
         assert query_job_result == []
 
     @pytest.mark.asyncio
@@ -581,8 +574,8 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        assert True is is_current_month
-        assert None is last_loaded_day
+        assert is_current_month
+        assert last_loaded_day is None
         assert query_job_result == []
 
     @pytest.mark.asyncio

--- a/test/test_bq_billing_base.py
+++ b/test/test_bq_billing_base.py
@@ -1,12 +1,10 @@
 from datetime import datetime
 from typing import Any
-from unittest import mock
 
 import google.cloud.bigquery as bq
+import pytest
 
-from db.python.tables.bq.billing_base import (
-    BillingBaseTable,
-)
+from db.python.tables.bq.billing_base import BillingBaseTable
 from db.python.tables.bq.billing_daily_extended import BillingDailyExtendedTable
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.billing_utils import (
@@ -29,8 +27,7 @@ from models.models import (
     BillingRunningCostQueryModel,
     BillingTotalCostQueryModel,
 )
-from test.testbase import run_as_sync
-from test.testbqbase import BqTest
+from test.testbqbase import BqTest, MockQueryJob, MockResult
 
 
 def mock_execute_query_running_cost(query, *_args, **_kwargs):
@@ -45,21 +42,24 @@ def mock_execute_query_running_cost(query, *_args, **_kwargs):
     if ' as last_loaded_day' in query:
         # This is the 1st query to get last loaded day
         # mockup BQ query result for last_loaded_day as list of rows
-        return [
-            mock.MagicMock(spec=bq.Row, last_loaded_day='2024-01-01 00:00:00+00:00')
-        ]
+        row_values = ('2024-01-01 00:00:00+00:00',)
+        return [bq.Row(row_values, {'last_loaded_day': 0})]
 
     # This is the 2nd query to get aggregated monthly cost
     # return mockup BQ query result as list of rows
     return [
-        mock.MagicMock(
-            spec=bq.Row,
-            field='TOPIC1',
-            cost_category='Compute Engine',
-            daily_cost=123.45,
-            monthly_cost=2345.67,
-        )
+        bq.Row(
+            ('TOPIC1', 'Compute Engine', 123.45, 2345.67),
+            {'field': 0, 'cost_category': 1, 'daily_cost': 2, 'monthly_cost': 3},
+        ),
     ]
+
+
+def mock_execute_query_empty(_query, *_args, **_kwargs):
+    """
+    Mock function returning an empty MockQueryJob.
+    """
+    return MockQueryJob(MockResult(rows=[], total_rows=0))
 
 
 def mock_execute_query_get_total_cost(_query, *_args, **_kwargs):
@@ -68,23 +68,20 @@ def mock_execute_query_get_total_cost(_query, *_args, **_kwargs):
     This returns one mockup BQ query result
     """
     # mockup BQ query result topic cost by invoice month, return row iterator
-    mock_rows = mock.MagicMock(spec=bq.table.RowIterator)
-    mock_rows.total_rows = 3
-    mock_rows.__iter__.return_value = [
+    rows = [
         {'day': '202301', 'topic': 'TOPIC1', 'cost': 123.10},
         {'day': '202302', 'topic': 'TOPIC1', 'cost': 223.20},
         {'day': '202303', 'topic': 'TOPIC1', 'cost': 323.30},
     ]
-    mock_result = mock.MagicMock(spec=bq.job.QueryJob)
-    mock_result.result.return_value = mock_rows
-    return mock_result
+    return MockQueryJob(MockResult(rows=rows))
 
 
 class TestBillingBaseTable(BqTest):
     """Test BillingBaseTable and its methods"""
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def set_up(self):
+        super().set_up()
 
         # setup table object
         # base is abstract, so we need to use a child class
@@ -118,8 +115,7 @@ class TestBillingBaseTable(BqTest):
         )
         filter_ = BillingBaseTable._query_to_partitioned_filter(query)
 
-        # BillingFilter has __eq__ method, so we can compare them directly
-        self.assertEqual(expected_filter, filter_)
+        assert expected_filter == filter_
 
     def test_abbrev_cost_category(self):
         """Test abbrev_cost_category"""
@@ -133,7 +129,7 @@ class TestBillingBaseTable(BqTest):
 
         # test category to abreveation
         for cat, expected_abrev in categories_to_expected.items():
-            self.assertEqual(expected_abrev, abbrev_cost_category(cat))
+            assert expected_abrev == abbrev_cost_category(cat)
 
     def test_prepare_time_periods_by_day(self):
         """Test prepare_time_periods"""
@@ -147,9 +143,9 @@ class TestBillingBaseTable(BqTest):
 
         time_group = prepare_time_periods(query)
 
-        self.assertEqual('FORMAT_DATE("%Y-%m-%d", day) as day', time_group.field)
-        self.assertEqual('PARSE_DATE("%Y-%m-%d", day) as day', time_group.formula)
-        self.assertEqual(',', time_group.separator)
+        assert time_group.field == 'FORMAT_DATE("%Y-%m-%d", day) as day'
+        assert time_group.formula == 'PARSE_DATE("%Y-%m-%d", day) as day'
+        assert time_group.separator == ','
 
     def test_prepare_time_periods_by_week(self):
         """Test prepare_time_periods"""
@@ -163,9 +159,9 @@ class TestBillingBaseTable(BqTest):
 
         time_group = prepare_time_periods(query)
 
-        self.assertEqual('FORMAT_DATE("%Y%W", day) as day', time_group.field)
-        self.assertEqual('PARSE_DATE("%Y%W", day) as day', time_group.formula)
-        self.assertEqual(',', time_group.separator)
+        assert time_group.field == 'FORMAT_DATE("%Y%W", day) as day'
+        assert time_group.formula == 'PARSE_DATE("%Y%W", day) as day'
+        assert time_group.separator == ','
 
     def test_prepare_time_periods_by_month(self):
         """Test prepare_time_periods"""
@@ -179,9 +175,9 @@ class TestBillingBaseTable(BqTest):
 
         time_group = prepare_time_periods(query)
 
-        self.assertEqual('FORMAT_DATE("%Y%m", day) as day', time_group.field)
-        self.assertEqual('PARSE_DATE("%Y%m", day) as day', time_group.formula)
-        self.assertEqual(',', time_group.separator)
+        assert time_group.field == 'FORMAT_DATE("%Y%m", day) as day'
+        assert time_group.formula == 'PARSE_DATE("%Y%m", day) as day'
+        assert time_group.separator == ','
 
     def test_prepare_time_periods_by_invoice_month(self):
         """Test prepare_time_periods"""
@@ -195,106 +191,74 @@ class TestBillingBaseTable(BqTest):
 
         time_group = prepare_time_periods(query)
 
-        self.assertEqual('invoice_month as day', time_group.field)
-        self.assertEqual('PARSE_DATE("%Y%m", day) as day', time_group.formula)
-        self.assertEqual(',', time_group.separator)
+        assert time_group.field == 'invoice_month as day'
+        assert time_group.formula == 'PARSE_DATE("%Y%m", day) as day'
+        assert time_group.separator == ','
 
     def test_filter_to_optimise_query(self):
         """Test _filter_to_optimise_query"""
 
         result = filter_to_optimise_query()
-        self.assertEqual(
-            'day >= TIMESTAMP(@start_day) AND day <= TIMESTAMP(@last_day)', result
-        )
+        assert result == 'day >= TIMESTAMP(@start_day) AND day <= TIMESTAMP(@last_day)'
 
     def test_last_loaded_day_filter(self):
         """Test _last_loaded_day_filter"""
 
         result = last_loaded_day_filter()
-        self.assertEqual('day = TIMESTAMP(@last_loaded_day)', result)
+        assert result == 'day = TIMESTAMP(@last_loaded_day)'
 
     def test_convert_output_empty_results(self):
         """Test _convert_output - various empty results"""
-
-        empty_results = convert_output(None)
-        self.assertEqual([], empty_results)
-
-        query_job_result = mock.MagicMock(spec=bq.job.QueryJob)
-        query_job_result.result.total_rows = 0
-
-        empty_list = convert_output(query_job_result)
-        self.assertEqual([], empty_list)
-
-        query_job_result = mock.MagicMock(spec=bq.job.QueryJob)
-        query_job_result.result.return_value = mock.MagicMock(spec=bq.table.RowIterator)
-
-        empty_row_iterator = convert_output(query_job_result)
-        self.assertEqual([], empty_row_iterator)
+        assert convert_output(None) == []
+        assert convert_output(MockQueryJob(MockResult(total_rows=0))) == []
+        assert convert_output(MockQueryJob(MockResult(rows=[]))) == []
 
     def test_convert_output_one_record(self):
         """Test _convert_output - one record result"""
-
-        mock_rows = mock.MagicMock(spec=bq.table.RowIterator)
-        mock_rows.total_rows = 1
-        mock_rows.__iter__.return_value = [{}]
-
-        query_job_result = mock.MagicMock(spec=bq.job.QueryJob)
-        query_job_result.result.return_value = mock_rows
-
-        single_row = convert_output(query_job_result)
-        self.assertEqual([{}], single_row)
+        single_row = convert_output(MockQueryJob(MockResult(rows=[{}])))
+        assert single_row == [{}]
 
     def test_convert_output_label_record(self):
         """Test _convert_output - test with label item"""
-        mock_rows = mock.MagicMock(spec=bq.table.RowIterator)
-        mock_rows.total_rows = 1
-        mock_rows.__iter__.return_value = [
-            {'labels': [{'key': 'test_key', 'value': 'test_value'}]}
-        ]
-
-        query_job_result = mock.MagicMock(spec=bq.job.QueryJob)
-        query_job_result.result.return_value = mock_rows
-
-        row_iterator = convert_output(query_job_result)
-        self.assertEqual(
-            [
-                {
-                    # keep the original labels
-                    'labels': [{'key': 'test_key', 'value': 'test_value'}],
-                    # append the labels as key-value pairs
-                    'test_key': 'test_value',
-                }
-            ],
-            row_iterator,
+        row_iterator = convert_output(
+            MockQueryJob(
+                MockResult(
+                    rows=[{'labels': [{'key': 'test_key', 'value': 'test_value'}]}]
+                )
+            )
         )
+        assert row_iterator == [
+            {
+                # keep the original tables
+                'labels': [{'key': 'test_key', 'value': 'test_value'}],
+                # append the labels as key-value pairs
+                'test_key': 'test_value',
+            }
+        ]
 
     def test_prepare_order_by_string_empty(self):
         """Test _prepare_order_by_string - empty results"""
-
-        self.assertEqual('', prepare_order_by_string(None))
+        assert prepare_order_by_string(None) == ''
 
     def test_prepare_order_by_string_order_by_one_column(self):
         """Test _prepare_order_by_string"""
 
         # DESC order by column
-        self.assertEqual(
-            'ORDER BY cost DESC',
-            prepare_order_by_string({BillingColumn.COST: True}),
+        assert (
+            prepare_order_by_string({BillingColumn.COST: True}) == 'ORDER BY cost DESC'
         )
-
         # ASC order by column
-        self.assertEqual(
-            'ORDER BY cost ASC',
-            prepare_order_by_string({BillingColumn.COST: False}),
+        assert (
+            prepare_order_by_string({BillingColumn.COST: False}) == 'ORDER BY cost ASC'
         )
 
     def test_prepare_order_by_string_order_by_two_columns(self):
         """Test _prepare_order_by_string - order by 2 columns"""
-        self.assertEqual(
-            'ORDER BY cost ASC,day DESC',
+        assert (
             prepare_order_by_string(
                 {BillingColumn.COST: False, BillingColumn.DAY: True}
-            ),
+            )
+            == 'ORDER BY cost ASC,day DESC'
         )
 
     def test_prepare_aggregation_default_group_by(self):
@@ -305,10 +269,11 @@ class TestBillingBaseTable(BqTest):
         )
 
         fields_selected, group_by = prepare_aggregation(query)
+
         # no fields selected so it is empty
-        self.assertEqual('', fields_selected)
+        assert fields_selected == ''
         # by default results are grouped by day
-        self.assertEqual('GROUP BY day', group_by)
+        assert group_by == 'GROUP BY day'
 
     def test_prepare_aggregation_default_no_grouping_by(self):
         """Test _prepare_aggregation"""
@@ -322,10 +287,11 @@ class TestBillingBaseTable(BqTest):
         )
 
         fields_selected, group_by = prepare_aggregation(query)
+
         # topic field is selected
-        self.assertEqual('topic', fields_selected)
+        assert fields_selected == 'topic'
         # group by is switched off
-        self.assertEqual('', group_by)
+        assert group_by == ''
 
     def test_prepare_aggregation_default_group_by_more_columns(self):
         """Test _prepare_aggregation"""
@@ -340,9 +306,9 @@ class TestBillingBaseTable(BqTest):
         )
 
         fields_selected, group_by = prepare_aggregation(query)
-        self.assertEqual('topic', fields_selected)
+        assert fields_selected == 'topic'
         # always group by day and any field that can be grouped by
-        self.assertEqual('GROUP BY day,topic', group_by)
+        assert group_by == 'GROUP BY day,topic'
 
     def test_execute_query_results_as_list(self):
         """Test _execute_query"""
@@ -354,11 +320,11 @@ class TestBillingBaseTable(BqTest):
         # test results_as_list=True
         given_bq_results = [[], [123], ['a', 'b', 'c']]
         for bq_result in given_bq_results:
-            self.bq_result.result.return_value = bq_result
+            self.bq_result._rows = bq_result
             results = self.table_obj._execute_query(
                 sql_query, sql_params, results_as_list=True
             )
-            self.assertEqual(bq_result, results)
+            assert bq_result == results
 
     def test_execute_query_results_not_as_list(self):
         """Test _execute_query"""
@@ -371,12 +337,12 @@ class TestBillingBaseTable(BqTest):
         given_bq_results = [[], [123], ['a', 'b', 'c']]
         for bq_result in given_bq_results:
             # mock BigQuery result
-            self.bq_result.result.return_value = bq_result
+            self.bq_result._rows = bq_result
             self.bq_result.total_bytes_processed = 0
             results = self.table_obj._execute_query(
                 sql_query, sql_params, results_as_list=True
             )
-            self.assertEqual(bq_result, results)
+            assert bq_result == results
 
     def test_execute_query_with_sql_params(self):
         """Test _execute_query"""
@@ -390,14 +356,14 @@ class TestBillingBaseTable(BqTest):
         given_bq_results = [[], [123], ['a', 'b', 'c']]
         for bq_result in given_bq_results:
             # mock BigQuery result
-            self.bq_result.result.return_value = bq_result
+            self.bq_result._rows = bq_result
             self.bq_result.total_bytes_processed = 0
             results = self.table_obj._execute_query(
                 sql_query, sql_params, results_as_list=True
             )
-            self.assertEqual(bq_result, results)
+            assert bq_result == results
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_append_total_running_cost_no_topic(self):
         """Test _append_total_running_cost"""
 
@@ -413,26 +379,23 @@ class TestBillingBaseTable(BqTest):
             results=[],
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='All Topics',
-                    total_monthly=3000.0,
-                    total_daily=300.0,
-                    compute_monthly=1000.0,
-                    compute_daily=100.0,
-                    storage_monthly=2000.0,
-                    storage_daily=200.0,
-                    details=[],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day=None,
-                )
-            ],
-            total_record,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='All Topics',
+                total_monthly=3000.0,
+                total_daily=300.0,
+                compute_monthly=1000.0,
+                compute_daily=100.0,
+                storage_monthly=2000.0,
+                storage_daily=200.0,
+                details=[],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day=None,
+            )
+        ] == total_record
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_append_total_running_cost_not_current_month(self):
         """Test _append_total_running_cost"""
 
@@ -448,26 +411,23 @@ class TestBillingBaseTable(BqTest):
             results=[],
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='All Topics',
-                    total_monthly=3000.0,
-                    total_daily=None,
-                    compute_monthly=1000.0,
-                    compute_daily=None,
-                    storage_monthly=2000.0,
-                    storage_daily=None,
-                    details=[],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day=None,
-                )
-            ],
-            total_record,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='All Topics',
+                total_monthly=3000.0,
+                total_daily=None,
+                compute_monthly=1000.0,
+                compute_daily=None,
+                storage_monthly=2000.0,
+                storage_daily=None,
+                details=[],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day=None,
+            )
+        ] == total_record
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_append_total_running_cost_current_month(self):
         """Test _append_total_running_cost"""
 
@@ -490,45 +450,42 @@ class TestBillingBaseTable(BqTest):
             results=[],
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='All Topics',
-                    total_monthly=3000.0,
-                    total_daily=300.0,
-                    compute_monthly=1000.0,
-                    compute_daily=100.0,
-                    storage_monthly=2000.0,
-                    storage_daily=200.0,
-                    details=[
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Compute Engine',
-                            daily_cost=90.0,
-                            monthly_cost=900.0,
-                        ),
-                        BillingCostDetailsRecord(
-                            cost_group='S',
-                            cost_category='Cloud Storage',
-                            daily_cost=200.0,
-                            monthly_cost=2000.0,
-                        ),
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Other',
-                            daily_cost=10.0,
-                            monthly_cost=100.0,
-                        ),
-                    ],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day=None,
-                )
-            ],
-            total_record,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='All Topics',
+                total_monthly=3000.0,
+                total_daily=300.0,
+                compute_monthly=1000.0,
+                compute_daily=100.0,
+                storage_monthly=2000.0,
+                storage_daily=200.0,
+                details=[
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Compute Engine',
+                        daily_cost=90.0,
+                        monthly_cost=900.0,
+                    ),
+                    BillingCostDetailsRecord(
+                        cost_group='S',
+                        cost_category='Cloud Storage',
+                        daily_cost=200.0,
+                        monthly_cost=2000.0,
+                    ),
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Other',
+                        daily_cost=10.0,
+                        monthly_cost=100.0,
+                    ),
+                ],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day=None,
+            )
+        ] == total_record
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_budgets_by_gcp_project_empty_results(self):
         """Test _budgets_by_gcp_project"""
 
@@ -536,61 +493,59 @@ class TestBillingBaseTable(BqTest):
         empty_result = await self.table_obj._budgets_by_gcp_project(
             BillingColumn.TOPIC, False
         )
-        self.assertEqual({}, empty_result)
+        assert empty_result == {}
 
         # GCP_PROJECT and current month, but BQ mockup setup as empty values
         empty_result = await self.table_obj._budgets_by_gcp_project(
             BillingColumn.GCP_PROJECT, True
         )
-        self.assertEqual({}, empty_result)
+        assert empty_result == {}
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_budgets_by_gcp_project_with_results(self):
         """Test _budgets_by_gcp_project"""
 
         # GCP_PROJECT and current month and Mockup set as 2 records
-        self.bq_result.result.return_value = [
-            mock.MagicMock(spec=bq.Row, gcp_project='Project1', budget=1000.0),
-            mock.MagicMock(spec=bq.Row, gcp_project='Project2', budget=2000.0),
+        self.bq_result._rows = [
+            bq.Row(('Project1', 1000.0), {'gcp_project': 0, 'budget': 1}),
+            bq.Row(('Project2', 2000.0), {'gcp_project': 0, 'budget': 1}),
         ]
 
         non_empty_result = await self.table_obj._budgets_by_gcp_project(
             BillingColumn.GCP_PROJECT, True
         )
-        self.assertDictEqual({'Project1': 1000.0, 'Project2': 2000.0}, non_empty_result)
+        assert non_empty_result == {'Project1': 1000.0, 'Project2': 2000.0}
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_execute_running_cost_query_invalid_months(self):
         """Test _execute_running_cost_query"""
 
         # test invalid inputs
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             await self.table_obj._execute_running_cost_query_with_filters(
                 BillingRunningCostQueryModel(
                     field=BillingColumn.TOPIC, invoice_month=None
                 )
             )
+        assert 'Invalid invoice month' in str(context.value)
 
-        self.assertTrue('Invalid invoice month' in str(context.exception))
-
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             await self.table_obj._execute_running_cost_query_with_filters(
                 BillingRunningCostQueryModel(
                     field=BillingColumn.TOPIC, invoice_month='12345678'
                 )
             )
+        assert 'Invalid invoice month' in str(context.value)
 
-        self.assertTrue('Invalid invoice month' in str(context.exception))
-
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             await self.table_obj._execute_running_cost_query_with_filters(
                 BillingRunningCostQueryModel(
                     field=BillingColumn.TOPIC, invoice_month='1024AA'
                 )
             )
-        self.assertTrue('Invalid invoice month' in str(context.exception))
+        assert 'Invalid invoice month' in str(context.value)
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_execute_running_cost_query_empty_results_old_month(self):
         """Test _execute_running_cost_query"""
 
@@ -605,11 +560,11 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        self.assertEqual(False, is_current_month)
-        self.assertEqual(None, last_loaded_day)
-        self.assertEqual([], query_job_result)
+        assert False is is_current_month
+        assert None is last_loaded_day
+        assert query_job_result == []
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_execute_running_cost_query_empty_results_current_month(self):
         """Test _execute_running_cost_query"""
 
@@ -626,11 +581,11 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        self.assertEqual(True, is_current_month)
-        self.assertEqual(None, last_loaded_day)
-        self.assertEqual([], query_job_result)
+        assert True is is_current_month
+        assert None is last_loaded_day
+        assert query_job_result == []
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_append_total_running_cost_empty_results(self):
         """Test append_total_running_cost"""
 
@@ -645,9 +600,9 @@ class TestBillingBaseTable(BqTest):
             results=[],
         )
 
-        self.assertEqual([], empty_results)
+        assert empty_results == []
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_append_running_cost_records_simple_data(self):
         """Test append_running_cost_records"""
 
@@ -666,26 +621,23 @@ class TestBillingBaseTable(BqTest):
             results=[],
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='Project1',
-                    total_monthly=0.0,
-                    compute_monthly=0.0,
-                    compute_daily=0.0,
-                    storage_monthly=0.0,
-                    storage_daily=0.0,
-                    details=[],
-                    last_loaded_day=None,
-                    total_daily=None,
-                    budget_spent=None,
-                    budget=None,
-                )
-            ],
-            simple_result,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='Project1',
+                total_monthly=0.0,
+                compute_monthly=0.0,
+                compute_daily=0.0,
+                storage_monthly=0.0,
+                storage_daily=0.0,
+                details=[],
+                last_loaded_day=None,
+                total_daily=None,
+                budget_spent=None,
+                budget=None,
+            )
+        ] == simple_result
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_append_running_cost_records_with_details(self):
         """Test append_running_cost_records"""
 
@@ -711,38 +663,35 @@ class TestBillingBaseTable(BqTest):
             results=[],
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='Project2',
-                    total_monthly=0.0,
-                    compute_monthly=0.0,
-                    compute_daily=0.0,
-                    storage_monthly=0.0,
-                    storage_daily=0.0,
-                    details=[
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Compute Engine',
-                            daily_cost=90.0,
-                            monthly_cost=900.0,
-                        )
-                    ],
-                    last_loaded_day=None,
-                    total_daily=None,
-                    budget_spent=None,
-                    budget=None,
-                )
-            ],
-            detailed_result,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='Project2',
+                total_monthly=0.0,
+                compute_monthly=0.0,
+                compute_daily=0.0,
+                storage_monthly=0.0,
+                storage_daily=0.0,
+                details=[
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Compute Engine',
+                        daily_cost=90.0,
+                        monthly_cost=900.0,
+                    )
+                ],
+                last_loaded_day=None,
+                total_daily=None,
+                budget_spent=None,
+                budget=None,
+            )
+        ] == detailed_result
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_get_running_cost_invalid_input(self):
         """Test get_running_cost"""
 
         # test invalid outputs
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             await self.table_obj.get_running_cost_with_filters(
                 # not allowed field
                 BillingRunningCostQueryModel(
@@ -751,15 +700,12 @@ class TestBillingBaseTable(BqTest):
                 )
             )
 
-        self.assertTrue(
-            (
-                'Invalid field only topic, dataset, gcp-project, compute_category, '
-                'wdl_task_name, cromwell_sub_workflow_name & namespace are allowed'
-            )
-            in str(context.exception)
-        )
+        assert (
+            'Invalid field only topic, dataset, gcp-project, compute_category, '
+            'wdl_task_name, cromwell_sub_workflow_name & namespace are allowed'
+        ) in str(context.value)
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_get_running_cost_empty_results(self):
         """Test get_running_cost"""
 
@@ -771,16 +717,14 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        self.assertEqual([], empty_results)
+        assert empty_results == []
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_get_running_cost_older_month(self):
         """Test get_running_cost"""
 
         # mockup BQ sql query result for _execute_running_cost_query function
-        self.table_obj._execute_query = mock.MagicMock(
-            side_effect=mock_execute_query_running_cost
-        )
+        self.table_obj._execute_query = mock_execute_query_running_cost
 
         one_record_result = await self.table_obj.get_running_cost_with_filters(
             BillingRunningCostQueryModel(
@@ -789,61 +733,55 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='All Topics',
-                    total_monthly=2345.67,
-                    total_daily=None,
-                    compute_monthly=2345.67,
-                    compute_daily=None,
-                    storage_monthly=0.0,
-                    storage_daily=None,
-                    details=[
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Compute Engine',
-                            daily_cost=None,
-                            monthly_cost=2345.67,
-                        )
-                    ],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day=None,
-                ),
-                BillingCostBudgetRecord(
-                    field='TOPIC1',
-                    total_monthly=2345.67,
-                    total_daily=None,
-                    compute_monthly=2345.67,
-                    compute_daily=0.0,
-                    storage_monthly=0.0,
-                    storage_daily=0.0,
-                    details=[
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Compute Engine',
-                            daily_cost=None,
-                            monthly_cost=2345.67,
-                        )
-                    ],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day=None,
-                ),
-            ],
-            one_record_result,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='All Topics',
+                total_monthly=2345.67,
+                total_daily=None,
+                compute_monthly=2345.67,
+                compute_daily=None,
+                storage_monthly=0.0,
+                storage_daily=None,
+                details=[
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Compute Engine',
+                        daily_cost=None,
+                        monthly_cost=2345.67,
+                    )
+                ],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day=None,
+            ),
+            BillingCostBudgetRecord(
+                field='TOPIC1',
+                total_monthly=2345.67,
+                total_daily=None,
+                compute_monthly=2345.67,
+                compute_daily=0.0,
+                storage_monthly=0.0,
+                storage_daily=0.0,
+                details=[
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Compute Engine',
+                        daily_cost=None,
+                        monthly_cost=2345.67,
+                    )
+                ],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day=None,
+            ),
+        ] == one_record_result
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_get_running_cost_current_month(self):
         """Test get_running_cost"""
 
         # mockup BQ sql query result for _execute_running_cost_query function
-        self.table_obj._execute_query = mock.MagicMock(
-            side_effect=mock_execute_query_running_cost
-        )
-
+        self.table_obj._execute_query = mock_execute_query_running_cost
         # use the current month to test the current month branch
         current_month_as_string = datetime.now().strftime('%Y%m')
 
@@ -854,53 +792,50 @@ class TestBillingBaseTable(BqTest):
             )
         )
 
-        self.assertEqual(
-            [
-                BillingCostBudgetRecord(
-                    field='All Topics',
-                    total_monthly=2345.67,
-                    total_daily=123.45,
-                    compute_monthly=2345.67,
-                    compute_daily=123.45,
-                    storage_monthly=0.0,
-                    storage_daily=0.0,
-                    details=[
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Compute Engine',
-                            daily_cost=123.45,
-                            monthly_cost=2345.67,
-                        )
-                    ],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day='Jan 01',
-                ),
-                BillingCostBudgetRecord(
-                    field='TOPIC1',
-                    total_monthly=2345.67,
-                    total_daily=123.45,
-                    compute_monthly=2345.67,
-                    compute_daily=123.45,
-                    storage_monthly=0.0,
-                    storage_daily=0.0,
-                    details=[
-                        BillingCostDetailsRecord(
-                            cost_group='C',
-                            cost_category='Compute Engine',
-                            daily_cost=123.45,
-                            monthly_cost=2345.67,
-                        )
-                    ],
-                    budget_spent=None,
-                    budget=None,
-                    last_loaded_day='Jan 01',
-                ),
-            ],
-            current_month_result,
-        )
+        assert [
+            BillingCostBudgetRecord(
+                field='All Topics',
+                total_monthly=2345.67,
+                total_daily=123.45,
+                compute_monthly=2345.67,
+                compute_daily=123.45,
+                storage_monthly=0.0,
+                storage_daily=0.0,
+                details=[
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Compute Engine',
+                        daily_cost=123.45,
+                        monthly_cost=2345.67,
+                    )
+                ],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day='Jan 01',
+            ),
+            BillingCostBudgetRecord(
+                field='TOPIC1',
+                total_monthly=2345.67,
+                total_daily=123.45,
+                compute_monthly=2345.67,
+                compute_daily=123.45,
+                storage_monthly=0.0,
+                storage_daily=0.0,
+                details=[
+                    BillingCostDetailsRecord(
+                        cost_group='C',
+                        cost_category='Compute Engine',
+                        daily_cost=123.45,
+                        monthly_cost=2345.67,
+                    )
+                ],
+                budget_spent=None,
+                budget=None,
+                last_loaded_day='Jan 01',
+            ),
+        ] == current_month_result
 
-    @run_as_sync
+    @pytest.mark.asyncio
     async def test_get_total_cost(self):
         """Test get_total_cost"""
 
@@ -909,10 +844,9 @@ class TestBillingBaseTable(BqTest):
             fields=[], start_date='2023-01-01', end_date='2024-01-01'
         )
 
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             await self.table_obj.get_total_cost(query)
-
-        self.assertTrue('Date and Fields are required' in str(context.exception))
+        assert 'Date and Fields are required' in str(context.value)
 
         # test empty results
         query = BillingTotalCostQueryModel(
@@ -924,19 +858,15 @@ class TestBillingBaseTable(BqTest):
 
         # no BQ mockup data setup, returns empty list
         empty_results = await self.table_obj.get_total_cost(query)
-        self.assertEqual([], empty_results)
+        assert empty_results == []
 
         # mockup BQ sql query result for _execute_query to return 3 records.
         # implementation is inside mock_execute_query function
-        self.table_obj._execute_query = mock.MagicMock(
-            side_effect=mock_execute_query_get_total_cost
-        )
+        self.table_obj._execute_query = mock_execute_query_get_total_cost
+
         results = await self.table_obj.get_total_cost(query)
-        self.assertEqual(
-            [
-                {'day': '202301', 'topic': 'TOPIC1', 'cost': 123.1},
-                {'day': '202302', 'topic': 'TOPIC1', 'cost': 223.2},
-                {'day': '202303', 'topic': 'TOPIC1', 'cost': 323.3},
-            ],
-            results,
-        )
+        assert results == [
+            {'day': '202301', 'topic': 'TOPIC1', 'cost': 123.1},
+            {'day': '202302', 'topic': 'TOPIC1', 'cost': 223.2},
+            {'day': '202303', 'topic': 'TOPIC1', 'cost': 323.3},
+        ]

--- a/test/test_bq_billing_daily.py
+++ b/test/test_bq_billing_daily.py
@@ -1,23 +1,23 @@
 import datetime
 from typing import Any
-from unittest import mock
 
 import google.cloud.bigquery as bq
+import pytest
 
 from db.python.tables.bq.billing_daily import BillingDailyTable
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
 from db.python.utils import InternalError
 from models.models import BillingColumn, BillingTotalCostQueryModel
-from test.testbase import run_as_sync
 from test.testbqbase import BqTest
 
 
 class TestBillingDailyTable(BqTest):
     """Test BillingRawTable and its methods"""
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def set_up(self):
+        super().set_up()
 
         # setup table object
         self.table_obj = BillingDailyTable(self.connection)
@@ -50,17 +50,16 @@ class TestBillingDailyTable(BqTest):
         filter_ = BillingDailyTable._query_to_partitioned_filter(query)
 
         # BillingFilter has __eq__ method, so we can compare them directly
-        self.assertEqual(expected_filter, filter_)
+        assert expected_filter == filter_
 
     def test_error_no_connection(self):
         """Test No connection exception"""
 
-        with self.assertRaises(InternalError) as context:
+        with pytest.raises(InternalError) as context:
             BillingDailyTable(None)
 
-        self.assertTrue(
-            "No connection was provided to the table 'BillingDailyTable'"
-            in str(context.exception)
+        assert "No connection was provided to the table 'BillingDailyTable'" in str(
+            context.value
         )
 
     def test_get_table_name(self):
@@ -75,41 +74,39 @@ class TestBillingDailyTable(BqTest):
         # test get table name function
         table_name = self.table_obj.get_table_name()
 
-        self.assertEqual(given_table_name, table_name)
+        assert given_table_name == table_name
 
-    @run_as_sync
-    async def test_last_loaded_day_return_valid_day(self):
+    @pytest.mark.asyncio
+    async def test_last_loaded_day_return_valid_day(self, monkeypatch):
         """Test _last_loaded_day"""
 
         given_last_day = '2021-01-01 00:00:00'
 
         # mock BigQuery result
+        row_values = (datetime.datetime.strptime(given_last_day, '%Y-%m-%d %H:%M:%S'),)
 
-        self.bq_result.result.return_value = [
-            mock.MagicMock(
-                spec=bq.Row,
-                last_loaded_day=datetime.datetime.strptime(
-                    given_last_day, '%Y-%m-%d %H:%M:%S'
-                ),
-            )
-        ]  # 2021-01-01
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return([bq.Row(row_values, {'last_loaded_day': 0})]),
+        )  # 2021-01-01
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
 
-        self.assertEqual(given_last_day, last_loaded_day)
+        assert given_last_day == last_loaded_day
 
-    @run_as_sync
-    async def test_last_loaded_day_return_none(self):
+    @pytest.mark.asyncio
+    async def test_last_loaded_day_return_none(self, monkeypatch):
         """Test _last_loaded_day as None"""
 
         # mock BigQuery result as empty list
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
 
-        self.assertEqual(None, last_loaded_day)
+        assert last_loaded_day is None
 
     def test_prepare_daily_cost_subquery(self):
         """Test _prepare_daily_cost_subquery"""
@@ -146,109 +143,128 @@ class TestBillingDailyTable(BqTest):
         AND month.cost_category = day.cost_category
         """
 
-        self.assertEqual(
-            [
-                bq.ScalarQueryParameter(
-                    'last_loaded_day', 'STRING', '2021-01-01 00:00:00'
-                )
-            ],
-            query_params,
-        )
+        assert [
+            bq.ScalarQueryParameter('last_loaded_day', 'STRING', '2021-01-01 00:00:00')
+        ] == query_params
 
-        self.assertEqual(', day.cost as daily_cost', daily_cost_field)
-        self.assertEqual(expected_daily_cost_join, daily_cost_join)
+        assert daily_cost_field == ', day.cost as daily_cost'
+        assert expected_daily_cost_join == daily_cost_join
 
-    @run_as_sync
-    async def test_get_entities_as_empty_list(self):
+    @pytest.mark.asyncio
+    async def test_get_entities_as_empty_list(self, monkeypatch):
         """
         Test get_topics, get_invoice_months,
         get_cost_categories and get_skus as empty list
         """
 
         # mock BigQuery result as empty list
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get_topics function
         records = await self.table_obj.get_topics()
-        self.assertEqual([], records)
+        assert records == []
 
         # test get_invoice_months function
         records = await self.table_obj.get_invoice_months()
-        self.assertEqual([], records)
+        assert records == []
 
         # test get_cost_categories function
         records = await self.table_obj.get_cost_categories()
-        self.assertEqual([], records)
+        assert records == []
 
         # test get_skus function
         records = await self.table_obj.get_skus()
-        self.assertEqual([], records)
+        assert records == []
 
-    @run_as_sync
-    async def test_get_topics_return_valid_list(self):
+    @pytest.mark.asyncio
+    async def test_get_topics_return_valid_list(self, monkeypatch):
         """Test get_topics as empty list"""
 
         # mock BigQuery result as list of 2 records
-        self.bq_result.result.return_value = [
-            {'topic': 'TOPIC1'},
-            {'topic': 'TOPIC2'},
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    {'topic': 'TOPIC1'},
+                    {'topic': 'TOPIC2'},
+                ]
+            ),
+        )
 
         # test get_topics function
         records = await self.table_obj.get_topics()
 
-        self.assertEqual(['TOPIC1', 'TOPIC2'], records)
+        assert records == ['TOPIC1', 'TOPIC2']
 
-    @run_as_sync
-    async def test_get_invoice_months_return_valid_list(self):
+    @pytest.mark.asyncio
+    async def test_get_invoice_months_return_valid_list(self, monkeypatch):
         """Test get_invoice_months as empty list"""
 
         # mock BigQuery result as list of 2 records
-        self.bq_result.result.return_value = [
-            {'invoice_month': '202401'},
-            {'invoice_month': '202402'},
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    {'invoice_month': '202401'},
+                    {'invoice_month': '202402'},
+                ]
+            ),
+        )
 
         # test get_invoice_months function
         records = await self.table_obj.get_invoice_months()
 
-        self.assertEqual(['202401', '202402'], records)
+        assert records == ['202401', '202402']
 
-    @run_as_sync
-    async def test_get_cost_categories_return_valid_list(self):
+    @pytest.mark.asyncio
+    async def test_get_cost_categories_return_valid_list(self, monkeypatch):
         """Test get_cost_categories as empty list"""
 
         # mock BigQuery result as list of 2 records
-        self.bq_result.result.return_value = [
-            {'cost_category': 'CAT1'},
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    {'cost_category': 'CAT1'},
+                ]
+            ),
+        )
 
         # test get_cost_categories function
         records = await self.table_obj.get_cost_categories()
 
-        self.assertEqual(['CAT1'], records)
+        assert records == ['CAT1']
 
-    @run_as_sync
-    async def test_get_skus_return_valid_list(self):
+    @pytest.mark.asyncio
+    async def test_get_skus_return_valid_list(self, monkeypatch):
         """Test get_skus as empty list"""
 
         # mock BigQuery result as list of 3 records
-        self.bq_result.result.return_value = [
-            {'sku': 'SKU1'},
-            {'sku': 'SKU2'},
-            {'sku': 'SKU3'},
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    {'sku': 'SKU1'},
+                    {'sku': 'SKU2'},
+                    {'sku': 'SKU3'},
+                ]
+            ),
+        )
 
         # test get_skus function
         records = await self.table_obj.get_skus()
-        self.assertEqual(['SKU1', 'SKU2', 'SKU3'], records)
+        assert records == ['SKU1', 'SKU2', 'SKU3']
 
         # test get_skus function with limit,
         # limit is ignored in the test as we already have mockup data
         records = await self.table_obj.get_skus(limit=3)
-        self.assertEqual(['SKU1', 'SKU2', 'SKU3'], records)
+        assert records == ['SKU1', 'SKU2', 'SKU3']
 
         # test get_skus function with limit & offset
         # limit & offset are ignored in the test as we already have mockup data
         records = await self.table_obj.get_skus(limit=3, offset=1)
-        self.assertEqual(['SKU1', 'SKU2', 'SKU3'], records)
+        assert records == ['SKU1', 'SKU2', 'SKU3']

--- a/test/test_bq_billing_daily.py
+++ b/test/test_bq_billing_daily.py
@@ -77,7 +77,7 @@ class TestBillingDailyTable(BqTest):
         assert given_table_name == table_name
 
     @pytest.mark.asyncio
-    async def test_last_loaded_day_return_valid_day(self, monkeypatch):
+    async def test_last_loaded_day_return_valid_day(self):
         """Test _last_loaded_day"""
 
         given_last_day = '2021-01-01 00:00:00'
@@ -85,11 +85,9 @@ class TestBillingDailyTable(BqTest):
         # mock BigQuery result
         row_values = (datetime.datetime.strptime(given_last_day, '%Y-%m-%d %H:%M:%S'),)
 
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return([bq.Row(row_values, {'last_loaded_day': 0})]),
-        )  # 2021-01-01
+        self.bq_result._rows = [
+            bq.Row(row_values, {'last_loaded_day': 0})
+        ]  # 2021-01-01
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
@@ -97,11 +95,11 @@ class TestBillingDailyTable(BqTest):
         assert given_last_day == last_loaded_day
 
     @pytest.mark.asyncio
-    async def test_last_loaded_day_return_none(self, monkeypatch):
+    async def test_last_loaded_day_return_none(self):
         """Test _last_loaded_day as None"""
 
         # mock BigQuery result as empty list
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
@@ -151,14 +149,14 @@ class TestBillingDailyTable(BqTest):
         assert expected_daily_cost_join == daily_cost_join
 
     @pytest.mark.asyncio
-    async def test_get_entities_as_empty_list(self, monkeypatch):
+    async def test_get_entities_as_empty_list(self):
         """
         Test get_topics, get_invoice_months,
         get_cost_categories and get_skus as empty list
         """
 
         # mock BigQuery result as empty list
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get_topics function
         records = await self.table_obj.get_topics()
@@ -177,20 +175,14 @@ class TestBillingDailyTable(BqTest):
         assert records == []
 
     @pytest.mark.asyncio
-    async def test_get_topics_return_valid_list(self, monkeypatch):
+    async def test_get_topics_return_valid_list(self):
         """Test get_topics as empty list"""
 
         # mock BigQuery result as list of 2 records
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    {'topic': 'TOPIC1'},
-                    {'topic': 'TOPIC2'},
-                ]
-            ),
-        )
+        self.bq_result._rows = [
+            {'topic': 'TOPIC1'},
+            {'topic': 'TOPIC2'},
+        ]
 
         # test get_topics function
         records = await self.table_obj.get_topics()
@@ -198,20 +190,14 @@ class TestBillingDailyTable(BqTest):
         assert records == ['TOPIC1', 'TOPIC2']
 
     @pytest.mark.asyncio
-    async def test_get_invoice_months_return_valid_list(self, monkeypatch):
+    async def test_get_invoice_months_return_valid_list(self):
         """Test get_invoice_months as empty list"""
 
         # mock BigQuery result as list of 2 records
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    {'invoice_month': '202401'},
-                    {'invoice_month': '202402'},
-                ]
-            ),
-        )
+        self.bq_result._rows = [
+            {'invoice_month': '202401'},
+            {'invoice_month': '202402'},
+        ]
 
         # test get_invoice_months function
         records = await self.table_obj.get_invoice_months()
@@ -219,19 +205,13 @@ class TestBillingDailyTable(BqTest):
         assert records == ['202401', '202402']
 
     @pytest.mark.asyncio
-    async def test_get_cost_categories_return_valid_list(self, monkeypatch):
+    async def test_get_cost_categories_return_valid_list(self):
         """Test get_cost_categories as empty list"""
 
         # mock BigQuery result as list of 2 records
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    {'cost_category': 'CAT1'},
-                ]
-            ),
-        )
+        self.bq_result._rows = [
+            {'cost_category': 'CAT1'},
+        ]
 
         # test get_cost_categories function
         records = await self.table_obj.get_cost_categories()
@@ -239,21 +219,15 @@ class TestBillingDailyTable(BqTest):
         assert records == ['CAT1']
 
     @pytest.mark.asyncio
-    async def test_get_skus_return_valid_list(self, monkeypatch):
+    async def test_get_skus_return_valid_list(self):
         """Test get_skus as empty list"""
 
         # mock BigQuery result as list of 3 records
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    {'sku': 'SKU1'},
-                    {'sku': 'SKU2'},
-                    {'sku': 'SKU3'},
-                ]
-            ),
-        )
+        self.bq_result._rows = [
+            {'sku': 'SKU1'},
+            {'sku': 'SKU2'},
+            {'sku': 'SKU3'},
+        ]
 
         # test get_skus function
         records = await self.table_obj.get_skus()

--- a/test/test_bq_billing_daily_extended.py
+++ b/test/test_bq_billing_daily_extended.py
@@ -1,20 +1,22 @@
 import datetime
 from typing import Any
 
+import pytest
+
 from db.python.tables.bq.billing_daily_extended import BillingDailyExtendedTable
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
 from db.python.utils import InternalError
 from models.models import BillingColumn, BillingTotalCostQueryModel
-from test.testbase import run_as_sync
 from test.testbqbase import BqTest
 
 
 class TestBillingGcpDailyTable(BqTest):
     """Test BillingRawTable and its methods"""
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def set_up(self):
+        super().set_up()
 
         # setup table object
         self.table_obj = BillingDailyExtendedTable(self.connection)
@@ -47,17 +49,17 @@ class TestBillingGcpDailyTable(BqTest):
         filter_ = BillingDailyExtendedTable._query_to_partitioned_filter(query)
 
         # BillingFilter has __eq__ method, so we can compare them directly
-        self.assertEqual(expected_filter, filter_)
+        assert expected_filter == filter_
 
     def test_error_no_connection(self):
         """Test No connection exception"""
 
-        with self.assertRaises(InternalError) as context:
+        with pytest.raises(InternalError) as context:
             BillingDailyExtendedTable(None)
 
-        self.assertTrue(
+        assert (
             "No connection was provided to the table 'BillingDailyExtendedTable'"
-            in str(context.exception)
+            in str(context.value)
         )
 
     def test_get_table_name(self):
@@ -72,44 +74,45 @@ class TestBillingGcpDailyTable(BqTest):
         # test get table name function
         table_name = self.table_obj.get_table_name()
 
-        self.assertEqual(given_table_name, table_name)
+        assert given_table_name == table_name
 
-    @run_as_sync
-    async def test_get_extended_values_return_empty_list(self):
+    @pytest.mark.asyncio
+    async def test_get_extended_values_return_empty_list(self, monkeypatch):
         """Test get_extended_values as empty list"""
 
         # mock BigQuery result as empty list
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get table name function
         records = await self.table_obj.get_extended_values('dataset')
 
-        self.assertEqual([], records)
+        assert records == []
 
-    @run_as_sync
-    async def test_get_extended_values_return_valid_list(self):
+    @pytest.mark.asyncio
+    async def test_get_extended_values_return_valid_list(self, monkeypatch):
         """Test get_extended_values as list of 2 records"""
 
         # mock BigQuery result as list of 2 records
-        self.bq_result.result.return_value = [
-            {'dataset': 'DATA1'},
-            {'dataset': 'DATA2'},
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return([{'dataset': 'DATA1'}, {'dataset': 'DATA2'}]),
+        )
 
         # test get table name function
         records = await self.table_obj.get_extended_values('dataset')
 
-        self.assertEqual(['DATA1', 'DATA2'], records)
+        assert records == ['DATA1', 'DATA2']
 
-    @run_as_sync
-    async def test_get_extended_values_error(self):
+    @pytest.mark.asyncio
+    async def test_get_extended_values_error(self, monkeypatch):
         """Test get_extended_values return exception as invalid ext column"""
 
         # mock BigQuery result as empty list
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get table name function
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             await self.table_obj.get_extended_values('rubish')
 
-        self.assertTrue('Invalid field value' in str(context.exception))
+        assert 'Invalid field value' in str(context.value)

--- a/test/test_bq_billing_daily_extended.py
+++ b/test/test_bq_billing_daily_extended.py
@@ -77,11 +77,11 @@ class TestBillingGcpDailyTable(BqTest):
         assert given_table_name == table_name
 
     @pytest.mark.asyncio
-    async def test_get_extended_values_return_empty_list(self, monkeypatch):
+    async def test_get_extended_values_return_empty_list(self):
         """Test get_extended_values as empty list"""
 
         # mock BigQuery result as empty list
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get table name function
         records = await self.table_obj.get_extended_values('dataset')
@@ -89,15 +89,11 @@ class TestBillingGcpDailyTable(BqTest):
         assert records == []
 
     @pytest.mark.asyncio
-    async def test_get_extended_values_return_valid_list(self, monkeypatch):
+    async def test_get_extended_values_return_valid_list(self):
         """Test get_extended_values as list of 2 records"""
 
         # mock BigQuery result as list of 2 records
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return([{'dataset': 'DATA1'}, {'dataset': 'DATA2'}]),
-        )
+        self.bq_result._rows = [{'dataset': 'DATA1'}, {'dataset': 'DATA2'}]
 
         # test get table name function
         records = await self.table_obj.get_extended_values('dataset')
@@ -105,11 +101,11 @@ class TestBillingGcpDailyTable(BqTest):
         assert records == ['DATA1', 'DATA2']
 
     @pytest.mark.asyncio
-    async def test_get_extended_values_error(self, monkeypatch):
+    async def test_get_extended_values_error(self):
         """Test get_extended_values return exception as invalid ext column"""
 
         # mock BigQuery result as empty list
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get table name function
         with pytest.raises(ValueError) as context:

--- a/test/test_bq_billing_gcp_daily.py
+++ b/test/test_bq_billing_gcp_daily.py
@@ -1,24 +1,24 @@
 import datetime
 from textwrap import dedent
 from typing import Any
-from unittest import mock
 
 import google.cloud.bigquery as bq
+import pytest
 
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.billing_gcp_daily import BillingGcpDailyTable
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
 from db.python.utils import InternalError
 from models.models import BillingColumn, BillingTotalCostQueryModel
-from test.testbase import run_as_sync
 from test.testbqbase import BqTest
 
 
 class TestBillingGcpDailyTable(BqTest):
     """Test BillingRawTable and its methods"""
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def set_up(self):
+        super().set_up()
 
         # setup table object
         self.table_obj = BillingGcpDailyTable(self.connection)
@@ -55,17 +55,16 @@ class TestBillingGcpDailyTable(BqTest):
         filter_ = BillingGcpDailyTable._query_to_partitioned_filter(query)
 
         # BillingFilter has __eq__ method, so we can compare them directly
-        self.assertEqual(expected_filter, filter_)
+        assert expected_filter == filter_
 
     def test_error_no_connection(self):
         """Test No connection exception"""
 
-        with self.assertRaises(InternalError) as context:
+        with pytest.raises(InternalError) as context:
             BillingGcpDailyTable(None)
 
-        self.assertTrue(
-            "No connection was provided to the table 'BillingGcpDailyTable'"
-            in str(context.exception)
+        assert "No connection was provided to the table 'BillingGcpDailyTable'" in str(
+            context.value
         )
 
     def test_get_table_name(self):
@@ -80,41 +79,41 @@ class TestBillingGcpDailyTable(BqTest):
         # test get table name function
         table_name = self.table_obj.get_table_name()
 
-        self.assertEqual(given_table_name, table_name)
+        assert given_table_name == table_name
 
-    @run_as_sync
-    async def test_last_loaded_day_return_valid_day(self):
+    @pytest.mark.asyncio
+    async def test_last_loaded_day_return_valid_day(self, monkeypatch):
         """Test _last_loaded_day"""
 
         given_last_day = '2021-01-01 00:00:00'
 
         # mock BigQuery result
+        row_values = (
+            (datetime.datetime.strptime(given_last_day, '%Y-%m-%d %H:%M:%S')),
+        )
 
-        self.bq_result.result.return_value = [
-            mock.MagicMock(
-                spec=bq.Row,
-                last_loaded_day=datetime.datetime.strptime(
-                    given_last_day, '%Y-%m-%d %H:%M:%S'
-                ),
-            )
-        ]  # 2021-01-01
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return([bq.Row(row_values, {'last_loaded_day': 0})]),
+        )  # 2021-01-01
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
 
-        self.assertEqual(given_last_day, last_loaded_day)
+        assert given_last_day == last_loaded_day
 
-    @run_as_sync
-    async def test_last_loaded_day_return_none(self):
+    @pytest.mark.asyncio
+    async def test_last_loaded_day_return_none(self, monkeypatch):
         """Test _last_loaded_day as None"""
 
         # mock BigQuery result as empty list
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
 
-        self.assertEqual(None, last_loaded_day)
+        assert last_loaded_day is None
 
     def test_prepare_daily_cost_subquery(self):
         """Test _prepare_daily_cost_subquery"""
@@ -157,40 +156,42 @@ class TestBillingGcpDailyTable(BqTest):
         AND month.cost_category = day.cost_category
         """
 
-        self.assertEqual(
-            [
-                bq.ScalarQueryParameter(
-                    'last_loaded_day', 'STRING', '2021-01-01 00:00:00'
-                )
-            ],
-            query_params,
-        )
-        self.assertEqual(', day.cost as daily_cost', daily_cost_field)
-        self.assertEqual(dedent(expected_daily_cost_join), dedent(daily_cost_join))
+        assert [
+            bq.ScalarQueryParameter('last_loaded_day', 'STRING', '2021-01-01 00:00:00')
+        ] == query_params
 
-    @run_as_sync
-    async def test_get_gcp_projects_return_empty_list(self):
+        assert daily_cost_field == ', day.cost as daily_cost'
+        assert dedent(expected_daily_cost_join) == dedent(daily_cost_join)
+
+    @pytest.mark.asyncio
+    async def test_get_gcp_projects_return_empty_list(self, monkeypatch):
         """Test get_gcp_projects as empty list"""
 
         # mock BigQuery result as empty list
-        self.bq_result.result.return_value = []
+        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
 
         # test get table name function
         gcp_projects = await self.table_obj.get_gcp_projects()
 
-        self.assertEqual([], gcp_projects)
+        assert gcp_projects == []
 
-    @run_as_sync
-    async def test_get_gcp_projects_return_valid_list(self):
+    @pytest.mark.asyncio
+    async def test_get_gcp_projects_return_valid_list(self, monkeypatch):
         """Test get_gcp_projects as empty list"""
 
         # mock BigQuery result as list of 2 records
-        self.bq_result.result.return_value = [
-            {'gcp_project': 'PROJECT1'},
-            {'gcp_project': 'PROJECT2'},
-        ]
+        monkeypatch.setattr(
+            self.bq_result,
+            'result',
+            self.mock_return(
+                [
+                    {'gcp_project': 'PROJECT1'},
+                    {'gcp_project': 'PROJECT2'},
+                ]
+            ),
+        )
 
         # test get table name function
         gcp_projects = await self.table_obj.get_gcp_projects()
 
-        self.assertEqual(['PROJECT1', 'PROJECT2'], gcp_projects)
+        assert gcp_projects == ['PROJECT1', 'PROJECT2']

--- a/test/test_bq_billing_gcp_daily.py
+++ b/test/test_bq_billing_gcp_daily.py
@@ -82,7 +82,7 @@ class TestBillingGcpDailyTable(BqTest):
         assert given_table_name == table_name
 
     @pytest.mark.asyncio
-    async def test_last_loaded_day_return_valid_day(self, monkeypatch):
+    async def test_last_loaded_day_return_valid_day(self):
         """Test _last_loaded_day"""
 
         given_last_day = '2021-01-01 00:00:00'
@@ -92,11 +92,9 @@ class TestBillingGcpDailyTable(BqTest):
             (datetime.datetime.strptime(given_last_day, '%Y-%m-%d %H:%M:%S')),
         )
 
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return([bq.Row(row_values, {'last_loaded_day': 0})]),
-        )  # 2021-01-01
+        self.bq_result._rows = [
+            bq.Row(row_values, {'last_loaded_day': 0})
+        ]  # 2021-01-01
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
@@ -104,11 +102,11 @@ class TestBillingGcpDailyTable(BqTest):
         assert given_last_day == last_loaded_day
 
     @pytest.mark.asyncio
-    async def test_last_loaded_day_return_none(self, monkeypatch):
+    async def test_last_loaded_day_return_none(self):
         """Test _last_loaded_day as None"""
 
         # mock BigQuery result as empty list
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get table name function
         last_loaded_day = await self.table_obj._last_loaded_day()
@@ -164,11 +162,11 @@ class TestBillingGcpDailyTable(BqTest):
         assert dedent(expected_daily_cost_join) == dedent(daily_cost_join)
 
     @pytest.mark.asyncio
-    async def test_get_gcp_projects_return_empty_list(self, monkeypatch):
+    async def test_get_gcp_projects_return_empty_list(self):
         """Test get_gcp_projects as empty list"""
 
         # mock BigQuery result as empty list
-        monkeypatch.setattr(self.bq_result, 'result', self.mock_return([]))
+        self.bq_result._rows = []
 
         # test get table name function
         gcp_projects = await self.table_obj.get_gcp_projects()
@@ -176,20 +174,14 @@ class TestBillingGcpDailyTable(BqTest):
         assert gcp_projects == []
 
     @pytest.mark.asyncio
-    async def test_get_gcp_projects_return_valid_list(self, monkeypatch):
+    async def test_get_gcp_projects_return_valid_list(self):
         """Test get_gcp_projects as empty list"""
 
         # mock BigQuery result as list of 2 records
-        monkeypatch.setattr(
-            self.bq_result,
-            'result',
-            self.mock_return(
-                [
-                    {'gcp_project': 'PROJECT1'},
-                    {'gcp_project': 'PROJECT2'},
-                ]
-            ),
-        )
+        self.bq_result._rows = [
+            {'gcp_project': 'PROJECT1'},
+            {'gcp_project': 'PROJECT2'},
+        ]
 
         # test get table name function
         gcp_projects = await self.table_obj.get_gcp_projects()

--- a/test/test_bq_billing_raw.py
+++ b/test/test_bq_billing_raw.py
@@ -1,6 +1,8 @@
 import datetime
 from typing import Any
 
+import pytest
+
 from db.python.tables.bq.billing_filter import BillingFilter
 from db.python.tables.bq.billing_raw import BillingRawTable
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
@@ -12,8 +14,9 @@ from test.testbqbase import BqTest
 class TestBillingRawTable(BqTest):
     """Test BillingRawTable and its methods"""
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def set_up(self):
+        super().set_up()
 
         # setup table object
         self.table_obj = BillingRawTable(self.connection)
@@ -46,17 +49,16 @@ class TestBillingRawTable(BqTest):
         filter_ = BillingRawTable._query_to_partitioned_filter(query)
 
         # BillingFilter has __eq__ method, so we can compare them directly
-        self.assertEqual(expected_filter, filter_)
+        assert expected_filter == filter_
 
     def test_error_no_connection(self):
         """Test No connection exception"""
 
-        with self.assertRaises(InternalError) as context:
+        with pytest.raises(InternalError) as context:
             BillingRawTable(None)
 
-        self.assertTrue(
-            "No connection was provided to the table 'BillingRawTable'"
-            in str(context.exception)
+        assert "No connection was provided to the table 'BillingRawTable'" in str(
+            context.value
         )
 
     def test_get_table_name(self):
@@ -71,4 +73,4 @@ class TestBillingRawTable(BqTest):
         # test get table name function
         table_name = self.table_obj.get_table_name()
 
-        self.assertEqual(given_table_name, table_name)
+        assert given_table_name == table_name

--- a/test/test_bq_function_filter.py
+++ b/test/test_bq_function_filter.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime
 from enum import StrEnum
 
@@ -16,7 +15,7 @@ class BGFunFilterTestEnum(StrEnum):
     VALUE = 'value'
 
 
-class TestFunctionBQFilter(unittest.TestCase):
+class TestFunctionBQFilter:
     """Test function filters SQL generation"""
 
     def test_empty_output(self):
@@ -29,8 +28,8 @@ class TestFunctionBQFilter(unittest.TestCase):
         # no params are present, should return empty SQL and Param list
         filter_.to_sql(BillingColumn.LABELS)
 
-        self.assertEqual([], filter_.func_sql_parameters)
-        self.assertEqual('', filter_.func_where)
+        assert filter_.func_sql_parameters == []
+        assert filter_.func_where == ''
 
     def test_one_param_output(self):
         """Test that function filter converts to SQL as expected"""
@@ -42,16 +41,12 @@ class TestFunctionBQFilter(unittest.TestCase):
         # no params are present, should return empty SQL and Param list
         filter_.to_sql(BillingColumn.LABELS, {'label_name': 'Some Value'})
 
-        self.assertEqual(
-            [
-                bq.ScalarQueryParameter('param1', 'STRING', 'label_name'),
-                bq.ScalarQueryParameter('value1', 'STRING', 'Some Value'),
-            ],
-            filter_.func_sql_parameters,
-        )
-        self.assertEqual(
-            '(test_sql_func(labels,@param1) = @value1)', filter_.func_where
-        )
+        assert [
+            bq.ScalarQueryParameter('param1', 'STRING', 'label_name'),
+            bq.ScalarQueryParameter('value1', 'STRING', 'Some Value'),
+        ] == filter_.func_sql_parameters
+
+        assert filter_.func_where == '(test_sql_func(labels,@param1) = @value1)'
 
     def test_two_param_default_operator_output(self):
         """Test that function filter converts to SQL as expected"""
@@ -63,21 +58,16 @@ class TestFunctionBQFilter(unittest.TestCase):
         # no params are present, should return empty SQL and Param list
         filter_.to_sql(BillingColumn.LABELS, {'label_name1': 10, 'label_name2': 123.45})
 
-        self.assertEqual(
-            [
-                bq.ScalarQueryParameter('param1', 'STRING', 'label_name1'),
-                bq.ScalarQueryParameter('value1', 'INT64', 10),
-                bq.ScalarQueryParameter('param2', 'STRING', 'label_name2'),
-                bq.ScalarQueryParameter('value2', 'FLOAT64', 123.45),
-            ],
-            filter_.func_sql_parameters,
-        )
-        self.assertEqual(
-            (
-                '(test_sql_func(labels,@param1) = @value1 '
-                'AND test_sql_func(labels,@param2) = @value2)'
-            ),
-            filter_.func_where,
+        assert [
+            bq.ScalarQueryParameter('param1', 'STRING', 'label_name1'),
+            bq.ScalarQueryParameter('value1', 'INT64', 10),
+            bq.ScalarQueryParameter('param2', 'STRING', 'label_name2'),
+            bq.ScalarQueryParameter('value2', 'FLOAT64', 123.45),
+        ] == filter_.func_sql_parameters
+
+        assert filter_.func_where == (
+            '(test_sql_func(labels,@param1) = @value1 '
+            'AND test_sql_func(labels,@param2) = @value2)'
         )
 
     def test_two_param_operator_or_output(self):
@@ -97,21 +87,16 @@ class TestFunctionBQFilter(unittest.TestCase):
             'OR',
         )
 
-        self.assertEqual(
-            [
-                bq.ScalarQueryParameter('param1', 'STRING', 'label_name1'),
-                bq.ScalarQueryParameter('value1', 'STRING', 'id'),
-                bq.ScalarQueryParameter('param2', 'STRING', 'label_name2'),
-                bq.ScalarQueryParameter('value2', 'STRING', '2024-01-01T00:00:00'),
-            ],
-            filter_.func_sql_parameters,
-        )
-        self.assertEqual(
-            (
-                '(test_sql_func(labels,@param1) = @value1 '
-                'OR test_sql_func(labels,@param2) = TIMESTAMP(@value2))'
-            ),
-            filter_.func_where,
+        assert [
+            bq.ScalarQueryParameter('param1', 'STRING', 'label_name1'),
+            bq.ScalarQueryParameter('value1', 'STRING', 'id'),
+            bq.ScalarQueryParameter('param2', 'STRING', 'label_name2'),
+            bq.ScalarQueryParameter('value2', 'STRING', '2024-01-01T00:00:00'),
+        ] == filter_.func_sql_parameters
+
+        assert (
+            filter_.func_where
+            == '(test_sql_func(labels,@param1) = @value1 OR test_sql_func(labels,@param2) = TIMESTAMP(@value2))'
         )
 
     def test_two_param_datime_with_zone_output(self):
@@ -133,23 +118,14 @@ class TestFunctionBQFilter(unittest.TestCase):
             'AND',
         )
 
-        self.assertEqual(
-            [
-                bq.ScalarQueryParameter('param1', 'STRING', 'label_name1'),
-                bq.ScalarQueryParameter(
-                    'value1', 'STRING', '2023-12-31T19:00:00-05:00'
-                ),
-                bq.ScalarQueryParameter('param2', 'STRING', 'label_name2'),
-                bq.ScalarQueryParameter(
-                    'value2', 'STRING', '2024-01-01T11:00:00+11:00'
-                ),
-            ],
-            filter_.func_sql_parameters,
-        )
-        self.assertEqual(
-            (
-                '(test_sql_func(labels,@param1) = TIMESTAMP(@value1) '
-                'AND test_sql_func(labels,@param2) = TIMESTAMP(@value2))'
-            ),
-            filter_.func_where,
+        assert [
+            bq.ScalarQueryParameter('param1', 'STRING', 'label_name1'),
+            bq.ScalarQueryParameter('value1', 'STRING', '2023-12-31T19:00:00-05:00'),
+            bq.ScalarQueryParameter('param2', 'STRING', 'label_name2'),
+            bq.ScalarQueryParameter('value2', 'STRING', '2024-01-01T11:00:00+11:00'),
+        ] == filter_.func_sql_parameters
+
+        assert filter_.func_where == (
+            '(test_sql_func(labels,@param1) = TIMESTAMP(@value1) '
+            'AND test_sql_func(labels,@param2) = TIMESTAMP(@value2))'
         )

--- a/test/test_bq_generic_filter.py
+++ b/test/test_bq_generic_filter.py
@@ -1,9 +1,9 @@
 import dataclasses
-import unittest
 from datetime import datetime
 from enum import Enum, StrEnum
 from typing import Any
 
+import pytest
 from google.cloud import bigquery
 
 from db.python.tables.bq.generic_bq_filter import GenericBQFilter
@@ -30,7 +30,7 @@ class BGFilterTestEnum(StrEnum):
     VALUE = 'value'
 
 
-class TestGenericBQFilter(unittest.TestCase):
+class TestGenericBQFilter:
     """Test generic filter SQL generation"""
 
     def test_basic_no_override(self):
@@ -38,30 +38,24 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_string=GenericBQFilter(eq='test'))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_string = @test_string_eq', sql)
-        self.assertDictEqual(
-            {
-                'test_string_eq': bigquery.ScalarQueryParameter(
-                    'test_string_eq', 'STRING', 'test'
-                )
-            },
-            values,
-        )
+        assert sql == 'test_string = @test_string_eq'
+        assert {
+            'test_string_eq': bigquery.ScalarQueryParameter(
+                'test_string_eq', 'STRING', 'test'
+            )
+        } == values
 
     def test_basic_override(self):
         """Test that the basic filter with an override converts to SQL as expected"""
         filter_ = GenericBQFilterTest(test_string=GenericBQFilter(eq='test'))
         sql, values = filter_.to_sql({'test_string': 't.string'})
 
-        self.assertEqual('t.string = @t_string_eq', sql)
-        self.assertDictEqual(
-            {
-                't_string_eq': bigquery.ScalarQueryParameter(
-                    't_string_eq', 'STRING', 'test'
-                )
-            },
-            values,
-        )
+        assert sql == 't.string = @t_string_eq'
+        assert {
+            't_string_eq': bigquery.ScalarQueryParameter(
+                't_string_eq', 'STRING', 'test'
+            )
+        } == values
 
     def test_single_string(self):
         """
@@ -71,15 +65,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_string=GenericBQFilter(in_=['test']))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_string = @test_string_in_eq', sql)
-        self.assertDictEqual(
-            {
-                'test_string_in_eq': bigquery.ScalarQueryParameter(
-                    'test_string_in_eq', 'STRING', 'test'
-                )
-            },
-            values,
-        )
+        assert sql == 'test_string = @test_string_in_eq'
+        assert {
+            'test_string_in_eq': bigquery.ScalarQueryParameter(
+                'test_string_in_eq', 'STRING', 'test'
+            )
+        } == values
 
     def test_single_int(self):
         """
@@ -89,15 +80,10 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_int=GenericBQFilter(gt=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_int > @test_int_gt', sql)
-        self.assertDictEqual(
-            {
-                'test_int_gt': bigquery.ScalarQueryParameter(
-                    'test_int_gt', 'INT64', value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_int > @test_int_gt'
+        assert {
+            'test_int_gt': bigquery.ScalarQueryParameter('test_int_gt', 'INT64', value)
+        } == values
 
     def test_single_float(self):
         """
@@ -107,15 +93,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_float=GenericBQFilter(gte=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_float >= @test_float_gte', sql)
-        self.assertDictEqual(
-            {
-                'test_float_gte': bigquery.ScalarQueryParameter(
-                    'test_float_gte', 'FLOAT64', value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_float >= @test_float_gte'
+        assert {
+            'test_float_gte': bigquery.ScalarQueryParameter(
+                'test_float_gte', 'FLOAT64', value
+            )
+        } == values
 
     def test_single_datetime(self):
         """
@@ -126,15 +109,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_dt=GenericBQFilter(lt=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_dt < TIMESTAMP(@test_dt_lt)', sql)
-        self.assertDictEqual(
-            {
-                'test_dt_lt': bigquery.ScalarQueryParameter(
-                    'test_dt_lt', 'STRING', datetime_str
-                )
-            },
-            values,
-        )
+        assert sql == 'test_dt < TIMESTAMP(@test_dt_lt)'
+        assert {
+            'test_dt_lt': bigquery.ScalarQueryParameter(
+                'test_dt_lt', 'STRING', datetime_str
+            )
+        } == values
 
     def test_single_enum(self):
         """
@@ -144,15 +124,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_enum=GenericBQFilter(lte=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_enum <= @test_enum_lte', sql)
-        self.assertDictEqual(
-            {
-                'test_enum_lte': bigquery.ScalarQueryParameter(
-                    'test_enum_lte', 'STRING', value.value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_enum <= @test_enum_lte'
+        assert {
+            'test_enum_lte': bigquery.ScalarQueryParameter(
+                'test_enum_lte', 'STRING', value.value
+            )
+        } == values
 
     def test_in_multiple_int(self):
         """
@@ -162,15 +139,10 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_int=GenericBQFilter(in_=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_int IN UNNEST(@test_int_in)', sql)
-        self.assertDictEqual(
-            {
-                'test_int_in': bigquery.ArrayQueryParameter(
-                    'test_int_in', 'INT64', value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_int IN UNNEST(@test_int_in)'
+        assert {
+            'test_int_in': bigquery.ArrayQueryParameter('test_int_in', 'INT64', value)
+        } == values
 
     def test_in_multiple_float(self):
         """
@@ -180,15 +152,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_float=GenericBQFilter(in_=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_float IN UNNEST(@test_float_in)', sql)
-        self.assertDictEqual(
-            {
-                'test_float_in': bigquery.ArrayQueryParameter(
-                    'test_float_in', 'FLOAT64', value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_float IN UNNEST(@test_float_in)'
+        assert {
+            'test_float_in': bigquery.ArrayQueryParameter(
+                'test_float_in', 'FLOAT64', value
+            )
+        } == values
 
     def test_in_multiple_str(self):
         """
@@ -198,15 +167,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_string=GenericBQFilter(in_=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_string IN UNNEST(@test_string_in)', sql)
-        self.assertDictEqual(
-            {
-                'test_string_in': bigquery.ArrayQueryParameter(
-                    'test_string_in', 'STRING', value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_string IN UNNEST(@test_string_in)'
+        assert {
+            'test_string_in': bigquery.ArrayQueryParameter(
+                'test_string_in', 'STRING', value
+            )
+        } == values
 
     def test_nin_multiple_str(self):
         """
@@ -216,15 +182,12 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_string=GenericBQFilter(nin=value))
         sql, values = filter_.to_sql()
 
-        self.assertEqual('test_string NOT IN UNNEST(@test_string_nin)', sql)
-        self.assertDictEqual(
-            {
-                'test_string_nin': bigquery.ArrayQueryParameter(
-                    'test_string_nin', 'STRING', value
-                )
-            },
-            values,
-        )
+        assert sql == 'test_string NOT IN UNNEST(@test_string_nin)'
+        assert {
+            'test_string_nin': bigquery.ArrayQueryParameter(
+                'test_string_nin', 'STRING', value
+            )
+        } == values
 
     def test_in_and_eq_multiple_str(self):
         """
@@ -234,21 +197,17 @@ class TestGenericBQFilter(unittest.TestCase):
         filter_ = GenericBQFilterTest(test_string=GenericBQFilter(in_=value, eq='B'))
         sql, values = filter_.to_sql()
 
-        self.assertEqual(
-            'test_string = @test_string_eq AND test_string = @test_string_in_eq',
-            sql,
+        assert (
+            sql == 'test_string = @test_string_eq AND test_string = @test_string_in_eq'
         )
-        self.assertDictEqual(
-            {
-                'test_string_eq': bigquery.ScalarQueryParameter(
-                    'test_string_eq', 'STRING', 'B'
-                ),
-                'test_string_in_eq': bigquery.ScalarQueryParameter(
-                    'test_string_in_eq', 'STRING', 'A'
-                ),
-            },
-            values,
-        )
+        assert {
+            'test_string_eq': bigquery.ScalarQueryParameter(
+                'test_string_eq', 'STRING', 'B'
+            ),
+            'test_string_in_eq': bigquery.ScalarQueryParameter(
+                'test_string_in_eq', 'STRING', 'A'
+            ),
+        } == values
 
     def test_fail_none_in_tuple(self):
         """
@@ -257,14 +216,14 @@ class TestGenericBQFilter(unittest.TestCase):
         value = (None,)
 
         # check if ValueError is raised
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError) as context:
             filter_ = GenericBQFilterTest(test_any=value)
             filter_.to_sql()
 
-        self.assertTrue(
+        assert (
             'There is very likely a trailing comma on the end of '
             'GenericBQFilterTest.test_any. '
             'If you actually want a tuple of length one with the value = (None,), '
             'then use dataclasses.field(default_factory=lambda: (None,))'
-            in str(context.exception)
+            in str(context.value)
         )

--- a/test/testbqbase.py
+++ b/test/testbqbase.py
@@ -5,7 +5,7 @@ from db.python.layers.billing import BillingLayer
 
 
 class MockResult:
-    """Mimics the RowIterator returned by MockQueryJob.result()."""
+    """Mimics the RowIterator returned by google.cloud.bigquery.job.query.QueryJob.result()."""
 
     def __init__(self, rows=None, total_rows=None):
         self._rows = rows or []
@@ -16,7 +16,7 @@ class MockResult:
 
 
 class MockQueryJob:
-    """Mimics the BigQuery Job"""
+    """Mimics google.cloud.bigquery.job.query.QueryJob class."""
 
     def __init__(self, rows=None):
         self._rows = rows or MockResult()
@@ -28,7 +28,7 @@ class MockQueryJob:
 
 class MockBqClient(bq.Client):
     """
-    Mock BigQuery Client class.
+    Mock  google.cloud.bigquery.client.Client class.
     """
 
     def __init__(self):
@@ -56,16 +56,24 @@ class MockBqConnection(BqConnection):
 class BqTest:
     """Base class for Big Query integration tests"""
 
+    # author and grp_project are not used in the BQ tests, but are required
+    # so some dummy values are preset
     author: str = 'Author'
     gcp_project: str = 'GCP_PROJECT'
 
     def set_up(self):
         self.table_obj = None
 
+        # mock BigQuery client
         self.bq_client = MockBqClient()
+
+        # Mockup BQ results
         self.bq_result = self.bq_client.mock_query_job
+
+        # Mock BqConnection
         self.connection = MockBqConnection(
             gcp_project=self.gcp_project, author=self.author, client=self.bq_client
         )
 
+        # Mockup BillingLayer
         self.layer = BillingLayer(self.connection)

--- a/test/testbqbase.py
+++ b/test/testbqbase.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import google.cloud.bigquery as bq
 
 from db.python.gcp_connect import BqConnection
@@ -7,7 +5,7 @@ from db.python.layers.billing import BillingLayer
 
 
 class MockResult:
-    """Mimics the RowIterator returned by query_job.result()."""
+    """Mimics the RowIterator returned by MockQueryJob.result()."""
 
     def __init__(self, rows=None, total_rows=None):
         self._rows = rows or []
@@ -18,6 +16,8 @@ class MockResult:
 
 
 class MockQueryJob:
+    """Mimics the BigQuery Job"""
+
     def __init__(self, rows=None):
         self._rows = rows or MockResult()
         self.total_bytes_processed = 0
@@ -27,12 +27,16 @@ class MockQueryJob:
 
 
 class MockBqClient(bq.Client):
+    """
+    Mock BigQuery Client class.
+    """
+
     def __init__(self):
         super().__init__()
         self.mock_query_job = MockQueryJob()
         self.executed_queries = []
 
-    def query(self, query: str, *args, **kwargs) -> MockQueryJob:
+    def query(self, query: str, *_args, **_kwargs) -> MockQueryJob:
         self.executed_queries.append(query)
         return self.mock_query_job
 
@@ -65,9 +69,3 @@ class BqTest:
         )
 
         self.layer = BillingLayer(self.connection)
-
-    def mock_return(self, value: Any) -> Any:
-        def mock_return_value(*args, **kwargs):
-            return value
-
-        return mock_return_value

--- a/test/testbqbase.py
+++ b/test/testbqbase.py
@@ -62,7 +62,6 @@ class BqTest:
     gcp_project: str = 'GCP_PROJECT'
 
     def set_up(self):
-        self.table_obj = None
 
         # mock BigQuery client
         self.bq_client = MockBqClient()
@@ -77,3 +76,6 @@ class BqTest:
 
         # Mockup BillingLayer
         self.layer = BillingLayer(self.connection)
+
+        # overwrite table object in inhereted tests:
+        self.table_obj = None

--- a/test/testbqbase.py
+++ b/test/testbqbase.py
@@ -1,6 +1,4 @@
-import unittest
 from typing import Any
-from unittest import mock
 
 import google.cloud.bigquery as bq
 
@@ -8,37 +6,68 @@ from db.python.gcp_connect import BqConnection
 from db.python.layers.billing import BillingLayer
 
 
-class BqTest(unittest.TestCase):
+class MockResult:
+    """Mimics the RowIterator returned by query_job.result()."""
+
+    def __init__(self, rows=None, total_rows=None):
+        self._rows = rows or []
+        self.total_rows = total_rows if total_rows is not None else len(self._rows)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class MockQueryJob:
+    def __init__(self, rows=None):
+        self._rows = rows or MockResult()
+        self.total_bytes_processed = 0
+
+    def result(self):
+        return self._rows
+
+
+class MockBqClient(bq.Client):
+    def __init__(self):
+        super().__init__()
+        self.mock_query_job = MockQueryJob()
+        self.executed_queries = []
+
+    def query(self, query: str, *args, **kwargs) -> MockQueryJob:
+        self.executed_queries.append(query)
+        return self.mock_query_job
+
+
+class MockBqConnection(BqConnection):
+    """
+    Mock BqConnection class.
+    """
+
+    def __init__(self, gcp_project: str, author: str, client: MockBqClient):
+        super().__init__(author)
+        self.gcp_project = gcp_project
+        self.author = author
+        self.connection = client
+
+
+class BqTest:
     """Base class for Big Query integration tests"""
 
-    # author and grp_project are not used in the BQ tests, but are required
-    # so some dummy values are preset
     author: str = 'Author'
     gcp_project: str = 'GCP_PROJECT'
 
-    bq_result: bq.job.QueryJob
-    bq_client: bq.Client
-    connection: BqConnection
-    table_obj: Any | None = None
+    def set_up(self):
+        self.table_obj = None
 
-    def setUp(self) -> None:
-        super().setUp()
+        self.bq_client = MockBqClient()
+        self.bq_result = self.bq_client.mock_query_job
+        self.connection = MockBqConnection(
+            gcp_project=self.gcp_project, author=self.author, client=self.bq_client
+        )
 
-        # Mockup BQ results
-        self.bq_result = mock.MagicMock(spec=bq.job.QueryJob)
-
-        # mock BigQuery client
-        self.bq_client = mock.MagicMock(spec=bq.Client)
-        self.bq_client.query.return_value = self.bq_result
-
-        # Mock BqConnection
-        self.connection = mock.MagicMock(spec=BqConnection)
-        self.connection.gcp_project = self.gcp_project
-        self.connection.connection = self.bq_client
-        self.connection.author = self.author
-
-        # Mockup BillingLayer
         self.layer = BillingLayer(self.connection)
 
-        # overwrite table object in inhereted tests:
-        self.table_obj = None
+    def mock_return(self, value: Any) -> Any:
+        def mock_return_value(*args, **kwargs):
+            return value
+
+        return mock_return_value

--- a/test/testbqbase.py
+++ b/test/testbqbase.py
@@ -77,5 +77,5 @@ class BqTest:
         # Mockup BillingLayer
         self.layer = BillingLayer(self.connection)
 
-        # overwrite table object in inhereted tests:
+        # overwrite table object in inherited tests:
         self.table_obj = None

--- a/test/testbqbase.py
+++ b/test/testbqbase.py
@@ -32,7 +32,6 @@ class MockBqClient(bq.Client):
     """
 
     def __init__(self):
-        super().__init__()
         self.mock_query_job = MockQueryJob()
         self.executed_queries = []
 
@@ -47,10 +46,10 @@ class MockBqConnection(BqConnection):
     """
 
     def __init__(self, gcp_project: str, author: str, client: MockBqClient):
-        super().__init__(author)
         self.gcp_project = gcp_project
         self.author = author
         self.connection = client
+        self._cost = 0
 
 
 class BqTest:


### PR DESCRIPTION
Migrate billing-related test cases from unittest to pytest.
Remove `unittest.mock.MagicMock` usages and introduce dummy mock classes (in `test/testbqbase.py`) and pytest `monkeypatch`. 