### PR TITLE
Change metamist project env var to be set to deploy gcp project

### DIFF
--- a/deploy/infra/config.py
+++ b/deploy/infra/config.py
@@ -37,7 +37,6 @@ class ServerConfig(BaseModel):
     gcp_bq_budget_view: str
     gcp_bq_billing_view: str
     gcp_bq_batches_view: str
-    metamist_gcp_project: str
     oauth_audience: str
     sm_legacy_proxy_sa: str
 

--- a/deploy/infra/server.py
+++ b/deploy/infra/server.py
@@ -166,7 +166,7 @@ def create_server_resources(
                         ),
                         gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
                             name='METAMIST_GCP_PROJECT',
-                            value=config.server.metamist_gcp_project,
+                            value=config.project,
                         ),
                         gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
                             name='SM_OAUTHAUDIENCE',


### PR DESCRIPTION
This var wasn't used in many places but still needed updating to ensure gcp actions in billing and output files are based on the correct project. This goes with https://github.com/populationgenomics/metamist-private/pull/32 which removes the value for this env var from the config.