### PR TITLE
Add metamist private sha to infra stack output and cloud run labels

### DIFF
--- a/.github/workflows/deploy_pg.yaml
+++ b/.github/workflows/deploy_pg.yaml
@@ -131,6 +131,9 @@ jobs:
           token: ${{ secrets.METAMIST_PRIVATE_PAT }}
           persist-credentials: false
 
+      - name: Get config repo SHA
+        run: |
+          echo "METAMIST_PRIVATE_SHA=$(git -C metamist-private rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Copy Pulumi configs
         env:
@@ -146,5 +149,6 @@ jobs:
           cloud-url: ${{ vars.PULUMI_STATE_BUCKET }}
           parallel: 20 # Otherwise requests might time out.
         env:
+          METAMIST_PRIVATE_SHA: ${{ env.METAMIST_PRIVATE_SHA }}
           # skip checkpointing to speed-up the workflow, and avoid lots of saved state jsons
           PULUMI_SKIP_CHECKPOINTS: true

--- a/deploy/__main__.py
+++ b/deploy/__main__.py
@@ -16,3 +16,4 @@ migrations = create_migration_resources(config, common.image_repository)
 # Export key resource identifiers
 pulumi.export('load balancer ip', server.ip_address.address)
 pulumi.export('migration service name', migrations.service.name)
+pulumi.export('metamist private sha', config.metamist_private_sha)

--- a/deploy/infra/config.py
+++ b/deploy/infra/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import pulumi_gcp as gcp
@@ -73,6 +74,8 @@ class InfraConfig(BaseModel):
     # Migrations configuration
     migrations: MigrationsConfig
 
+    metamist_private_sha: str
+
     @property
     def registry_url(self) -> str:
         return f'{self.region}-docker.pkg.dev/{self.project}'
@@ -109,4 +112,5 @@ def load_config() -> InfraConfig:
         common=common,
         server=server,
         migrations=migrations,
+        metamist_private_sha=os.environ.get('METAMIST_PRIVATE_SHA', 'unknown'),
     )

--- a/deploy/infra/migrations.py
+++ b/deploy/infra/migrations.py
@@ -71,6 +71,9 @@ def create_migration_resources(
         'metamist-migration-service',
         name=f'metamist-migration-{config.stack}',
         location=config.region,
+        labels={
+            'metamist-private-sha': config.metamist_private_sha,
+        },
         template=gcp.cloudrunv2.ServiceTemplateArgs(
             service_account=migration_service_account.email,
             timeout='600s',

--- a/deploy/infra/server.py
+++ b/deploy/infra/server.py
@@ -60,6 +60,9 @@ def create_server_resources(
         ingress='INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER',
         location=config.region,
         default_uri_disabled=True,
+        labels={
+            'metamist-private-sha': config.metamist_private_sha,
+        },
         template=gcp.cloudrunv2.ServiceTemplateArgs(
             service_account=service_account.email,
             timeout='300s',


### PR DESCRIPTION
For debugging purposes, it will be very helpful to know exactly what config the current stack was deployed with. This adds a step to the deploy workflow to get the sha of the metamist-private repo and passes it as an env var to the pulumi deploy, where it is stored as a stack output as well as labels on the cloud run instances