### PR TITLE
SET-999 Add PBMC viability report to OurDNA dashboard

### DIFF
--- a/test/data/generate_ourdna_data.py
+++ b/test/data/generate_ourdna_data.py
@@ -4,6 +4,8 @@ This is a simple script to generate some participants and samples for testing ou
 Local Backend API needs to run prior executing this script
 
 """
+import os
+import sys
 
 import argparse
 import datetime
@@ -11,7 +13,7 @@ import random
 import uuid
 from collections.abc import Sequence
 
-from metamist.apis import EnumsApi, ParticipantApi
+from metamist.apis import EnumsApi, ParticipantApi, ProjectApi
 from metamist.models import ParticipantUpsert, SampleUpsert
 
 
@@ -350,6 +352,7 @@ def create_participant():
 
 def main(project='ourdna', num_participants=10):
     """Doing the generation for you"""
+    project_api = ProjectApi()
     participant_api = ParticipantApi()
 
     sample_types = [
@@ -364,6 +367,26 @@ def main(project='ourdna', num_participants=10):
     # add sample type enums
     for typ in sample_types:
         enums_api.post_sample_types(new_type=typ)
+
+    # Create the project if it doesn't exist
+    existing_projects = project_api.get_my_projects()
+    if project not in existing_projects:
+        project_api.create_project(
+            name=project, dataset=project, create_test_project=False
+        )
+        default_user = os.getenv('SM_LOCALONLY_DEFAULTUSER')
+        if not default_user:
+            print(
+                'SM_LOCALONLY_DEFAULTUSER env var is not set, please set it before generating data'
+            )
+            sys.exit(1)
+
+        project_api.update_project_members(
+            project=project,
+            project_member_update=[
+                {'member': default_user, 'roles': ['reader', 'writer']}
+            ],
+        )
 
     participants = [create_participant() for _ in range(num_participants)]
     participants_rec = participant_api.upsert_participants(project, participants)

--- a/test/data/generate_ourdna_data.py
+++ b/test/data/generate_ourdna_data.py
@@ -4,12 +4,12 @@ This is a simple script to generate some participants and samples for testing ou
 Local Backend API needs to run prior executing this script
 
 """
-import os
-import sys
 
 import argparse
 import datetime
+import os
 import random
+import sys
 import uuid
 from collections.abc import Sequence
 

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -548,10 +548,10 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             query: `
                                 SELECT
                                     s_child.meta_percent_viability AS percent_viability,
-                                    s_parent.meta_processing_site 
-                                        || ' - ' || 
-                                        s_parent.meta_collection_event_type 
-                                        || ' - ' || 
+                                    s_parent.meta_processing_site
+                                        || ' - ' ||
+                                        s_parent.meta_collection_event_type
+                                        || ' - ' ||
                                         s_parent.meta_collection_lab AS grouping_combination
                                 FROM
                                     sample AS s_child
@@ -608,10 +608,10 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     s_parent.meta_processing_site AS biobank,
                                     s_parent.meta_collection_event_type AS collection_event_type,
                                     s_parent.meta_collection_lab AS collection_lab,
-                                    s_parent.meta_processing_site 
-                                        || ' - ' || 
-                                        s_parent.meta_collection_event_type 
-                                        || ' - ' || 
+                                    s_parent.meta_processing_site
+                                        || ' - ' ||
+                                        s_parent.meta_collection_event_type
+                                        || ' - ' ||
                                         s_parent.meta_collection_lab AS grouping_combination
                                 FROM
                                     sample AS s_child
@@ -676,7 +676,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 FROM pbmc_data p
                                 JOIN quartiles q ON p.grouping_combination = q.grouping_combination
                                 JOIN stats_no_outliers s ON p.grouping_combination = s.grouping_combination
-                                GROUP BY 
+                                GROUP BY
                                     biobank,
                                     collection_event_type,
                                     collection_lab,

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -464,6 +464,62 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     })}
                 />
             </ReportRow>
+            <ReportRow>
+                <ReportItemPlot
+                    height={ROW_HEIGHT}
+                    flexGrow={1}
+                    title="Viability by collection day"
+                    description="Shows the percent viability of PBMC samples based on their collection date."
+                    project={project}
+                    query={[
+                        {
+                            name: 'result',
+                            query: `
+                                SELECT
+                                    try_strptime(meta_collection_datetime, '%Y-%m-%dT%H:%M:%S') as collection_time,
+                                    meta_percent_viability as percent_viability
+                                FROM
+                                    sample
+                                WHERE
+                                    type = 'pbmc'
+                                    AND meta_collection_datetime IS NOT NULL
+                                    AND meta_percent_viability IS NOT NULL
+                            `,
+                        },
+                    ]}
+                    plot={(data) => ({
+                        y: { grid: true, label: 'Percent Viability' },
+                        x: { grid: true, label: 'Collection Date' },
+                        marginTop: 20,
+                        marginRight: 20,
+                        marginBottom: 50,
+                        marginLeft: 50,
+                        marks: [
+                            Plot.dot(data, {
+                                x: 'collection_time',
+                                y: 'percent_viability',
+                                // stroke: null,
+                                tip: true,
+                            }),
+                            // Plot.dot(data, {
+                            //     x: 'collection_time',
+                            //     y: 'percent_viability',
+                                
+                            //     fill: 'processing_site',
+                            //     fillOpacity: 0.5,
+                            //     channels: {
+                            //         process_end: 'process_end_time',
+                            //         sample_id: 'sample_id',
+                            //         sample_agd_id: 'sample_agd_id',
+                            //         participant_id: 'participant_id',
+                            //         participant_portal_id: 'participant_portal_id',
+                            //     },
+                            //     tip: true,
+                            // }),
+                        ],
+                    })}
+                />
+            </ReportRow>
         </Report>
     )
 }

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -603,7 +603,10 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             name: 'pbmc_data',
                             query: `
                                 SELECT
-                                    s_child.meta_percent_viability as percent_viability,
+                                    s_child.meta_percent_viability AS percent_viability,
+                                    s_parent.meta_processing_site AS biobank,
+                                    s_parent.meta_collection_event_type AS collection_event_type,
+                                    s_parent.meta_collection_lab AS collection_centre,
                                     s_parent.meta_processing_site || ' - ' || s_parent.meta_collection_event_type || ' - ' || s_parent.meta_collection_lab as grouping_combination
                                 FROM
                                     sample AS s_child
@@ -622,8 +625,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             query: `
                                 SELECT
                                     grouping_combination,
-                                    quantile_disc(percent_viability, 0.25) AS q1,
-                                    quantile_disc(percent_viability, 0.75) AS q3,
+                                    quantile_cont(percent_viability, 0.25) AS q1,
+                                    quantile_cont(percent_viability, 0.75) AS q3,
                                     q3 - q1 AS iqr
                                 FROM pbmc_data
                                 GROUP BY 1
@@ -652,7 +655,9 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             name: 'result',
                             query: `
                                 SELECT
-                                    p.grouping_combination AS "Processing Combination",
+                                    p.biobank AS "Biobank",
+                                    p.collection_event_type AS "Collection Event Type",
+                                    p.collection_centre as "Collection Centre",
                                     s.min_val AS "Minimum (No Outliers)",
                                     q.q1 AS "Q1",
                                     median(p.percent_viability) AS "Median (Q2)",
@@ -662,8 +667,18 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 FROM pbmc_data p
                                 JOIN quartiles q ON p.grouping_combination = q.grouping_combination
                                 JOIN stats_no_outliers s ON p.grouping_combination = s.grouping_combination
-                                GROUP BY 1, 2, 3, 5, 6
-                                ORDER BY 1
+                                GROUP BY 
+                                    biobank,
+                                    collection_event_type,
+                                    collection_centre,
+                                    min_val,
+                                    q1,
+                                    q3,
+                                    max_val
+                                ORDER BY
+                                    biobank,
+                                    collection_event_type,
+                                    collection_centre;
                             `,
                         },
                     ]}

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -86,7 +86,7 @@ function ProcessingTimesByCollectionDay(props: {
                 marginRight: 0,
                 marginBottom: 40,
                 marginLeft: 0,
-                colour: {
+                color: {
                     scheme: 'RdYlGn',
                     legend: true,
                     reverse: true,
@@ -166,7 +166,7 @@ function ProcessingTimesByAncestry(props: { project: string }) {
                 marginRight: 100,
                 marginBottom: 40,
                 marginLeft: 100,
-                colour: {
+                color: {
                     scheme: 'RdYlGn',
                     legend: true,
                     reverse: true,

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -229,7 +229,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         marginTop: 20,
                         marginRight: 20,
                         marginBottom: 40,
-                        colour: { legend: true },
+                        color: { legend: true },
 
                         marginLeft: 40,
                         marks: [
@@ -278,7 +278,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         marginTop: 20,
                         marginRight: 20,
                         marginBottom: 40,
-                        colour: { legend: true },
+                        color: { legend: true },
 
                         marginLeft: 40,
                         marks: [
@@ -344,7 +344,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     plot={(data) => ({
                         marginLeft: 100,
                         inset: 10,
-                        colour: {
+                        color: {
                             scheme: 'RdYlGn',
                             reverse: true,
                         },
@@ -388,7 +388,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         marginLeft: 100,
                         marginRight: 100,
                         inset: 10,
-                        colour: {
+                        color: {
                             scheme: 'RdYlGn',
                             reverse: true,
                         },

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -590,6 +590,86 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     })}
                 />
             </ReportRow>
+            <ReportRow>
+                <ReportItemTable
+                    height={ROW_HEIGHT}
+                    flexGrow={1}
+                    flexBasis={300}
+                    title="PBMC Viability Statistics"
+                    description="Summary statistics for the box-and-whisker plot, showing the distribution of PBMC sample viability for each biobank, event-type, collection-centre combination."
+                    project={project}
+                    showToolbar={true}
+                    query={[
+                        {
+                            name: 'pbmc_data',
+                            query: `
+                                SELECT
+                                    s_child.meta_percent_viability as percent_viability,
+                                    s_parent.meta_processing_site || ' - ' || s_parent.meta_collection_event_type || ' - ' || s_parent.meta_collection_lab as grouping_combination
+                                FROM
+                                    sample AS s_child
+                                JOIN
+                                    sample AS s_parent ON s_child.sample_parent_id = s_parent.sample_id
+                                WHERE
+                                    s_child.type = 'pbmc'
+                                    AND s_child.meta_percent_viability IS NOT NULL
+                                    AND s_parent.meta_processing_site IS NOT NULL
+                                    AND s_parent.meta_collection_event_type IS NOT NULL
+                                    AND s_parent.meta_collection_lab IS NOT NULL
+                            `,
+                        },
+                        {
+                            name: 'quartiles',
+                            query: `
+                                SELECT
+                                    grouping_combination,
+                                    quantile_disc(percent_viability, 0.25) AS q1,
+                                    quantile_disc(percent_viability, 0.75) AS q3,
+                                    q3 - q1 AS iqr
+                                FROM pbmc_data
+                                GROUP BY 1
+                            `,
+                        },
+                        {
+                            name: 'stats_no_outliers',
+                            query: `
+                                WITH non_outliers AS (
+                                    SELECT
+                                        p.grouping_combination,
+                                        p.percent_viability
+                                    FROM pbmc_data p
+                                    JOIN quartiles q ON p.grouping_combination = q.grouping_combination
+                                    WHERE p.percent_viability >= q.q1 - 1.5 * q.iqr AND p.percent_viability <= q.q3 + 1.5 * q.iqr
+                                )
+                                SELECT
+                                    grouping_combination,
+                                    MIN(percent_viability) as min_val,
+                                    MAX(percent_viability) as max_val
+                                FROM non_outliers
+                                GROUP BY 1
+                            `,
+                        },
+                        {
+                            name: 'result',
+                            query: `
+                                SELECT
+                                    p.grouping_combination AS "Processing Combination",
+                                    s.min_val AS "Minimum (No Outliers)",
+                                    q.q1 AS "Q1",
+                                    median(p.percent_viability) AS "Median (Q2)",
+                                    q.q3 AS "Q3",
+                                    s.max_val AS "Maximum (No Outliers)",
+                                    avg(p.percent_viability) AS "Average"
+                                FROM pbmc_data p
+                                JOIN quartiles q ON p.grouping_combination = q.grouping_combination
+                                JOIN stats_no_outliers s ON p.grouping_combination = s.grouping_combination
+                                GROUP BY 1, 2, 3, 5, 6
+                                ORDER BY 1
+                            `,
+                        },
+                    ]}
+                />
+            </ReportRow>
         </Report>
     )
 }

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -514,6 +514,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     s_child.type = 'pbmc'
                                     AND s_parent.meta_collection_datetime IS NOT NULL
                                     AND s_child.meta_percent_viability IS NOT NULL
+                                    AND s_child.meta_percent_viability >= 0
+                                    AND s_child.meta_percent_viability <= 100
                             `,
                         },
                     ]}
@@ -561,6 +563,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     AND s_parent.meta_processing_site IS NOT NULL
                                     AND s_parent.meta_collection_event_type IS NOT NULL
                                     AND s_parent.meta_collection_lab IS NOT NULL
+                                    AND s_child.meta_percent_viability >= 0
+                                    AND s_child.meta_percent_viability <= 100
                             `,
                         },
                     ]}
@@ -619,6 +623,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     AND s_parent.meta_processing_site IS NOT NULL
                                     AND s_parent.meta_collection_event_type IS NOT NULL
                                     AND s_parent.meta_collection_lab IS NOT NULL
+                                    AND s_child.meta_percent_viability >= 0
+                                    AND s_child.meta_percent_viability <= 100
                             `,
                         },
                         {
@@ -682,6 +688,35 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     biobank,
                                     collection_event_type,
                                     collection_lab;
+                            `,
+                        },
+                    ]}
+                />
+            </ReportRow>
+            <ReportRow>
+                <ReportItemTable
+                    height={ROW_HEIGHT}
+                    flexGrow={1}
+                    flexBasis={300}
+                    title="Outlier/invalid PBMC samples"
+                    description="Table of PBMC samples with outlier percent_viability values."
+                    project={project}
+                    showToolbar={true}
+                    query={[
+                        {
+                            name: 'result',
+                            query: `
+                                SELECT
+                                    s_child.external_id AS external_id,
+                                    s_child.meta_percent_viability AS percent_viability
+                                FROM
+                                    sample AS s_child
+                                JOIN
+                                    sample AS s_parent ON s_child.sample_parent_id = s_parent.sample_id
+                                WHERE
+                                    s_child.type = 'pbmc'
+                                    AND s_child.meta_percent_viability IS NOT NULL
+                                    AND (s_child.meta_percent_viability < 0 OR s_child.meta_percent_viability > 100)
                             `,
                         },
                     ]}

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -544,8 +544,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                 <ReportItemPlot
                     height={ROW_HEIGHT}
                     flexGrow={1}
-                    title="PBMC Viability by Processing Group"
-                    description="Box-and-whisker plot of PBMC sample viability, grouped by processing site, collection event type, and collection lab."
+                    title="PBMC Viability by Processing Combination"
+                    description="Box-and-whisker plot of PBMC sample viability, grouped by their biobank, event-type, collection-centre combination."
                     project={project}
                     query={[
                         {
@@ -569,7 +569,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     ]}
                     plot={(data) => ({
                         y: { grid: true, label: 'Percent Viability' },
-                        x: { label: 'Processing Group' },
+                        x: { label: 'Processing Combination' },
                         color: {
                             scheme: 'RdYlGn',
                             legend: true,

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -553,7 +553,11 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             query: `
                                 SELECT
                                     s_child.meta_percent_viability as percent_viability,
-                                    s_parent.meta_processing_site || ' - ' || s_parent.meta_collection_event_type || ' - ' || s_parent.meta_collection_lab as grouping_combination
+                                    s_parent.meta_processing_site 
+                                        || ' - ' || 
+                                        s_parent.meta_collection_event_type 
+                                        || ' - ' || 
+                                        s_parent.meta_collection_lab as grouping_combination
                                 FROM
                                     sample AS s_child
                                 JOIN
@@ -607,7 +611,11 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     s_parent.meta_processing_site AS biobank,
                                     s_parent.meta_collection_event_type AS collection_event_type,
                                     s_parent.meta_collection_lab AS collection_centre,
-                                    s_parent.meta_processing_site || ' - ' || s_parent.meta_collection_event_type || ' - ' || s_parent.meta_collection_lab as grouping_combination
+                                    s_parent.meta_processing_site 
+                                        || ' - ' || 
+                                        s_parent.meta_collection_event_type 
+                                        || ' - ' || 
+                                        s_parent.meta_collection_lab as grouping_combination
                                 FROM
                                     sample AS s_child
                                 JOIN
@@ -629,7 +637,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     quantile_cont(percent_viability, 0.75) AS q3,
                                     q3 - q1 AS iqr
                                 FROM pbmc_data
-                                GROUP BY 1
+                                GROUP BY grouping_combination
                             `,
                         },
                         {
@@ -641,6 +649,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                         p.percent_viability
                                     FROM pbmc_data p
                                     JOIN quartiles q ON p.grouping_combination = q.grouping_combination
+                                    -- Outlier criteria from
+                                    -- https://www.geeksforgeeks.org/data-visualization/what-is-box-plot-and-the-condition-of-outliers/
                                     WHERE p.percent_viability >= q.q1 - 1.5 * q.iqr AND p.percent_viability <= q.q3 + 1.5 * q.iqr
                                 )
                                 SELECT
@@ -648,7 +658,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     MIN(percent_viability) as min_val,
                                     MAX(percent_viability) as max_val
                                 FROM non_outliers
-                                GROUP BY 1
+                                GROUP BY grouping_combination
                             `,
                         },
                         {

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -203,7 +203,7 @@ function ProcessingTimesByAncestry(props: { project: string }) {
 }
 
 export default function ProcessingTimes({ project }: { project: string }) {
-    const [viabilityColour, setViabilityColour] = useState('processing_site')
+    const [viabilityColour, setViabilityColour] = useState('biobank')
 
     const handleColourChange = (event: SelectChangeEvent) => {
         setViabilityColour(event.target.value as string)
@@ -489,7 +489,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             label="Colour by"
                             onChange={handleColourChange}
                         >
-                            <MenuItem value="processing_site">Processing Site</MenuItem>
+                            <MenuItem value="biobank">Biobank</MenuItem>
                             <MenuItem value="collection_lab">Collection Lab</MenuItem>
                             <MenuItem value="collection_event_type">Collection Event Type</MenuItem>
                         </Select>
@@ -510,7 +510,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 SELECT
                                     try_strptime(s_parent.meta_collection_datetime, '%Y-%m-%dT%H:%M:%S') as collection_time,
                                     s_child.meta_percent_viability as percent_viability,
-                                    s_parent.meta_processing_site as processing_site,
+                                    s_parent.meta_processing_site as biobank,
                                     s_parent.meta_collection_lab as collection_lab,
                                     s_parent.meta_collection_event_type as collection_event_type
                                 FROM
@@ -528,16 +528,63 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         y: { grid: true, label: 'Percent Viability' },
                         x: { grid: true, label: 'Collection Date' },
                         color: { legend: true },
-                        marginTop: 20,
-                        marginRight: 20,
                         marginBottom: 50,
-                        marginLeft: 50,
                         marks: [
                             Plot.dot(data, {
                                 x: 'collection_time',
                                 y: 'percent_viability',
                                 fill: viabilityColour,
                                 tip: true,
+                            }),
+                        ],
+                    })}
+                />
+            </ReportRow>
+            <ReportRow>
+                <ReportItemPlot
+                    height={ROW_HEIGHT}
+                    flexGrow={1}
+                    title="PBMC Viability by Processing Group"
+                    description="Box-and-whisker plot of PBMC sample viability, grouped by processing site, collection event type, and collection lab."
+                    project={project}
+                    query={[
+                        {
+                            name: 'result',
+                            query: `
+                                SELECT
+                                    s_child.meta_percent_viability as percent_viability,
+                                    s_parent.meta_processing_site || ' - ' || s_parent.meta_collection_event_type || ' - ' || s_parent.meta_collection_lab as grouping_combination
+                                FROM
+                                    sample AS s_child
+                                JOIN
+                                    sample AS s_parent ON s_child.sample_parent_id = s_parent.sample_id
+                                WHERE
+                                    s_child.type = 'pbmc'
+                                    AND s_child.meta_percent_viability IS NOT NULL
+                                    AND s_parent.meta_processing_site IS NOT NULL
+                                    AND s_parent.meta_collection_event_type IS NOT NULL
+                                    AND s_parent.meta_collection_lab IS NOT NULL
+                            `,
+                        },
+                    ]}
+                    plot={(data) => ({
+                        y: { grid: true, label: 'Percent Viability' },
+                        x: { label: 'Processing Group' },
+                        color: {
+                            scheme: 'RdYlGn',
+                            legend: true,
+                            reverse: true,
+                        },
+                        marks: [
+                            Plot.boxY(data, {
+                                x: 'grouping_combination',
+                                y: 'percent_viability',
+
+                            }),
+                            Plot.dot(data, {
+                                x: 'grouping_combination',
+                                y: 'percent_viability',
+                                strokeOpacity: 0.4
                             }),
                         ],
                     })}

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -538,7 +538,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     height={ROW_HEIGHT}
                     flexGrow={1}
                     title="PBMC Viability by Processing Combination"
-                    description="Box-and-whisker plot of PBMC sample viability, grouped by their biobank, event-type, collection-centre combination."
+                    description="Box-and-whisker plot of PBMC sample viability, grouped by their biobank, event-type, collection-lab combination."
                     project={project}
                     query={[
                         {
@@ -592,7 +592,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     flexGrow={1}
                     flexBasis={300}
                     title="PBMC Viability Statistics"
-                    description="Summary statistics for the box-and-whisker plot, showing the distribution of PBMC sample viability for each biobank, event-type, collection-centre combination."
+                    description="Summary statistics for the box-and-whisker plot, showing the distribution of PBMC sample viability for each biobank, event-type, collection-lab combination."
                     project={project}
                     showToolbar={true}
                     query={[
@@ -603,7 +603,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                     s_child.meta_percent_viability AS percent_viability,
                                     s_parent.meta_processing_site AS biobank,
                                     s_parent.meta_collection_event_type AS collection_event_type,
-                                    s_parent.meta_collection_lab AS collection_centre,
+                                    s_parent.meta_collection_lab AS collection_lab,
                                     s_parent.meta_processing_site 
                                         || ' - ' || 
                                         s_parent.meta_collection_event_type 
@@ -660,7 +660,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 SELECT
                                     p.biobank AS "Biobank",
                                     p.collection_event_type AS "Collection Event Type",
-                                    p.collection_centre AS "Collection Centre",
+                                    p.collection_lab AS "Collection Lab",
                                     s.min_val AS "Minimum (No Outliers)",
                                     q.q1 AS "Q1",
                                     median(p.percent_viability) AS "Median (Q2)",
@@ -673,7 +673,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 GROUP BY 
                                     biobank,
                                     collection_event_type,
-                                    collection_centre,
+                                    collection_lab,
                                     min_val,
                                     q1,
                                     q3,
@@ -681,7 +681,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 ORDER BY
                                     biobank,
                                     collection_event_type,
-                                    collection_centre;
+                                    collection_lab;
                             `,
                         },
                     ]}

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -1,4 +1,13 @@
+import {
+    Box,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    SelectChangeEvent,
+} from '@mui/material'
 import * as Plot from '@observablehq/plot'
+import { useState } from 'react'
 import Report from '../../components/Report'
 import { ReportItemPlot, ReportItemTable } from '../../components/ReportItem'
 import ReportRow from '../../components/ReportRow'
@@ -84,7 +93,7 @@ function ProcessingTimesByCollectionDay(props: {
                 marginRight: 0,
                 marginBottom: 40,
                 marginLeft: 0,
-                color: {
+                colour: {
                     scheme: 'RdYlGn',
                     legend: true,
                     reverse: true,
@@ -164,7 +173,7 @@ function ProcessingTimesByAncestry(props: { project: string }) {
                 marginRight: 100,
                 marginBottom: 40,
                 marginLeft: 100,
-                color: {
+                colour: {
                     scheme: 'RdYlGn',
                     legend: true,
                     reverse: true,
@@ -194,6 +203,12 @@ function ProcessingTimesByAncestry(props: { project: string }) {
 }
 
 export default function ProcessingTimes({ project }: { project: string }) {
+    const [viabilityColour, setViabilityColour] = useState('processing_site')
+
+    const handleColourChange = (event: SelectChangeEvent) => {
+        setViabilityColour(event.target.value as string)
+    }
+
     return (
         <Report>
             <ReportRow>
@@ -221,7 +236,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         marginTop: 20,
                         marginRight: 20,
                         marginBottom: 40,
-                        color: { legend: true },
+                        colour: { legend: true },
 
                         marginLeft: 40,
                         marks: [
@@ -270,7 +285,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         marginTop: 20,
                         marginRight: 20,
                         marginBottom: 40,
-                        color: { legend: true },
+                        colour: { legend: true },
 
                         marginLeft: 40,
                         marks: [
@@ -336,7 +351,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     plot={(data) => ({
                         marginLeft: 100,
                         inset: 10,
-                        color: {
+                        colour: {
                             scheme: 'RdYlGn',
                             reverse: true,
                         },
@@ -380,7 +395,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                         marginLeft: 100,
                         marginRight: 100,
                         inset: 10,
-                        color: {
+                        colour: {
                             scheme: 'RdYlGn',
                             reverse: true,
                         },
@@ -465,6 +480,23 @@ export default function ProcessingTimes({ project }: { project: string }) {
                 />
             </ReportRow>
             <ReportRow>
+                <Box>
+                    <FormControl sx={{ display: 'flex', justifyContent: 'flex-end', marginTop: 2, minWidth: 200 }}>
+                        <InputLabel id="viability-colour-label">Colour by</InputLabel>
+                        <Select
+                            labelId="viability-colour-label"
+                            value={viabilityColour}
+                            label="Colour by"
+                            onChange={handleColourChange}
+                        >
+                            <MenuItem value="processing_site">Processing Site</MenuItem>
+                            <MenuItem value="collection_lab">Collection Lab</MenuItem>
+                            <MenuItem value="collection_event_type">Collection Event Type</MenuItem>
+                        </Select>
+                    </FormControl>
+                </Box>
+            </ReportRow>
+            <ReportRow>
                 <ReportItemPlot
                     height={ROW_HEIGHT}
                     flexGrow={1}
@@ -495,6 +527,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     plot={(data) => ({
                         y: { grid: true, label: 'Percent Viability' },
                         x: { grid: true, label: 'Collection Date' },
+                        colour: { legend: true },
                         marginTop: 20,
                         marginRight: 20,
                         marginBottom: 50,
@@ -503,24 +536,9 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             Plot.dot(data, {
                                 x: 'collection_time',
                                 y: 'percent_viability',
-                                // stroke: null,
+                                fill: viabilityColour,
                                 tip: true,
                             }),
-                            // Plot.dot(data, {
-                            //     x: 'collection_time',
-                            //     y: 'percent_viability',
-                                
-                            //     fill: 'processing_site',
-                            //     fillOpacity: 0.5,
-                            //     channels: {
-                            //         process_end: 'process_end_time',
-                            //         sample_id: 'sample_id',
-                            //         sample_agd_id: 'sample_agd_id',
-                            //         participant_id: 'participant_id',
-                            //         participant_portal_id: 'participant_portal_id',
-                            //     },
-                            //     tip: true,
-                            // }),
                         ],
                     })}
                 />

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -527,7 +527,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                     plot={(data) => ({
                         y: { grid: true, label: 'Percent Viability' },
                         x: { grid: true, label: 'Collection Date' },
-                        colour: { legend: true },
+                        color: { legend: true },
                         marginTop: 20,
                         marginRight: 20,
                         marginBottom: 50,

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -1,11 +1,4 @@
-import {
-    Box,
-    FormControl,
-    InputLabel,
-    MenuItem,
-    Select,
-    SelectChangeEvent,
-} from '@mui/material'
+import { Box, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material'
 import * as Plot from '@observablehq/plot'
 import { useState } from 'react'
 import Report from '../../components/Report'
@@ -481,7 +474,14 @@ export default function ProcessingTimes({ project }: { project: string }) {
             </ReportRow>
             <ReportRow>
                 <Box>
-                    <FormControl sx={{ display: 'flex', justifyContent: 'flex-end', marginTop: 2, minWidth: 200 }}>
+                    <FormControl
+                        sx={{
+                            display: 'flex',
+                            justifyContent: 'flex-end',
+                            marginTop: 2,
+                            minWidth: 200,
+                        }}
+                    >
                         <InputLabel id="viability-colour-label">Colour by</InputLabel>
                         <Select
                             labelId="viability-colour-label"
@@ -579,12 +579,11 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             Plot.boxY(data, {
                                 x: 'grouping_combination',
                                 y: 'percent_viability',
-
                             }),
                             Plot.dot(data, {
                                 x: 'grouping_combination',
                                 y: 'percent_viability',
-                                strokeOpacity: 0.4
+                                strokeOpacity: 0.4,
                             }),
                         ],
                     })}

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -198,7 +198,7 @@ function ProcessingTimesByAncestry(props: { project: string }) {
 export default function ProcessingTimes({ project }: { project: string }) {
     const [viabilityColour, setViabilityColour] = useState('biobank')
 
-    const handleColourChange = (event: SelectChangeEvent) => {
+    const handleColouringChange = (event: SelectChangeEvent) => {
         setViabilityColour(event.target.value as string)
     }
 
@@ -474,20 +474,13 @@ export default function ProcessingTimes({ project }: { project: string }) {
             </ReportRow>
             <ReportRow>
                 <Box>
-                    <FormControl
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'flex-end',
-                            marginTop: 2,
-                            minWidth: 200,
-                        }}
-                    >
+                    <FormControl sx={{ marginTop: 2, minWidth: 200 }}>
                         <InputLabel id="viability-colour-label">Colour by</InputLabel>
                         <Select
                             labelId="viability-colour-label"
                             value={viabilityColour}
                             label="Colour by"
-                            onChange={handleColourChange}
+                            onChange={handleColouringChange}
                         >
                             <MenuItem value="biobank">Biobank</MenuItem>
                             <MenuItem value="collection_lab">Collection Lab</MenuItem>
@@ -508,11 +501,11 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             name: 'result',
                             query: `
                                 SELECT
-                                    try_strptime(s_parent.meta_collection_datetime, '%Y-%m-%dT%H:%M:%S') as collection_time,
-                                    s_child.meta_percent_viability as percent_viability,
-                                    s_parent.meta_processing_site as biobank,
-                                    s_parent.meta_collection_lab as collection_lab,
-                                    s_parent.meta_collection_event_type as collection_event_type
+                                    try_strptime(s_parent.meta_collection_datetime, '%Y-%m-%dT%H:%M:%S') AS collection_time,
+                                    s_child.meta_percent_viability AS percent_viability,
+                                    s_parent.meta_processing_site AS biobank,
+                                    s_parent.meta_collection_lab AS collection_lab,
+                                    s_parent.meta_collection_event_type AS collection_event_type
                                 FROM
                                     sample AS s_child
                                 JOIN
@@ -552,12 +545,12 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             name: 'result',
                             query: `
                                 SELECT
-                                    s_child.meta_percent_viability as percent_viability,
+                                    s_child.meta_percent_viability AS percent_viability,
                                     s_parent.meta_processing_site 
                                         || ' - ' || 
                                         s_parent.meta_collection_event_type 
                                         || ' - ' || 
-                                        s_parent.meta_collection_lab as grouping_combination
+                                        s_parent.meta_collection_lab AS grouping_combination
                                 FROM
                                     sample AS s_child
                                 JOIN
@@ -615,7 +608,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                         || ' - ' || 
                                         s_parent.meta_collection_event_type 
                                         || ' - ' || 
-                                        s_parent.meta_collection_lab as grouping_combination
+                                        s_parent.meta_collection_lab AS grouping_combination
                                 FROM
                                     sample AS s_child
                                 JOIN
@@ -655,8 +648,8 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 )
                                 SELECT
                                     grouping_combination,
-                                    MIN(percent_viability) as min_val,
-                                    MAX(percent_viability) as max_val
+                                    MIN(percent_viability) AS min_val,
+                                    MAX(percent_viability) AS max_val
                                 FROM non_outliers
                                 GROUP BY grouping_combination
                             `,
@@ -667,7 +660,7 @@ export default function ProcessingTimes({ project }: { project: string }) {
                                 SELECT
                                     p.biobank AS "Biobank",
                                     p.collection_event_type AS "Collection Event Type",
-                                    p.collection_centre as "Collection Centre",
+                                    p.collection_centre AS "Collection Centre",
                                     s.min_val AS "Minimum (No Outliers)",
                                     q.q1 AS "Q1",
                                     median(p.percent_viability) AS "Median (Q2)",

--- a/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
+++ b/web/src/pages/report/reports/ourdna/SampleProcessing.tsx
@@ -476,14 +476,19 @@ export default function ProcessingTimes({ project }: { project: string }) {
                             name: 'result',
                             query: `
                                 SELECT
-                                    try_strptime(meta_collection_datetime, '%Y-%m-%dT%H:%M:%S') as collection_time,
-                                    meta_percent_viability as percent_viability
+                                    try_strptime(s_parent.meta_collection_datetime, '%Y-%m-%dT%H:%M:%S') as collection_time,
+                                    s_child.meta_percent_viability as percent_viability,
+                                    s_parent.meta_processing_site as processing_site,
+                                    s_parent.meta_collection_lab as collection_lab,
+                                    s_parent.meta_collection_event_type as collection_event_type
                                 FROM
-                                    sample
+                                    sample AS s_child
+                                JOIN
+                                    sample AS s_parent ON s_child.sample_parent_id = s_parent.sample_id
                                 WHERE
-                                    type = 'pbmc'
-                                    AND meta_collection_datetime IS NOT NULL
-                                    AND meta_percent_viability IS NOT NULL
+                                    s_child.type = 'pbmc'
+                                    AND s_parent.meta_collection_datetime IS NOT NULL
+                                    AND s_child.meta_percent_viability IS NOT NULL
                             `,
                         },
                     ]}


### PR DESCRIPTION
Adds the following visualisations for PBMC samples to the OurDNA reports dashboard under the "Sample Processing" tab:

Percent Viability by Collection Date
- This is a scatter plot of percent viability against collection date.
- A small drop-down menu has been added just above the plot that allows data points to be colour coded according to either biobank, collection event type or collection lab.

A box-and-whisker plot of PBMC viabilities by the biobank, event-type, collection-lab combination
- Visually displays summary statistics for different collection/processing conditions.

A table of the statistics from the box-and-whisker plot
- Contains minimum and maximum (excluding outliers), median (Q2), first quartile value (Q1), third quartile value (Q3) and average for each condition.

**Additionally** the `generate_ourdna_data.py` script was modified to eliminate the need to manually create an OurDNA project in the database before generating test data.