### PR TITLE
migrate queries that we missed during previous migration

### DIFF
--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -4,8 +4,6 @@ import itertools
 from datetime import datetime
 from typing import Any, NamedTuple
 
-from databases.interfaces import Record
-
 from db.python.enum_tables import SequencingPlatformTable as SeqPlatformTable
 from db.python.enum_tables import SequencingTechnologyTable as SeqTechTable
 from db.python.layers.base import BaseLayer
@@ -136,8 +134,8 @@ class ProjectInsightsDb(DbBase):
     """
 
     # Helper functions
-    def get_analysis_row(self, row: Record) -> AnalysisRow:
-        """Parse a table row returned by fetch_all into an AnalysisRow object"""
+    def get_analysis_row(self, row: dict[str, Any]) -> AnalysisRow:
+        """Parse a table row returned by fetchall into an AnalysisRow object"""
         return AnalysisRow(
             id=row['id'],
             output=row['output'],

--- a/db/python/tables/bq/billing_ar_batch.py
+++ b/db/python/tables/bq/billing_ar_batch.py
@@ -116,25 +116,26 @@ class BillingArBatchTable(BillingBaseTable):
         Get min timestamp by sequencing groups
         """
         # Find the minimum day when samples has been added
-        # using FOR SYSTEM_TIME ALL gives us full history
-        _query = """
+        # Using history.sequencing_group to get previous states
+        _query = t"""
         SELECT sg.id, MIN(l.timestamp) as start_date
-        FROM sequencing_group FOR SYSTEM_TIME ALL sg
+        FROM (
+            SELECT id, audit_log_id FROM sequencing_group
+            UNION ALL
+            SELECT id, audit_log_id FROM history.sequencing_group
+        ) sg
         LEFT JOIN audit_log l on l.id = sg.audit_log_id
-        WHERE sg.id IN :seq_groups
+        WHERE sg.id = ANY({sequencing_groups_as_ids})
         GROUP BY sg.id
         """
-        info_record = await connection.connection.fetch_all(
-            _query,
-            {
-                'seq_groups': list(sequencing_groups_as_ids),
-            },
-        )
+        info_record = await (await connection.pg_connection.execute(_query)).fetchall()
 
         # Map sequencing group IDs to their first record date
         # if audit log not present, use current datetime
         first_seq_record_date = {
-            seq_id_map[row.id]: row.start_date if row.start_date else datetime.now()
+            seq_id_map[row['id']]: row['start_date']
+            if row['start_date']
+            else datetime.now()
             for row in info_record
         }
         return first_seq_record_date
@@ -145,18 +146,13 @@ class BillingArBatchTable(BillingBaseTable):
         """
         Get number of sequencing groups for the given projects
         """
-        _query = """
+        _query = t"""
             SELECT COUNT(distinct sg.id) as cnt
             FROM sample s
             INNER JOIN sequencing_group sg ON sg.sample_id = s.id
-            WHERE s.project IN :projects
+            WHERE s.project = ANY({[project_id]})
         """
-        info_record = await connection.connection.fetch_one(
-            _query,
-            {
-                'projects': [project_id],
-            },
-        )
+        info_record = await (await connection.pg_connection.execute(_query)).fetchone()
         return dict(info_record).get('cnt', 0)
 
     async def get_total_crams_info(
@@ -165,21 +161,16 @@ class BillingArBatchTable(BillingBaseTable):
         """
         Get the cram size per project, total size and count cram files
         """
-        _query = """
+        _query = t"""
             SELECT sum(f.size) as total_crams_size
             FROM output_file f
             INNER JOIN analysis_outputs o ON o.file_id = f.id
             INNER JOIN analysis a ON a.id = o.analysis_id
             where a.type = 'CRAM'
             AND a.status = 'COMPLETED'
-            and a.project IN :projects
+            and a.project = ANY({[project_id]})
         """
-        info_record = await connection.connection.fetch_one(
-            _query,
-            {
-                'projects': [project_id],
-            },
-        )
+        info_record = await (await connection.pg_connection.execute(_query)).fetchone()
 
         total_cram_info = dict(info_record)
         total_crams_size = float(total_cram_info.get('total_crams_size') or 0)
@@ -200,23 +191,17 @@ class BillingArBatchTable(BillingBaseTable):
         """
         Get CRAM files information for the given sequencing groups
         """
-        _query = """
+        _query = t"""
             SELECT sg.id, sum(f.size) as crams_size
             FROM sequencing_group sg
             LEFT JOIN analysis_sequencing_group asg ON asg.sequencing_group_id = sg.id
-            LEFT JOIN analysis a ON asg.analysis_id = a.id AND a.type = 'CRAM' AND a.status = 'COMPLETED' AND a.project = :project
+            LEFT JOIN analysis a ON asg.analysis_id = a.id AND a.type = 'CRAM' AND a.status = 'COMPLETED' AND a.project = {project_id}
             LEFT JOIN analysis_outputs o ON a.id = o.analysis_id
             LEFT JOIN output_file f ON o.file_id = f.id
-            WHERE sg.id IN :seq_groups
+            WHERE sg.id = ANY({sequencing_groups_as_ids})
             GROUP BY sg.id
         """
-        records = await connection.connection.fetch_all(
-            _query,
-            {
-                'project': project_id,
-                'seq_groups': list(sequencing_groups_as_ids),
-            },
-        )
+        records = await (await connection.pg_connection.execute(_query)).fetchall()
         sg_storage_cost: list[dict] = []
         cram_sizes = dict(  # noqa: C402
             (row['id'], float(row['crams_size'] if row['crams_size'] else 0))
@@ -359,20 +344,15 @@ class BillingArBatchTable(BillingBaseTable):
         """
         Create map project to sequencing groups and project names
         """
-        _query = """
-            SELECT s.project, GROUP_CONCAT(sg.id ORDER BY sg.id ASC SEPARATOR ',') as seq_grps
+        _query = t"""
+            SELECT s.project, ARRAY_AGG(sg.id ORDER BY sg.id ASC) as seq_grps
             FROM sequencing_group sg
             INNER JOIN sample s ON s.id = sg.sample_id
-            WHERE sg.id in :sequencing_group_ids
+            WHERE sg.id = ANY({sequencing_groups_as_ids})
             GROUP BY s.project
         """
-        rows = await connection.connection.fetch_all(
-            _query, {'sequencing_group_ids': sequencing_groups_as_ids}
-        )
-        projects = {
-            row.project: [int(seq_id) for seq_id in row.seq_grps.split(',')]
-            for row in rows
-        }
+        rows = await (await connection.pg_connection.execute(_query)).fetchall()
+        projects = {row['project']: row['seq_grps'] for row in rows}
         if not projects:
             return (None, None)
 
@@ -389,23 +369,19 @@ class BillingArBatchTable(BillingBaseTable):
         Get sequencing groups per sample ids
         Return map of Sample id -> seq group
         """
-        query = """
-            SELECT sample_id, GROUP_CONCAT(id ORDER BY id ASC SEPARATOR ',') as seq_grps
+        query = t"""
+            SELECT sample_id, ARRAY_AGG(id ORDER BY id ASC) as seq_grps
             FROM sequencing_group
             WHERE
-                sample_id IN :sample_ids
+                sample_id = ANY({sample_ids})
                 AND NOT archived
             GROUP BY sample_id
         """
-        sample_seq_records = await connection.connection.fetch_all(
-            query,
-            {
-                'sample_ids': sample_ids,
-            },
-        )
+        sample_seq_records = await (
+            await connection.pg_connection.execute(query)
+        ).fetchall()
         sample_to_seq_groups = {
-            row.sample_id: [int(seq_id) for seq_id in row.seq_grps.split(',')]
-            for row in sample_seq_records
+            row['sample_id']: row['seq_grps'] for row in sample_seq_records
         }
         return sample_to_seq_groups
 

--- a/db/python/tables/bq/billing_ar_batch.py
+++ b/db/python/tables/bq/billing_ar_batch.py
@@ -153,7 +153,8 @@ class BillingArBatchTable(BillingBaseTable):
             WHERE s.project = ANY({[project_id]})
         """
         info_record = await (await connection.pg_connection.execute(_query)).fetchone()
-        return dict(info_record).get('cnt', 0)
+        assert info_record
+        return info_record.get('cnt', 0)
 
     async def get_total_crams_info(
         self, connection: Connection, project_id: int
@@ -172,8 +173,8 @@ class BillingArBatchTable(BillingBaseTable):
         """
         info_record = await (await connection.pg_connection.execute(_query)).fetchone()
 
-        total_cram_info = dict(info_record)
-        total_crams_size = float(total_cram_info.get('total_crams_size') or 0)
+        assert info_record
+        total_crams_size = float(info_record.get('total_crams_size') or 0)
         return total_crams_size
 
     async def calculate_storage_cost_using_cram_files_info(

--- a/db/python/tables/bq/billing_utils.py
+++ b/db/python/tables/bq/billing_utils.py
@@ -92,9 +92,11 @@ async def get_topic_to_project_map(
 
     # run the SQL to get all topics and their projects
     _query = """select id as project_id, dataset from project;"""
-    _query_results = await connection.connection.fetch_all(
-        _query,
-    )
+    _query_results = await (
+        await connection.pg_connection.execute(
+            _query,
+        )
+    ).fetchall()
 
     for row in _query_results:
         result[row['dataset']] = row['project_id']

--- a/db/python/tables/meta_table.py
+++ b/db/python/tables/meta_table.py
@@ -8,7 +8,6 @@ from typing import Any
 import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
-from databases.interfaces import Record
 
 from db.python.tables.base import DbBase
 from models.models import PRIMARY_EXTERNAL_ORG
@@ -44,7 +43,7 @@ class MetaTable(DbBase):
     async def entity_meta_table(
         self,
         query: Template,
-        row_getter: Callable[[Record], dict[str, Any]],
+        row_getter: Callable[[dict[str, Any]], dict[str, Any]],
         has_external_ids: bool,
         has_meta: bool,
     ):

--- a/db/python/utils.py
+++ b/db/python/utils.py
@@ -88,7 +88,7 @@ def get_logger():
     if _logger:
         return _logger
 
-    for lname in ('asyncio', 'urllib3', 'databases'):
+    for lname in ('asyncio', 'urllib3'):
         logging.getLogger(lname).setLevel(logging.WARNING)
 
     _logger = logging.getLogger('sample-metadata-api')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "psycopg[binary]~=3.3",
     "psycopg-pool~=3.3",
     "pytest~=9.0",
-    "databases~=0.9.0",
     "hypercorn>=0.18.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -549,18 +549,6 @@ wheels = [
 ]
 
 [[package]]
-name = "databases"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sqlalchemy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/de/ea55722907bd1b2389b01e362faa3c66a09d5a8463c13d44c80da7b32497/databases-0.9.0.tar.gz", hash = "sha256:d2f259677609bf187737644c95fa41701072e995dfeb8d2882f335795c5b61b0", size = 31084, upload-time = "2024-03-01T17:39:28.378Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/43/6035922af5471f1a196851831a1d5f403447401b395f474bf673efa8959f/databases-0.9.0-py3-none-any.whl", hash = "sha256:9ee657c9863b34f8d3a06c06eafbe1bda68af2a434b56996312edf1f1c0b6297", size = 25580, upload-time = "2024-03-01T17:39:26.352Z" },
-]
-
-[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -1152,29 +1140,6 @@ wheels = [
 ]
 
 [[package]]
-name = "greenlet"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz", hash = "sha256:41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98", size = 184690, upload-time = "2026-01-23T15:31:02.076Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
-    { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
-    { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
-    { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
-    { url = "https://files.pythonhosted.org/packages/52/cb/c21a3fd5d2c9c8b622e7bede6d6d00e00551a5ee474ea6d831b5f567a8b4/greenlet-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:96aff77af063b607f2489473484e39a0bbae730f2ea90c9e5606c9b73c44174a", size = 228125, upload-time = "2026-01-23T15:32:45.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8e/8a2db6d11491837af1de64b8aff23707c6e85241be13c60ed399a72e2ef8/greenlet-3.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:b066e8b50e28b503f604fa538adc764a638b38cf8e81e025011d26e8a627fa79", size = 227519, upload-time = "2026-01-23T15:31:47.284Z" },
-    { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
-    { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
-    { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
-    { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2b/98c7f93e6db9977aaee07eb1e51ca63bd5f779b900d362791d3252e60558/greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451", size = 233181, upload-time = "2026-01-23T15:33:00.29Z" },
-]
-
-[[package]]
 name = "grpc-google-iam-v1"
 version = "0.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,7 +1509,6 @@ dependencies = [
     { name = "cloudpathlib" },
     { name = "cpg-utils" },
     { name = "cryptography" },
-    { name = "databases" },
     { name = "duckdb" },
     { name = "fastapi", extra = ["all"] },
     { name = "fsspec" },
@@ -1599,7 +1563,6 @@ requires-dist = [
     { name = "cloudpathlib", specifier = "~=0.23.0" },
     { name = "cpg-utils", specifier = ">=5.5.0" },
     { name = "cryptography", specifier = "~=46.0" },
-    { name = "databases", specifier = "~=0.9.0" },
     { name = "duckdb", specifier = "~=1.4" },
     { name = "fastapi", extras = ["all"], specifier = "~=0.128.0" },
     { name = "fsspec", specifier = "==2026.1.0" },
@@ -2669,30 +2632,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
-name = "sqlalchemy"
-version = "2.0.46"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393, upload-time = "2026-01-21T18:03:45.119Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/f8/5ecdfc73383ec496de038ed1614de9e740a82db9ad67e6e4514ebc0708a3/sqlalchemy-2.0.46-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bdd261bfd0895452006d5316cbf35739c53b9bb71a170a331fa0ea560b2ada", size = 2152079, upload-time = "2026-01-21T19:05:58.477Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/bf/eba3036be7663ce4d9c050bc3d63794dc29fbe01691f2bf5ccb64e048d20/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33e462154edb9493f6c3ad2125931e273bbd0be8ae53f3ecd1c161ea9a1dd366", size = 3272216, upload-time = "2026-01-21T18:46:52.634Z" },
-    { url = "https://files.pythonhosted.org/packages/05/45/1256fb597bb83b58a01ddb600c59fe6fdf0e5afe333f0456ed75c0f8d7bd/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcdce05f056622a632f1d44bb47dbdb677f58cad393612280406ce37530eb6d", size = 3277208, upload-time = "2026-01-21T18:40:16.38Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a0/2053b39e4e63b5d7ceb3372cface0859a067c1ddbd575ea7e9985716f771/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e84b09a9b0f19accedcbeff5c2caf36e0dd537341a33aad8d680336152dc34e", size = 3221994, upload-time = "2026-01-21T18:46:54.622Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/87/97713497d9502553c68f105a1cb62786ba1ee91dea3852ae4067ed956a50/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4f52f7291a92381e9b4de9050b0a65ce5d6a763333406861e33906b8aa4906bf", size = 3243990, upload-time = "2026-01-21T18:40:18.253Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/87/5d1b23548f420ff823c236f8bea36b1a997250fd2f892e44a3838ca424f4/sqlalchemy-2.0.46-cp314-cp314-win32.whl", hash = "sha256:70ed2830b169a9960193f4d4322d22be5c0925357d82cbf485b3369893350908", size = 2114215, upload-time = "2026-01-21T18:42:55.232Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/20/555f39cbcf0c10cf452988b6a93c2a12495035f68b3dbd1a408531049d31/sqlalchemy-2.0.46-cp314-cp314-win_amd64.whl", hash = "sha256:3c32e993bc57be6d177f7d5d31edb93f30726d798ad86ff9066d75d9bf2e0b6b", size = 2139867, upload-time = "2026-01-21T18:42:56.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f0/f96c8057c982d9d8a7a68f45d69c674bc6f78cad401099692fe16521640a/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4dafb537740eef640c4d6a7c254611dca2df87eaf6d14d6a5fca9d1f4c3fc0fa", size = 3561202, upload-time = "2026-01-21T18:33:10.337Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/53/3b37dda0a5b137f21ef608d8dfc77b08477bab0fe2ac9d3e0a66eaeab6fc/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42a1643dc5427b69aca967dae540a90b0fbf57eaf248f13a90ea5930e0966863", size = 3526296, upload-time = "2026-01-21T18:45:12.657Z" },
-    { url = "https://files.pythonhosted.org/packages/33/75/f28622ba6dde79cd545055ea7bd4062dc934e0621f7b3be2891f8563f8de/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ff33c6e6ad006bbc0f34f5faf941cfc62c45841c64c0a058ac38c799f15b5ede", size = 3470008, upload-time = "2026-01-21T18:33:11.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/42/4afecbbc38d5e99b18acef446453c76eec6fbd03db0a457a12a056836e22/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:82ec52100ec1e6ec671563bbd02d7c7c8d0b9e71a0723c72f22ecf52d1755330", size = 3476137, upload-time = "2026-01-21T18:45:15.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a1/9c4efa03300926601c19c18582531b45aededfb961ab3c3585f1e24f120b/sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e", size = 1937882, upload-time = "2026-01-21T18:22:10.456Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
There were a few database queries hidden away that we missed earlier in the migration, this catches all of those and removes the databases library as it is no longer needed.