### PR TITLE
Fix bug in graphql sg analyses resolver

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -1191,8 +1191,6 @@ class GraphQLSequencingGroup:
         project: GraphQLFilter[str] | None = None,
     ) -> list[GraphQLAnalysis]:
         async with info.context['get_connection']() as connection:
-            loader = info.context['loaders'][LoaderKeys.ANALYSES_FOR_SEQUENCING_GROUPS]
-
             _project_filter: GenericFilter[ProjectId] | None = None
             if project:
                 project_names = project.all_values()
@@ -1207,23 +1205,24 @@ class GraphQLSequencingGroup:
                     lambda p: project_id_map[p]
                 )
 
-            analyses = await loader.load(
-                {
-                    'id': root.internal_id,
-                    'filter_': AnalysisFilter(
-                        status=status.to_internal_filter() if status else None,
-                        type=type.to_internal_filter() if type else None,
-                        meta=graphql_meta_filter_to_internal_filter(meta),
-                        active=(
-                            active.to_internal_filter()
-                            if active
-                            else GenericFilter(eq=True)
-                        ),
-                        project=_project_filter,
+        loader = info.context['loaders'][LoaderKeys.ANALYSES_FOR_SEQUENCING_GROUPS]
+        analyses = await loader.load(
+            {
+                'id': root.internal_id,
+                'filter_': AnalysisFilter(
+                    status=status.to_internal_filter() if status else None,
+                    type=type.to_internal_filter() if type else None,
+                    meta=graphql_meta_filter_to_internal_filter(meta),
+                    active=(
+                        active.to_internal_filter()
+                        if active
+                        else GenericFilter(eq=True)
                     ),
-                }
-            )
-            return [GraphQLAnalysis.from_internal(a) for a in analyses]
+                    project=_project_filter,
+                ),
+            }
+        )
+        return [GraphQLAnalysis.from_internal(a) for a in analyses]
 
     @strawberry.field
     async def assays(


### PR DESCRIPTION
This resolver was causing problems with exhausting connections in the connection pool. A connection was obtained from the pool and then the call to the loader would cause another connection to be obtained from the pool without returning the first one. In the case where lots of calls were made to this resolver, this resulted in exhausting pool connections before any could be returned, resulting in timeouts. The solution is to move the loader out from the connection context manager so that the connection is returned to the pool before the loader runs.