### PR TITLE
Insights dashboard improvements

### DIFF
--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -668,7 +668,7 @@ INNER JOIN (
     FROM analysis
     WHERE
         status = 'COMPLETED'
-        AND type = 'CUSTOM'
+        AND type in ('CUSTOM', 'matrixtable')
         AND JSON_EXTRACT(meta, '$.stage') = 'AnnotateDataset'
         AND JSON_UNQUOTE(JSON_EXTRACT(meta, '$.sequencing_type')) IN :sequencing_types
     GROUP BY project, JSON_EXTRACT(meta, '$.sequencing_type')
@@ -676,7 +676,7 @@ INNER JOIN (
 AND a.timestamp_completed = max_timestamps.max_timestamp
 AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) = max_timestamps.sequencing_type
 WHERE
-    a.type = 'CUSTOM'
+    a.type in ('CUSTOM', 'matrixtable')
     AND a.status = 'COMPLETED'
     AND a.project IN :projects
     AND JSON_UNQUOTE(JSON_EXTRACT(a.meta, '$.sequencing_type')) IN :sequencing_types

--- a/db/python/layers/project_insights.py
+++ b/db/python/layers/project_insights.py
@@ -167,8 +167,8 @@ class ProjectInsightsDb(DbBase):
                 row['sequencing_type'],
                 row['sequencing_technology'],
             )
-            if value_field == 'sequencing_group_ids':
-                parsed_rows[key] = [int(sgid) for sgid in row[value_field].split(',')]
+            if value_field.endswith('_ids'):
+                parsed_rows[key] = [int(v) for v in row[value_field].split(',') if v]
             else:
                 try:
                     parsed_rows[key] = row[value_field]
@@ -286,7 +286,7 @@ GROUP BY analysis_id;
         return {
             'id': cram_row.id if cram_row else None,
             'output': cram_row.output if cram_row else None,
-            'timestamp_completed': cram_row.timestamp_completed.strftime('%d-%m-%y')
+            'timestamp_completed': cram_row.timestamp_completed.strftime('%Y-%m-%d')
             if cram_row
             else None,
         }
@@ -310,9 +310,9 @@ GROUP BY analysis_id;
         self,
         summary_row_key: ProjectSeqTypeTechnologyKey,
         project: Project,
-        total_families: int,
-        total_participants: int,
-        total_samples: int,
+        family_ids: list[int],
+        participant_ids: list[int],
+        sample_ids: list[int],
         total_sequencing_groups: int,
         crams: list[SequencingGroupInternalId],
         analysis_sequencing_groups: dict[AnalysisId, list[SequencingGroupInternalId]],
@@ -336,14 +336,17 @@ GROUP BY analysis_id;
             dataset=project.name,
             sequencing_type=summary_row_key.sequencing_type,
             sequencing_technology=summary_row_key.sequencing_technology,
-            total_families=total_families,
-            total_participants=total_participants,
-            total_samples=total_samples,
+            total_families=len(family_ids),
+            total_participants=len(participant_ids),
+            total_samples=len(sample_ids),
             total_sequencing_groups=total_sequencing_groups,
             total_crams=len(set(crams)),
             latest_annotate_dataset=latest_annotate_dataset,
             latest_snv_es_index=latest_snv_es_index,
             latest_sv_es_index=latest_sv_es_index,
+            family_ids=family_ids,
+            participant_ids=participant_ids,
+            sample_ids=sample_ids,
         )
 
     def get_insights_details_internal_row(  # noqa: PLR0913
@@ -386,8 +389,8 @@ GROUP BY analysis_id;
             project=project.id,
             dataset=project.name,
             sequencing_type=sequencing_type,
-            sequencing_platform=sequencing_technology,
-            sequencing_technology=sequencing_platform,
+            sequencing_platform=sequencing_platform,
+            sequencing_technology=sequencing_technology,
             sample_type=sequencing_group_details.sample_type,
             family_id=sequencing_group_details.family_id,
             family_ext_id=sequencing_group_details.family_external_id,
@@ -409,13 +412,13 @@ GROUP BY analysis_id;
     # Project Insights Summary queries
     async def _total_families_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+    ) -> dict[ProjectSeqTypeTechnologyKey, list[int]]:
         _query = """
 SELECT
     f.project,
     sg.type as sequencing_type,
     sg.technology as sequencing_technology,
-    COUNT(DISTINCT f.id) as num_families
+    GROUP_CONCAT(DISTINCT f.id) as family_ids
 FROM
     family f
     LEFT JOIN family_participant fp ON f.id = fp.family_id
@@ -424,6 +427,7 @@ FROM
 WHERE
     f.project IN :projects
     AND sg.type IN :sequencing_types
+    AND NOT sg.archived
 GROUP BY
     f.project,
     sg.type,
@@ -438,18 +442,18 @@ GROUP BY
             },
         )
         return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_families'
+            _query_results, 'family_ids'
         )
 
     async def _total_participants_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+    ) -> dict[ProjectSeqTypeTechnologyKey, list[int]]:
         _query = """
 SELECT
     p.project,
     sg.type as sequencing_type,
     sg.technology as sequencing_technology,
-    COUNT(DISTINCT p.id) as num_participants
+    GROUP_CONCAT(DISTINCT p.id) as participant_ids
 FROM
     participant p
     LEFT JOIN sample s ON p.id = s.participant_id
@@ -457,6 +461,7 @@ FROM
 WHERE
     p.project IN :projects
     AND sg.type IN :sequencing_types
+    AND NOT sg.archived
 GROUP BY
     p.project,
     sg.type,
@@ -470,24 +475,25 @@ GROUP BY
             },
         )
         return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_participants'
+            _query_results, 'participant_ids'
         )
 
     async def _total_samples_by_project_id_and_seq_fields(
         self, project_ids: list[ProjectId], sequencing_types: list[SequencingType]
-    ) -> dict[ProjectSeqTypeTechnologyKey, int]:
+    ) -> dict[ProjectSeqTypeTechnologyKey, list[int]]:
         _query = """
 SELECT
     s.project,
     sg.type as sequencing_type,
     sg.technology as sequencing_technology,
-    COUNT(DISTINCT s.id) as num_samples
+    GROUP_CONCAT(DISTINCT s.id) as sample_ids
 FROM
     sample s
     LEFT JOIN sequencing_group sg on sg.sample_id = s.id
 WHERE
     s.project IN :projects
     AND sg.type IN :sequencing_types
+    AND NOT sg.archived
 GROUP BY
     s.project,
     sg.type,
@@ -501,7 +507,7 @@ GROUP BY
             },
         )
         return self.parse_project_seqtype_technology_keyed_rows(
-            _query_results, 'num_samples'
+            _query_results, 'sample_ids'
         )
 
     async def _total_sequencing_groups_by_project_id_and_seq_fields(
@@ -519,6 +525,7 @@ FROM
 WHERE
     s.project IN :projects
     AND sg.type IN :sequencing_types
+    AND NOT sg.archived
 GROUP BY
     s.project,
     sg.type,
@@ -555,6 +562,7 @@ WHERE
     AND sg.type IN :sequencing_types
     AND a.type = 'CRAM'
     AND a.status = 'COMPLETED'
+    AND NOT sg.archived
 GROUP BY
     a.project,
     sg.type,
@@ -598,9 +606,11 @@ FROM
             MAX(a.timestamp_completed) as max_timestamp
         FROM analysis a
         INNER JOIN analysis_sequencing_group asg ON a.id = asg.analysis_id
+        INNER JOIN sequencing_group sg2 ON sg2.id = asg.sequencing_group_id
         WHERE a.type='CRAM'
         AND a.status='COMPLETED'
         AND a.project IN :projects
+        AND NOT sg2.archived
         GROUP BY asg.sequencing_group_id
     ) max_timestamps ON asg.sequencing_group_id = max_timestamps.sequencing_group_id
     AND a.timestamp_completed = max_timestamps.max_timestamp
@@ -608,7 +618,8 @@ WHERE
     a.project IN :projects
     AND sg.type IN :sequencing_types
     AND a.type = 'CRAM'
-    AND a.status = 'COMPLETED';
+    AND a.status = 'COMPLETED'
+    AND NOT sg.archived;
         """
         _query_results = await self.connection.fetch_all(
             _query,
@@ -767,6 +778,7 @@ FROM
 WHERE
     f.project IN :projects
     AND sg.type IN :sequencing_types
+    AND NOT sg.archived
 ORDER BY
     f.project,
     sg.type,
@@ -1022,19 +1034,19 @@ INNER JOIN (
                 latest_es_indices_by_project_id_and_seq_type_and_stage,
             )
 
-            total_families_by_project_id_and_seq_fields.setdefault(rowkey, 0)
-            total_participants_by_project_id_and_seq_fields.setdefault(rowkey, 0)
-            total_samples_by_project_id_and_seq_fields.setdefault(rowkey, 0)
-
             response.append(
                 self.get_insights_summary_internal_row(
                     summary_row_key=rowkey,
                     project=project,
-                    total_families=total_families_by_project_id_and_seq_fields[rowkey],
-                    total_participants=total_participants_by_project_id_and_seq_fields[
-                        rowkey
-                    ],
-                    total_samples=total_samples_by_project_id_and_seq_fields[rowkey],
+                    family_ids=total_families_by_project_id_and_seq_fields.get(
+                        rowkey, []
+                    ),
+                    participant_ids=total_participants_by_project_id_and_seq_fields.get(
+                        rowkey, []
+                    ),
+                    sample_ids=total_samples_by_project_id_and_seq_fields.get(
+                        rowkey, []
+                    ),
                     total_sequencing_groups=total_sequencing_groups,
                     crams=crams_in_project_with_sequencing_fields,
                     analysis_sequencing_groups=analysis_sequencing_groups,

--- a/models/models/project_insights.py
+++ b/models/models/project_insights.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Optional
 
@@ -129,6 +129,9 @@ class ProjectInsightsSummaryInternal:
     latest_annotate_dataset: AnalysisStatsInternal | None = None
     latest_snv_es_index: AnalysisStatsInternal | None = None
     latest_sv_es_index: AnalysisStatsInternal | None = None
+    family_ids: list[int] = field(default_factory=list)
+    participant_ids: list[int] = field(default_factory=list)
+    sample_ids: list[int] = field(default_factory=list)
 
     def to_external(self):
         """Convert to transport model"""
@@ -151,6 +154,9 @@ class ProjectInsightsSummaryInternal:
             latest_sv_es_index=self.latest_sv_es_index.to_external()
             if self.latest_sv_es_index
             else None,
+            family_ids=self.family_ids,
+            participant_ids=self.participant_ids,
+            sample_ids=self.sample_ids,
         )
 
 
@@ -169,3 +175,6 @@ class ProjectInsightsSummary(SMBase):
     latest_annotate_dataset: AnalysisStats | None
     latest_snv_es_index: AnalysisStats | None
     latest_sv_es_index: AnalysisStats | None
+    family_ids: list[int]
+    participant_ids: list[int]
+    sample_ids: list[int]

--- a/test/data/generate_seqr_project_data.py
+++ b/test/data/generate_seqr_project_data.py
@@ -8,12 +8,23 @@ import random
 import sys
 import tempfile
 
-from metamist.apis import AnalysisApi, FamilyApi, ParticipantApi, ProjectApi, SampleApi
+from metamist.apis import (
+    AnalysisApi,
+    CohortApi,
+    EnumsApi,
+    FamilyApi,
+    ParticipantApi,
+    ProjectApi,
+    SampleApi,
+)
 from metamist.graphql import gql, query_async
 from metamist.model.analysis import Analysis
 from metamist.models import (
     AnalysisStatus,
     AssayUpsert,
+    BodyCreateCohortFromCriteria,
+    CohortBody,
+    CohortCriteria,
     SampleUpsert,
     SequencingGroupUpsert,
 )
@@ -65,6 +76,10 @@ PROJECTS = [
     'OMEGA',
 ]
 
+SEQ_TYPES = ['genome', 'exome', 'transcriptome']
+SEQ_TECHS = ['short-read', 'long-read']
+SEQ_PLATFORMS = ['illumina', 'oxford-nanopore', 'pacbio']
+
 LOCI = [
     'ABCD',
     'EFGH',
@@ -88,6 +103,8 @@ QUERY_PROJECT_SGS = gql(
             sequencingGroups {
                 id
                 type
+                technology
+                platform
             }
         }
     }
@@ -266,7 +283,7 @@ def generate_seq_technology(sequencing_technologies: list[str], sequencing_type:
     """Return a random sequencing technology, biased towards illumina for short-reads"""
     if sequencing_type == 'genome':
         return random.choices(['short-read', 'long-read'], weights=[0.95, 0.05], k=1)[0]
-    if sequencing_type == 'exome':
+    if sequencing_type in ['exome', 'transcriptome']:
         return 'short-read'
     return random.choice([t for t in sequencing_technologies if 'rna' in t])
 
@@ -318,14 +335,6 @@ async def generate_sample_entries(
     """
 
     sample_types = metamist_enums['enum']['sampleType']
-    sequencing_technologies = [
-        'short-read',
-        'long-read',
-        'bulk-rna-seq',
-        'single-cell-rna-seq',
-    ]
-    sequencing_platforms = ['illumina', 'oxford-nanopore', 'pacbio']
-    sequencing_types = ['genome', 'exome', 'transcriptome']
 
     # Arbitrary distribution for number of samples, sequencing groups, assays
     default_count_probabilities = {1: 0.78, 2: 0.16, 3: 0.05, 4: 0.01}
@@ -351,8 +360,8 @@ async def generate_sample_entries(
             )
             samples.append(sample)
 
-            for stype in generate_sequencing_type(
-                default_count_probabilities, sequencing_types
+            for seq_type in generate_sequencing_type(
+                default_count_probabilities, SEQ_TYPES
             ):
                 facility = random.choice(
                     [
@@ -361,12 +370,12 @@ async def generate_sample_entries(
                         'Dept of Seq.',
                     ]
                 )
-                stechnology = generate_seq_technology(sequencing_technologies, stype)
-                splatform = generate_seq_platform(sequencing_platforms, stechnology)
+                seq_tech = generate_seq_technology(SEQ_TECHS, seq_type)
+                seq_platform = generate_seq_platform(SEQ_PLATFORMS, seq_tech)
                 sg = SequencingGroupUpsert(
-                    type=stype,
-                    technology=stechnology,
-                    platform=splatform,
+                    type=seq_type,
+                    technology=seq_tech,
+                    platform=seq_platform,
                     meta={
                         'facility': facility,
                     },
@@ -385,9 +394,9 @@ async def generate_sample_entries(
                                 'facility': facility,
                                 'reads': [],
                                 'coverage': f'{random.choice([30, 90, 300, 9000, "?"])}x',
-                                'sequencing_type': stype,
-                                'sequencing_technology': stechnology,
-                                'sequencing_platform': splatform,
+                                'sequencing_type': seq_type,
+                                'sequencing_technology': seq_tech,
+                                'sequencing_platform': seq_platform,
                             },
                         )
                     )
@@ -413,29 +422,178 @@ async def generate_cram_analyses(
         k=random.randint(int(len(sequencing_groups) / 2), len(sequencing_groups)),
     )
 
-    # Insert completed CRAM analyses for the aligned sequencing groups
-    analyses_to_insert.extend(
-        [
+    # Insert completed CRAM analyses for the aligned sequencing groups, depending on their sequencing type, technology, and platform
+    for sg in aligned_sgs:
+        if sg['technology'] == 'short-read':
+            if sg['type'] == 'genome':
+                crampath = f'FAKE://{project}/cram/{sg["id"]}.cram'
+            elif sg['type'] == 'exome':
+                crampath = f'FAKE://{project}/exome/cram/{sg["id"]}.cram'
+            elif sg['type'] == 'transcriptome':
+                crampath = f'FAKE://{project}/transcriptome/cram/{sg["id"]}.cram'
+            else:
+                crampath = f'FAKE://{project}/crams/{sg["id"]}.cram'
+        elif sg['technology'] == 'long-read':
+            crampath = f'FAKE://{project}/long_read/{sg["id"]}.cram'
+        else:
+            crampath = f'FAKE://{project}/crams/{sg["id"]}.cram'
+        analyses_to_insert.append(
             Analysis(
                 sequencing_group_ids=[sg['id']],
                 type='cram',
                 status=AnalysisStatus('completed'),
                 project=project_id,
-                output=f'FAKE://{project}/crams/{sg["id"]}.cram',
+                output=crampath,
                 timestamp_completed=(
                     datetime.datetime.now()
                     - datetime.timedelta(days=random.randint(1, 15))
                 ).isoformat(),
                 meta={
+                    'sequencing_type': sg['type'],
+                    'sequencing_technology': sg['technology'],
+                    'sequencing_platform': sg['platform'],
                     # random size between 5, 25 GB
                     'size': random.randint(5 * 1024, 25 * 1024) * 1024 * 1024,
                 },
             )
-            for sg in aligned_sgs
-        ]
-    )
+        )
 
     return aligned_sgs
+
+
+async def generate_cohorts(
+    project: str,
+    aligned_sequencing_groups: list[dict],
+    cohort_api: CohortApi,
+) -> dict[tuple[str, str], str]:
+    """
+    Generates "Custom cohorts" for the input project and its aligned sequencing groups, with generated names.
+    Uses these cohort IDs when creating multi-SG analyses, like the QC and es-index analyses.
+
+    Returns a dict mapping sequencing type and technology combinations to cohort IDs (platform is ignored here).
+    """
+    # First lists of sequencing groups by type and technology
+    sgs_by_type_tech: dict[tuple[str, str], list[str]] = {}
+    for sg in aligned_sequencing_groups:
+        key = (sg['type'], sg['technology'])
+        if key not in sgs_by_type_tech:
+            sgs_by_type_tech[key] = []
+        sgs_by_type_tech[key].append(sg['id'])
+
+    # Next, create cohorts for each combination of sequencing type and technology
+    cohort_ids_by_type_tech: dict[tuple[str, str], str] = {}
+    for (seq_type, seq_tech), sg_ids in sgs_by_type_tech.items():
+        cohort_criteria = CohortCriteria(
+            sg_ids_internal=sg_ids,
+        )
+        cohort_body = CohortBody(
+            name=f'{project} {seq_type} {seq_tech} {datetime.date.today().isoformat()}',
+            description=f'{seq_type} and {seq_tech} only',
+        )
+        cohort = cohort_api.create_cohort_from_criteria(
+            project=project,
+            body_create_cohort_from_criteria=BodyCreateCohortFromCriteria(
+                cohort_spec=cohort_body,
+                cohort_criteria=cohort_criteria,
+            ),
+        )
+        cohort_ids_by_type_tech[(seq_type, seq_tech)] = cohort['cohort_id']
+
+    return cohort_ids_by_type_tech
+
+
+async def generate_qc_analyses(
+    project: str,
+    cohort_ids_by_type_tech: dict[tuple[str, str], str],
+    analyses_to_insert: list[Analysis],
+):
+    """
+    Generates multi-SG analyses of type QC for the input project and cohorts, with random QC metrics in the meta field.
+    Created QC analyses include all SGs in the given cohorts, with results from stages `CramMultiQC` and `SomalierPedigree`.
+    """
+    for (seq_type, seq_tech), cohort_id in cohort_ids_by_type_tech.items():
+        if seq_tech == 'long-read':
+            continue
+        if seq_type in ['exome', 'genome']:
+            analyses_to_insert.append(
+                Analysis(
+                    cohort_ids=[cohort_id],
+                    type='qc',
+                    status=AnalysisStatus('completed'),
+                    output=f'FAKE::{project}-{seq_type}-qc-{datetime.date.today()}.json',
+                    meta={'stage': 'CramMultiQC', 'sequencing_type': seq_type},
+                )
+            )
+            analyses_to_insert.append(
+                Analysis(
+                    cohort_ids=[cohort_id],
+                    type='qc',
+                    status=AnalysisStatus('completed'),
+                    output=f'FAKE::{project}-{seq_type}-qc-{datetime.date.today()}.json',
+                    meta={'stage': 'SomalierPedigree', 'sequencing_type': seq_type},
+                )
+            )
+
+
+async def generate_seqr_loader_analyses(
+    project: str,
+    cohort_ids_by_type_tech: dict[tuple[str, str], str],
+    analyses_to_insert: list[Analysis],
+):
+    """
+    Generates matrixtable analyses from the AnnotateDataset stage, and ES-index analyses
+    from the MtToEs stage, using the generated cohorts for the input project.
+
+    Extends the `analyses_to_insert` list with the new analyses, which will be inserted
+    in bulk at the end of the main function.
+    """
+    for (seq_type, seq_tech), cohort_id in cohort_ids_by_type_tech.items():
+        if seq_tech == 'long-read':
+            continue
+        if seq_type in ['exome', 'genome']:
+            analyses_to_insert.extend(
+                [
+                    Analysis(
+                        cohort_ids=[cohort_id],
+                        type='matrixtable',
+                        status=AnalysisStatus('completed'),
+                        output=f'FAKE::{project}-{seq_type}-{datetime.date.today()}.mt',
+                        meta={'stage': 'AnnotateDataset', 'sequencing_type': seq_type},
+                    ),
+                    Analysis(
+                        cohort_ids=[cohort_id],
+                        type='es-index',
+                        status=AnalysisStatus('completed'),
+                        output=f'FAKE::{project}-{seq_type}-es-{datetime.date.today()}.done',
+                        meta={'stage': 'MtToEs', 'sequencing_type': seq_type},
+                    ),
+                ]
+            )
+            # Insert an SV es-index for genomes, and a GCNV es-index for exomes
+            if seq_type == 'genome':
+                analyses_to_insert.extend(
+                    [
+                        Analysis(
+                            cohort_ids=[cohort_id],
+                            type='es-index',
+                            status=AnalysisStatus('completed'),
+                            output=f'FAKE::{project}-{seq_type}-sv-{datetime.date.today()}.done',
+                            meta={'stage': 'MtToEsSv', 'sequencing_type': seq_type},
+                        ),
+                    ]
+                )
+            elif seq_type == 'exome':
+                analyses_to_insert.extend(
+                    [
+                        Analysis(
+                            cohort_ids=[cohort_id],
+                            type='es-index',
+                            status=AnalysisStatus('completed'),
+                            output=f'FAKE::{project}-{seq_type}-gcnv-{datetime.date.today()}.done',
+                            meta={'stage': 'MtToEsCNV', 'sequencing_type': seq_type},
+                        ),
+                    ]
+                )
 
 
 async def generate_web_report_analyses(
@@ -463,7 +621,7 @@ async def generate_web_report_analyses(
 
         return {'outliers_detected': outliers_detected, 'outlier_loci': outlier_loci}
 
-    # Insert completed web analyses for the aligned sequencing groups
+    # Insert a completed web analysis for MitoReport and STRipy reports for each of the aligned sequencing groups
     for sg in aligned_sequencing_groups:
         stripy_outliers = get_stripy_outliers()
         analyses_to_insert.extend(
@@ -481,8 +639,8 @@ async def generate_web_report_analyses(
                     meta={
                         'stage': 'Stripy',
                         'sequencing_type': sg['type'],
-                        # random size between 5, 50 MB
-                        'size': random.randint(5 * 1024, 25 * 1024) * 1024,
+                        # random size between 0.5, 2.5 MB
+                        'size': random.randint(512, 2560) * 1024,
                         'outliers_detected': stripy_outliers['outliers_detected'],
                         'outlier_loci': stripy_outliers['outlier_loci'],
                     },
@@ -500,76 +658,29 @@ async def generate_web_report_analyses(
                     meta={
                         'stage': 'MitoReport',
                         'sequencing_type': sg['type'],
-                        # random size between 5, 50 MB
-                        'size': random.randint(5 * 1024, 25 * 1024) * 1024,
+                        # random size between 0.5, 2.5 MB
+                        'size': random.randint(512, 2560) * 1024,
                     },
                 ),
             ]
         )
-
-
-async def generate_joint_called_analyses(
-    project: str, aligned_sgs: list[dict], analyses_to_insert: list[Analysis]
-):
-    """
-    Selects a subset of the aligned sequencing groups for the input project and
-    generates joint-called AnnotateDataset and ES-index analysis entries for them.
-    """
-    seq_type_to_sg_list = {
-        'genome': [sg['id'] for sg in aligned_sgs if sg['type'] == 'genome'],
-        'exome': [sg['id'] for sg in aligned_sgs if sg['type'] == 'exome'],
-        'transcriptome': [
-            sg['id'] for sg in aligned_sgs if sg['type'] == 'transcriptome'
-        ],
-    }
-    for seq_type, sg_list in seq_type_to_sg_list.items():
-        if not sg_list:
-            continue
-        joint_called_sgs = random.sample(sg_list, k=random.randint(1, len(sg_list)))
-
-        analyses_to_insert.extend(
-            [
-                Analysis(
-                    sequencing_group_ids=joint_called_sgs,
-                    type='custom',
-                    status=AnalysisStatus('completed'),
-                    output=f'FAKE::{project}-{seq_type}-{datetime.date.today()}.mt',
-                    meta={'stage': 'AnnotateDataset', 'sequencing_type': seq_type},
-                ),
-                Analysis(
-                    sequencing_group_ids=joint_called_sgs,
-                    type='es-index',
-                    status=AnalysisStatus('completed'),
-                    output=f'FAKE::{project}-{seq_type}-es-{datetime.date.today()}',
-                    meta={'stage': 'MtToEs', 'sequencing_type': seq_type},
-                ),
-            ]
+    # Also insert a web report for the STRipy index for the whole project
+    analyses_to_insert.append(
+        Analysis(
+            sequencing_group_ids=[sg['id'] for sg in aligned_sequencing_groups],
+            project=project_id,
+            type='web',
+            status=AnalysisStatus('completed'),
+            output=f'FAKE://{project}/stripy/index.html',
+            timestamp_completed=datetime.datetime.now().isoformat(),
+            meta={
+                'stage': 'MakeIndexPage',
+                'sequencing_type': 'genome',
+                # random size between 5, 50 MB
+                'size': random.randint(5 * 1024, 50 * 1024) * 1024,
+            },
         )
-
-        if seq_type == 'genome':
-            analyses_to_insert.extend(
-                [
-                    Analysis(
-                        sequencing_group_ids=joint_called_sgs,
-                        type='es-index',
-                        status=AnalysisStatus('completed'),
-                        output=f'FAKE::{project}-{seq_type}-sv-{datetime.date.today()}',
-                        meta={'stage': 'MtToEsSv', 'sequencing_type': seq_type},
-                    ),
-                ]
-            )
-        elif seq_type == 'exome':
-            analyses_to_insert.extend(
-                [
-                    Analysis(
-                        sequencing_group_ids=joint_called_sgs,
-                        type='es-index',
-                        status=AnalysisStatus('completed'),
-                        output=f'FAKE::{project}-{seq_type}-gcnv-{datetime.date.today()}',
-                        meta={'stage': 'MtToEsCNV', 'sequencing_type': seq_type},
-                    ),
-                ]
-            )
+    )
 
 
 async def main():
@@ -583,7 +694,10 @@ async def main():
     aapi = AnalysisApi()
     papi = ProjectApi()
     sapi = SampleApi()
+    logging.getLogger().setLevel(logging.WARN)
     metamist_enums: dict[str, dict[str, list[str]]] = await query_async(QUERY_ENUMS)
+    logging.getLogger().setLevel(logging.INFO)
+    await EnumsApi().post_analysis_types_async('matrixtable')
 
     existing_projects = await papi.get_my_projects_async()
     for project in PROJECTS:
@@ -640,12 +754,17 @@ async def main():
         aligned_sgs = await generate_cram_analyses(
             project, project_id, analyses_to_insert
         )
+        cohort_ids_by_type_tech = await generate_cohorts(
+            project, aligned_sgs, CohortApi()
+        )
 
         await generate_web_report_analyses(
             project, project_id, aligned_sgs, analyses_to_insert
         )
 
-        await generate_joint_called_analyses(project, aligned_sgs, analyses_to_insert)
+        await generate_seqr_loader_analyses(
+            project, cohort_ids_by_type_tech, analyses_to_insert
+        )
 
         for analyses in chunk(analyses_to_insert, 50):
             logging.info(f'Inserting {len(analyses)} analysis entries into {project}')

--- a/test/data/generate_seqr_project_data.py
+++ b/test/data/generate_seqr_project_data.py
@@ -127,7 +127,7 @@ QUERY_ENUMS = gql(
 )
 
 
-class ped_row:  # noqa: N801
+class PedigreeRow:
     """The pedigree row class"""
 
     def __init__(self, values):
@@ -168,10 +168,10 @@ def generate_pedigree_rows(num_families=1):  # noqa: D417
 
     Returns
     -------
-    A list of ped_row objects representing a project's pedigree.
+    A list of PedigreeRow objects representing a project's pedigree.
     """
     used_ids: set[str] = set()
-    rows: list[ped_row] = []
+    rows: list[PedigreeRow] = []
     for _ in range(num_families):
         num_individuals_in_family = random.randint(1, 5)
         family_id = generate_random_id(used_ids)
@@ -180,7 +180,9 @@ def generate_pedigree_rows(num_families=1):  # noqa: D417
         if num_individuals_in_family == 1:  # Singleton
             individual_id = generate_random_id(used_ids)
             rows.append(
-                ped_row([family_id, individual_id, '', '', random.choice([0, 1]), 2])
+                PedigreeRow(
+                    [family_id, individual_id, '', '', random.choice([0, 1]), 2]
+                )
             )
             continue
 
@@ -191,13 +193,13 @@ def generate_pedigree_rows(num_families=1):  # noqa: D417
                 0
             ]
             rows.append(
-                ped_row([family_id, parent_id, '', '', parent_sex, parent_affected])
+                PedigreeRow([family_id, parent_id, '', '', parent_sex, parent_affected])
             )
 
             individual_id = generate_random_id(used_ids)
             if parent_sex == 1:
                 rows.append(
-                    ped_row(
+                    PedigreeRow(
                         [
                             family_id,
                             individual_id,
@@ -210,7 +212,7 @@ def generate_pedigree_rows(num_families=1):  # noqa: D417
                 )
             else:
                 rows.append(
-                    ped_row(
+                    PedigreeRow(
                         [
                             family_id,
                             individual_id,
@@ -227,7 +229,9 @@ def generate_pedigree_rows(num_families=1):  # noqa: D417
                 founder_id = generate_random_id(used_ids)
                 sex = i + 1
                 affected = random.choices([0, 1, 2], weights=[0.05, 0.8, 0.15], k=1)[0]
-                founders.append(ped_row([family_id, founder_id, '', '', sex, affected]))
+                founders.append(
+                    PedigreeRow([family_id, founder_id, '', '', sex, affected])
+                )
 
             rows.extend(founders)
             # Generate remaining individuals in the family
@@ -246,7 +250,7 @@ def generate_pedigree_rows(num_families=1):  # noqa: D417
                     0
                 ]  # Randomly assign affected status
                 rows.append(
-                    ped_row(
+                    PedigreeRow(
                         [
                             family_id,
                             individual_id,

--- a/test/data/generate_seqr_project_data.py
+++ b/test/data/generate_seqr_project_data.py
@@ -527,9 +527,9 @@ async def generate_qc_analyses(
             analyses_to_insert.append(
                 Analysis(
                     cohort_ids=[cohort_id],
-                    type='qc',
+                    type='web',
                     status=AnalysisStatus('completed'),
-                    output=f'FAKE::{project}-{seq_type}-qc-{datetime.date.today()}.json',
+                    output=f'FAKE::{project}-{seq_type}-web/somalierpedigree-{datetime.date.today()}.html',
                     meta={'stage': 'SomalierPedigree', 'sequencing_type': seq_type},
                 )
             )

--- a/test/test_generate_seqr_project_data.py
+++ b/test/test_generate_seqr_project_data.py
@@ -1,0 +1,934 @@
+import asyncio
+import random
+import re
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from metamist.graphql import configure_sync_client, validate
+from metamist.model.analysis import Analysis
+
+from api.graphql.schema import schema  # type: ignore
+from test.data.generate_seqr_project_data import (
+    NAMES,
+    PROJECTS,
+    QUERY_ENUMS,
+    QUERY_PROJECT_ID,
+    QUERY_PROJECT_SGS,
+    SEQ_PLATFORMS,
+    SEQ_TECHS,
+    SEQ_TYPES,
+    generate_cohorts,
+    generate_cram_analyses,
+    generate_pedigree_rows,
+    generate_project_pedigree,
+    generate_qc_analyses,
+    generate_random_id,
+    generate_random_number_within_distribution,
+    generate_sample_entries,
+    generate_seq_platform,
+    generate_seq_technology,
+    generate_seqr_loader_analyses,
+    generate_sequencing_type,
+    generate_web_report_analyses,
+    main,
+    ped_row,
+)
+
+
+class ValidateSeqrGenerateDataQueries(unittest.TestCase):
+    """Validate that the GraphQL queries in generate_seqr_project_data are valid against the schema."""
+
+    def test_validate_queries(self):
+        client = configure_sync_client(schema=schema.as_str(), auth_token='FAKE')
+        validate(QUERY_PROJECT_ID, client=client)
+        validate(QUERY_PROJECT_SGS, client=client)
+        validate(QUERY_ENUMS, client=client)
+
+
+class TestPedRow(unittest.TestCase):
+    """Phase 1a: Tests for the ped_row class."""
+
+    def test_construction_from_list(self):
+        values = ['FAM1', 'IND1', 'PAT1', 'MAT1', 1, 2]
+        row = ped_row(values)
+        self.assertEqual(row.family_id, 'FAM1')
+        self.assertEqual(row.individual_id, 'IND1')
+        self.assertEqual(row.paternal_id, 'PAT1')
+        self.assertEqual(row.maternal_id, 'MAT1')
+        self.assertEqual(row.sex, 1)
+        self.assertEqual(row.affected, 2)
+
+    def test_iter_yields_correct_order(self):
+        values = ['FAM1', 'IND1', 'PAT1', 'MAT1', 1, 2]
+        row = ped_row(values)
+        self.assertEqual(list(row), values)
+
+    def test_field_access(self):
+        values = ['FAM_X', 'IND_Y', '', '', 0, 1]
+        row = ped_row(values)
+        self.assertEqual(row.family_id, 'FAM_X')
+        self.assertEqual(row.individual_id, 'IND_Y')
+        self.assertEqual(row.paternal_id, '')
+        self.assertEqual(row.maternal_id, '')
+        self.assertEqual(row.sex, 0)
+        self.assertEqual(row.affected, 1)
+
+
+class TestGenerateRandomId(unittest.TestCase):
+    """Phase 1b: Tests for generate_random_id."""
+
+    def test_returns_matching_pattern(self):
+        random.seed(42)
+        used_ids: set[str] = set()
+        rid = generate_random_id(used_ids)
+        # Pattern: NAME_NNNN where NAME is from NAMES and NNNN is zero-padded 4 digits
+        pattern = re.compile(r'^[A-Z]+_\d{4}$')
+        self.assertRegex(rid, pattern)
+        name_part = rid.split('_')[0]
+        self.assertIn(name_part, NAMES)
+
+    def test_adds_to_used_ids(self):
+        random.seed(42)
+        used_ids: set[str] = set()
+        rid = generate_random_id(used_ids)
+        self.assertIn(rid, used_ids)
+
+    def test_never_returns_duplicate(self):
+        random.seed(42)
+        used_ids: set[str] = set()
+        ids = [generate_random_id(used_ids) for _ in range(50)]
+        self.assertEqual(len(ids), len(set(ids)))
+
+
+class TestGeneratePedigreeRows(unittest.TestCase):
+    """Phase 1c: Tests for generate_pedigree_rows."""
+
+    def test_zero_families_returns_empty(self):
+        result = generate_pedigree_rows(num_families=0)
+        self.assertEqual(result, [])
+
+    def test_one_family_returns_at_least_one_row(self):
+        random.seed(42)
+        result = generate_pedigree_rows(num_families=1)
+        self.assertGreaterEqual(len(result), 1)
+
+    def test_all_rows_are_ped_row_instances(self):
+        random.seed(42)
+        result = generate_pedigree_rows(num_families=5)
+        for row in result:
+            self.assertIsInstance(row, ped_row)
+
+    def test_all_individual_ids_unique(self):
+        random.seed(42)
+        result = generate_pedigree_rows(num_families=10)
+        individual_ids = [row.individual_id for row in result]
+        self.assertEqual(len(individual_ids), len(set(individual_ids)))
+
+    def test_singleton_family(self):
+        """Force a singleton family (1 individual) and check properties."""
+        with patch(
+            'test.data.generate_seqr_project_data.random.randint',
+            side_effect=lambda a, b: 1 if (a, b) == (1, 5) else random.Random(42).randint(a, b),
+        ):
+            result = generate_pedigree_rows(num_families=1)
+            self.assertEqual(len(result), 1)
+            row = result[0]
+            self.assertEqual(row.paternal_id, '')
+            self.assertEqual(row.maternal_id, '')
+            self.assertEqual(row.affected, 2)
+
+    def test_duo_family(self):
+        """Force a duo family (2 individuals) and check parent-child relationship."""
+        rng = random.Random(42)
+        with patch(
+            'test.data.generate_seqr_project_data.random.randint',
+            side_effect=lambda a, b: 2 if (a, b) == (1, 5) else rng.randint(a, b),
+        ), patch(
+            'test.data.generate_seqr_project_data.random.choice',
+            side_effect=rng.choice,
+        ), patch(
+            'test.data.generate_seqr_project_data.random.choices',
+            side_effect=lambda pop, weights=None, k=1: rng.choices(pop, weights=weights, k=k),
+        ):
+            result = generate_pedigree_rows(num_families=1)
+            self.assertEqual(len(result), 2)
+            parent = result[0]
+            child = result[1]
+            # Parent has no parents
+            self.assertEqual(parent.paternal_id, '')
+            self.assertEqual(parent.maternal_id, '')
+            # Child references parent based on parent sex
+            if parent.sex == 1:
+                self.assertEqual(child.paternal_id, parent.individual_id)
+                self.assertEqual(child.maternal_id, '')
+            else:
+                self.assertEqual(child.paternal_id, '')
+                self.assertEqual(child.maternal_id, parent.individual_id)
+            self.assertEqual(child.affected, 2)
+
+    def test_trio_plus_family(self):
+        """Force a trio+ family (3-5 individuals) and check founders."""
+        rng = random.Random(42)
+        with patch(
+            'test.data.generate_seqr_project_data.random.randint',
+            side_effect=lambda a, b: 4 if (a, b) == (1, 5) else rng.randint(a, b),
+        ), patch(
+            'test.data.generate_seqr_project_data.random.choice',
+            side_effect=rng.choice,
+        ), patch(
+            'test.data.generate_seqr_project_data.random.choices',
+            side_effect=lambda pop, weights=None, k=1: rng.choices(pop, weights=weights, k=k),
+        ):
+            result = generate_pedigree_rows(num_families=1)
+            self.assertEqual(len(result), 4)
+            # First two are founders
+            founder1 = result[0]
+            founder2 = result[1]
+            self.assertEqual(founder1.sex, 1)
+            self.assertEqual(founder2.sex, 2)
+            self.assertEqual(founder1.paternal_id, '')
+            self.assertEqual(founder1.maternal_id, '')
+            self.assertEqual(founder2.paternal_id, '')
+            self.assertEqual(founder2.maternal_id, '')
+            # Children reference founders
+            for child in result[2:]:
+                if child.paternal_id:
+                    self.assertEqual(
+                        child.paternal_id, founder1.individual_id
+                    )
+                if child.maternal_id:
+                    self.assertEqual(
+                        child.maternal_id, founder2.individual_id
+                    )
+
+
+class TestSequencingGenerators(unittest.TestCase):
+    """Phase 1d-g: Tests for sequencing type/platform/technology generators."""
+
+    # Phase 1d: generate_sequencing_type
+    def test_generate_sequencing_type_returns_list(self):
+        random.seed(42)
+        dist = {1: 0.8, 2: 0.15, 3: 0.05}
+        result = generate_sequencing_type(dist, SEQ_TYPES)
+        self.assertIsInstance(result, list)
+
+    def test_generate_sequencing_type_length_from_distribution(self):
+        random.seed(42)
+        dist = {1: 0.8, 2: 0.15, 3: 0.05}
+        result = generate_sequencing_type(dist, SEQ_TYPES)
+        self.assertIn(len(result), dist.keys())
+
+    def test_generate_sequencing_type_values_from_seq_types(self):
+        random.seed(42)
+        dist = {1: 0.8, 2: 0.15, 3: 0.05}
+        result = generate_sequencing_type(dist, SEQ_TYPES)
+        for val in result:
+            self.assertIn(val, SEQ_TYPES)
+
+    # Phase 1e: generate_seq_platform
+    def test_long_read_always_pacbio(self):
+        for seed in range(20):
+            random.seed(seed)
+            result = generate_seq_platform(SEQ_PLATFORMS, 'long-read')
+            self.assertEqual(result, 'pacbio')
+
+    def test_short_read_returns_platform(self):
+        random.seed(42)
+        result = generate_seq_platform(SEQ_PLATFORMS, 'short-read')
+        self.assertIn(result, SEQ_PLATFORMS)
+
+    # Phase 1f: generate_seq_technology
+    def test_genome_returns_short_or_long_read(self):
+        results = set()
+        for seed in range(200):
+            random.seed(seed)
+            results.add(generate_seq_technology(SEQ_TECHS, 'genome'))
+        self.assertTrue(results.issubset({'short-read', 'long-read'}))
+
+    def test_exome_always_short_read(self):
+        for seed in range(20):
+            random.seed(seed)
+            result = generate_seq_technology(SEQ_TECHS, 'exome')
+            self.assertEqual(result, 'short-read')
+
+    def test_transcriptome_always_short_read(self):
+        for seed in range(20):
+            random.seed(seed)
+            result = generate_seq_technology(SEQ_TECHS, 'transcriptome')
+            self.assertEqual(result, 'short-read')
+
+    # Phase 1g: generate_random_number_within_distribution
+    def test_returns_key_from_distribution(self):
+        random.seed(42)
+        dist = {1: 0.5, 2: 0.3, 3: 0.2}
+        result = generate_random_number_within_distribution(dist)
+        self.assertIn(result, dist.keys())
+
+    def test_respects_weighting(self):
+        random.seed(42)
+        dist = {10: 0.99, 20: 0.01}
+        results = [
+            generate_random_number_within_distribution(dist) for _ in range(100)
+        ]
+        # With 99% weight, 10 should appear far more often
+        self.assertGreater(results.count(10), results.count(20))
+
+
+class TestGenerateCramAnalyses(unittest.TestCase):
+    """Phase 3a: Tests for generate_cram_analyses."""
+
+    def _make_sg(self, sg_id, sg_type, technology, platform='illumina'):
+        return {
+            'id': sg_id,
+            'type': sg_type,
+            'technology': technology,
+            'platform': platform,
+        }
+
+    def test_cram_analyses_appended(self):
+        sgs = [
+            self._make_sg('SG001', 'genome', 'short-read'),
+            self._make_sg('SG002', 'exome', 'short-read'),
+            self._make_sg('SG003', 'transcriptome', 'short-read'),
+            self._make_sg('SG004', 'genome', 'long-read', 'pacbio'),
+        ]
+        mock_response = {'project': {'sequencingGroups': sgs}}
+
+        analyses: list[Analysis] = []
+
+        with patch(
+            'test.data.generate_seqr_project_data.query_async',
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            # Force all SGs to be selected as aligned
+            random.seed(42)
+            result = asyncio.run(
+                generate_cram_analyses('TESTPROJ', 1, analyses)
+            )
+
+        # All SGs returned as aligned (random.sample with k >= len/2)
+        self.assertGreater(len(result), 0)
+        self.assertGreater(len(analyses), 0)
+
+        # Analyses should correspond to the aligned (returned) SGs
+        aligned_sg_ids = {sg['id'] for sg in result}
+        for a in analyses:
+            self.assertEqual(a.type, 'cram')
+            self.assertEqual(str(a.status), 'completed')
+            self.assertTrue(
+                set(a.sequencing_group_ids).issubset(aligned_sg_ids),
+                f'Analysis SG IDs {a.sequencing_group_ids} not in aligned SGs {aligned_sg_ids}',
+            )
+
+    def _run_cram_with_all_aligned(self, sgs):
+        """Helper: run generate_cram_analyses forcing all SGs to be aligned."""
+        mock_response = {'project': {'sequencingGroups': sgs}}
+        analyses: list[Analysis] = []
+
+        with patch(
+            'test.data.generate_seqr_project_data.query_async',
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ), patch(
+            'test.data.generate_seqr_project_data.random.sample',
+            side_effect=lambda population, k: population,  # noqa: ARG005
+        ):
+            random.seed(42)
+            result = asyncio.run(
+                generate_cram_analyses('PROJ', 1, analyses)
+            )
+        return analyses, result
+
+    def test_cram_path_short_read_genome(self):
+        sgs = [self._make_sg('SG001', 'genome', 'short-read')]
+        analyses, _ = self._run_cram_with_all_aligned(sgs)
+        self.assertEqual(len(analyses), 1)
+        self.assertEqual(analyses[0].output, 'FAKE://PROJ/cram/SG001.cram')
+
+    def test_cram_path_short_read_exome(self):
+        sgs = [self._make_sg('SG001', 'exome', 'short-read')]
+        analyses, _ = self._run_cram_with_all_aligned(sgs)
+        self.assertEqual(len(analyses), 1)
+        self.assertEqual(
+            analyses[0].output, 'FAKE://PROJ/exome/cram/SG001.cram'
+        )
+
+    def test_cram_path_short_read_transcriptome(self):
+        sgs = [self._make_sg('SG001', 'transcriptome', 'short-read')]
+        analyses, _ = self._run_cram_with_all_aligned(sgs)
+        self.assertEqual(len(analyses), 1)
+        self.assertEqual(
+            analyses[0].output, 'FAKE://PROJ/transcriptome/cram/SG001.cram'
+        )
+
+    def test_cram_path_long_read(self):
+        sgs = [self._make_sg('SG001', 'genome', 'long-read', 'pacbio')]
+        analyses, _ = self._run_cram_with_all_aligned(sgs)
+        self.assertEqual(len(analyses), 1)
+        self.assertEqual(
+            analyses[0].output, 'FAKE://PROJ/long_read/SG001.cram'
+        )
+
+    def test_cram_path_unknown_technology_fallback(self):
+        sgs = [self._make_sg('SG001', 'genome', 'unknown-tech')]
+        analyses, _ = self._run_cram_with_all_aligned(sgs)
+        self.assertEqual(len(analyses), 1)
+        self.assertEqual(
+            analyses[0].output, 'FAKE://PROJ/crams/SG001.cram'
+        )
+
+    def test_cram_meta_fields(self):
+        sgs = [self._make_sg('SG001', 'genome', 'short-read', 'illumina')]
+        analyses, _ = self._run_cram_with_all_aligned(sgs)
+        meta = analyses[0].meta
+        self.assertEqual(meta['sequencing_type'], 'genome')
+        self.assertEqual(meta['sequencing_technology'], 'short-read')
+        self.assertEqual(meta['sequencing_platform'], 'illumina')
+        self.assertIn('size', meta)
+
+    def test_returns_subset_of_sgs(self):
+        sgs = [
+            self._make_sg(f'SG{i:03}', 'genome', 'short-read')
+            for i in range(10)
+        ]
+        mock_response = {'project': {'sequencingGroups': sgs}}
+        analyses: list[Analysis] = []
+
+        with patch(
+            'test.data.generate_seqr_project_data.query_async',
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            random.seed(42)
+            result = asyncio.run(
+                generate_cram_analyses('PROJ', 1, analyses)
+            )
+
+        # Returns between len/2 and len SGs
+        self.assertGreaterEqual(len(result), len(sgs) // 2)
+        self.assertLessEqual(len(result), len(sgs))
+        # All returned SGs should be from the original list
+        result_ids = {sg['id'] for sg in result}
+        original_ids = {sg['id'] for sg in sgs}
+        self.assertTrue(result_ids.issubset(original_ids))
+
+
+class TestGenerateQcAnalyses(unittest.TestCase):
+    """Phase 3b: Tests for generate_qc_analyses."""
+
+    def test_long_read_skipped(self):
+        cohort_ids = {
+            ('genome', 'long-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_qc_analyses('PROJ', cohort_ids, analyses)
+        )
+        self.assertEqual(len(analyses), 0)
+
+    def test_exome_produces_qc_and_web(self):
+        cohort_ids = {
+            ('exome', 'short-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_qc_analyses('PROJ', cohort_ids, analyses)
+        )
+        self.assertEqual(len(analyses), 2)
+        types = [(a.type, a.meta.get('stage')) for a in analyses]
+        self.assertIn(('qc', 'CramMultiQC'), types)
+        self.assertIn(('web', 'SomalierPedigree'), types)
+
+    def test_genome_produces_qc_and_web(self):
+        cohort_ids = {
+            ('genome', 'short-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_qc_analyses('PROJ', cohort_ids, analyses)
+        )
+        self.assertEqual(len(analyses), 2)
+        types = [(a.type, a.meta.get('stage')) for a in analyses]
+        self.assertIn(('qc', 'CramMultiQC'), types)
+        self.assertIn(('web', 'SomalierPedigree'), types)
+
+    def test_transcriptome_skipped(self):
+        cohort_ids = {
+            ('transcriptome', 'short-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_qc_analyses('PROJ', cohort_ids, analyses)
+        )
+        self.assertEqual(len(analyses), 0)
+
+    def test_mixed_cohorts(self):
+        cohort_ids = {
+            ('genome', 'short-read'): 'COH001',
+            ('exome', 'short-read'): 'COH002',
+            ('genome', 'long-read'): 'COH003',
+            ('transcriptome', 'short-read'): 'COH004',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_qc_analyses('PROJ', cohort_ids, analyses)
+        )
+        # genome short-read: 2, exome short-read: 2, long-read: 0, transcriptome: 0
+        self.assertEqual(len(analyses), 4)
+
+
+class TestGenerateSeqrLoaderAnalyses(unittest.TestCase):
+    """Phase 3c: Tests for generate_seqr_loader_analyses."""
+
+    def test_long_read_skipped(self):
+        cohort_ids = {
+            ('genome', 'long-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
+        )
+        self.assertEqual(len(analyses), 0)
+
+    def test_genome_produces_matrixtable_and_es_index_and_sv(self):
+        cohort_ids = {
+            ('genome', 'short-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
+        )
+        # matrixtable (AnnotateDataset) + es-index (MtToEs) + es-index (MtToEsSv)
+        self.assertEqual(len(analyses), 3)
+        types_stages = [(a.type, a.meta.get('stage')) for a in analyses]
+        self.assertIn(('matrixtable', 'AnnotateDataset'), types_stages)
+        self.assertIn(('es-index', 'MtToEs'), types_stages)
+        self.assertIn(('es-index', 'MtToEsSv'), types_stages)
+
+    def test_exome_produces_matrixtable_and_es_index_and_gcnv(self):
+        cohort_ids = {
+            ('exome', 'short-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
+        )
+        # matrixtable (AnnotateDataset) + es-index (MtToEs) + es-index (MtToEsCNV)
+        self.assertEqual(len(analyses), 3)
+        types_stages = [(a.type, a.meta.get('stage')) for a in analyses]
+        self.assertIn(('matrixtable', 'AnnotateDataset'), types_stages)
+        self.assertIn(('es-index', 'MtToEs'), types_stages)
+        self.assertIn(('es-index', 'MtToEsCNV'), types_stages)
+
+    def test_transcriptome_skipped(self):
+        cohort_ids = {
+            ('transcriptome', 'short-read'): 'COH001',
+        }
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
+        )
+        self.assertEqual(len(analyses), 0)
+
+
+class TestGenerateWebReportAnalyses(unittest.TestCase):
+    """Phase 3d: Tests for generate_web_report_analyses."""
+
+    def _make_sg(self, sg_id, sg_type='genome', technology='short-read', platform='illumina'):
+        return {
+            'id': sg_id,
+            'type': sg_type,
+            'technology': technology,
+            'platform': platform,
+        }
+
+    def test_each_sg_gets_stripy_and_mito(self):
+        random.seed(42)
+        sgs = [self._make_sg('SG001'), self._make_sg('SG002')]
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_web_report_analyses('PROJ', 1, sgs, analyses)
+        )
+        # 2 SGs * 2 analyses each + 1 STRipy index = 5
+        self.assertEqual(len(analyses), 5)
+
+        # Check per-SG analyses
+        for sg in sgs:
+            sg_analyses = [
+                a
+                for a in analyses
+                if a.sequencing_group_ids == [sg['id']]
+            ]
+            stages = [a.meta.get('stage') for a in sg_analyses]
+            self.assertIn('Stripy', stages)
+            self.assertIn('MitoReport', stages)
+
+    def test_stripy_index_references_all_sg_ids(self):
+        random.seed(42)
+        sgs = [self._make_sg('SG001'), self._make_sg('SG002'), self._make_sg('SG003')]
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_web_report_analyses('PROJ', 1, sgs, analyses)
+        )
+        # Last analysis is the STRipy index
+        index_analysis = analyses[-1]
+        self.assertEqual(index_analysis.meta.get('stage'), 'MakeIndexPage')
+        expected_ids = [sg['id'] for sg in sgs]
+        self.assertEqual(index_analysis.sequencing_group_ids, expected_ids)
+
+    def test_stripy_meta_contains_outlier_keys(self):
+        random.seed(42)
+        sgs = [self._make_sg('SG001')]
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_web_report_analyses('PROJ', 1, sgs, analyses)
+        )
+        stripy_analyses = [
+            a for a in analyses if a.meta.get('stage') == 'Stripy'
+        ]
+        self.assertGreater(len(stripy_analyses), 0)
+        for a in stripy_analyses:
+            self.assertIn('outliers_detected', a.meta)
+            self.assertIn('outlier_loci', a.meta)
+
+    def test_analyses_are_web_type_completed(self):
+        random.seed(42)
+        sgs = [self._make_sg('SG001')]
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_web_report_analyses('PROJ', 1, sgs, analyses)
+        )
+        for a in analyses:
+            self.assertEqual(a.type, 'web')
+            self.assertEqual(str(a.status), 'completed')
+
+
+class TestGenerateProjectPedigree(unittest.TestCase):
+    """Phase 4a: Tests for generate_project_pedigree."""
+
+    @patch('test.data.generate_seqr_project_data.ParticipantApi')
+    @patch('test.data.generate_seqr_project_data.FamilyApi')
+    def test_returns_id_map_from_participant_api(self, mock_family_cls, mock_participant_cls):
+        random.seed(42)
+        expected_map = {'SOLAR_0042': 1, 'LUNAR_0099': 2}
+
+        mock_family_instance = mock_family_cls.return_value
+        mock_family_instance.import_pedigree_async = AsyncMock()
+
+        mock_participant_instance = mock_participant_cls.return_value
+        mock_participant_instance.get_participant_id_map_by_external_ids_async = AsyncMock(
+            return_value=expected_map
+        )
+
+        result = asyncio.run(generate_project_pedigree('test-project'))
+        self.assertEqual(result, expected_map)
+
+    @patch('test.data.generate_seqr_project_data.ParticipantApi')
+    @patch('test.data.generate_seqr_project_data.FamilyApi')
+    def test_import_pedigree_called_with_correct_args(self, mock_family_cls, mock_participant_cls):
+        random.seed(42)
+
+        mock_family_instance = mock_family_cls.return_value
+        mock_family_instance.import_pedigree_async = AsyncMock()
+
+        mock_participant_instance = mock_participant_cls.return_value
+        mock_participant_instance.get_participant_id_map_by_external_ids_async = AsyncMock(
+            return_value={}
+        )
+
+        asyncio.run(generate_project_pedigree('test-project'))
+
+        mock_family_instance.import_pedigree_async.assert_called_once()
+        call_kwargs = mock_family_instance.import_pedigree_async.call_args
+        self.assertEqual(call_kwargs.kwargs['project'], 'test-project')
+        self.assertFalse(call_kwargs.kwargs['has_header'])
+        self.assertTrue(call_kwargs.kwargs['create_missing_participants'])
+
+    @patch('test.data.generate_seqr_project_data.ParticipantApi')
+    @patch('test.data.generate_seqr_project_data.FamilyApi')
+    def test_participant_eids_passed_to_get_id_map(self, mock_family_cls, mock_participant_cls):
+        random.seed(42)
+
+        mock_family_instance = mock_family_cls.return_value
+        mock_family_instance.import_pedigree_async = AsyncMock()
+
+        mock_participant_instance = mock_participant_cls.return_value
+        mock_participant_instance.get_participant_id_map_by_external_ids_async = AsyncMock(
+            return_value={}
+        )
+
+        asyncio.run(generate_project_pedigree('test-project'))
+
+        call_kwargs = mock_participant_instance.get_participant_id_map_by_external_ids_async.call_args
+        self.assertEqual(call_kwargs.kwargs['project'], 'test-project')
+        # request_body should be a list of individual IDs (strings)
+        request_body = call_kwargs.kwargs['request_body']
+        self.assertIsInstance(request_body, list)
+        self.assertGreater(len(request_body), 0)
+        for eid in request_body:
+            self.assertIsInstance(eid, str)
+
+
+class TestGenerateSampleEntries(unittest.TestCase):
+    """Phase 4b: Tests for generate_sample_entries."""
+
+    def test_upsert_called_with_sample_upserts(self):
+        random.seed(42)
+        participant_id_map = {'PART_01': 1, 'PART_02': 2}
+        fake_enums = {'enum': {'sampleType': ['blood', 'saliva']}}
+        mock_sapi = AsyncMock()
+
+        asyncio.run(
+            generate_sample_entries('test-proj', participant_id_map, fake_enums, mock_sapi)
+        )
+
+        mock_sapi.upsert_samples_async.assert_called_once()
+        call_args = mock_sapi.upsert_samples_async.call_args
+        self.assertEqual(call_args[0][0], 'test-proj')
+        samples = call_args[0][1]
+        self.assertIsInstance(samples, list)
+        self.assertGreater(len(samples), 0)
+
+    def test_each_sample_has_valid_fields(self):
+        random.seed(42)
+        participant_id_map = {'PART_01': 1, 'PART_02': 2}
+        fake_enums = {'enum': {'sampleType': ['blood', 'saliva']}}
+        mock_sapi = AsyncMock()
+
+        asyncio.run(
+            generate_sample_entries('test-proj', participant_id_map, fake_enums, mock_sapi)
+        )
+
+        samples = mock_sapi.upsert_samples_async.call_args[0][1]
+        valid_participant_ids = set(participant_id_map.values())
+        for sample in samples:
+            # Each sample should have external_ids dict
+            self.assertIsNotNone(sample.external_ids)
+            # Each sample type should be from the enums
+            self.assertIn(sample.type, ['blood', 'saliva'])
+            # Each sample should reference a valid participant
+            self.assertIn(sample.participant_id, valid_participant_ids)
+
+    def test_deterministic_with_seed(self):
+        """Same seed should produce the same samples."""
+        participant_id_map = {'PART_01': 1}
+        fake_enums = {'enum': {'sampleType': ['blood']}}
+
+        mock_sapi_1 = AsyncMock()
+        random.seed(99)
+        asyncio.run(
+            generate_sample_entries('proj', participant_id_map, fake_enums, mock_sapi_1)
+        )
+
+        mock_sapi_2 = AsyncMock()
+        random.seed(99)
+        asyncio.run(
+            generate_sample_entries('proj', participant_id_map, fake_enums, mock_sapi_2)
+        )
+
+        samples_1 = mock_sapi_1.upsert_samples_async.call_args[0][1]
+        samples_2 = mock_sapi_2.upsert_samples_async.call_args[0][1]
+        self.assertEqual(len(samples_1), len(samples_2))
+        for s1, s2 in zip(samples_1, samples_2, strict=True):
+            self.assertEqual(s1.external_ids, s2.external_ids)
+            self.assertEqual(s1.type, s2.type)
+            self.assertEqual(s1.participant_id, s2.participant_id)
+
+
+class TestGenerateCohorts(unittest.TestCase):
+    """Phase 4c: Tests for generate_cohorts."""
+
+    def _make_mock_cohort_api(self, cohort_id='COH123'):
+        """Create a MagicMock cohort API (create_cohort_from_criteria is sync)."""
+        mock_cohort_api = MagicMock()
+        mock_cohort_api.create_cohort_from_criteria.return_value = {
+            'cohort_id': cohort_id
+        }
+        return mock_cohort_api
+
+    def test_one_cohort_per_type_tech_pair(self):
+        sgs = [
+            {'id': 'SG1', 'type': 'genome', 'technology': 'short-read'},
+            {'id': 'SG2', 'type': 'genome', 'technology': 'short-read'},
+            {'id': 'SG3', 'type': 'exome', 'technology': 'short-read'},
+            {'id': 'SG4', 'type': 'genome', 'technology': 'long-read'},
+        ]
+        mock_cohort_api = self._make_mock_cohort_api()
+
+        result = asyncio.run(generate_cohorts('test-proj', sgs, mock_cohort_api))
+
+        # 3 unique (type, tech) pairs
+        self.assertEqual(len(result), 3)
+        self.assertIn(('genome', 'short-read'), result)
+        self.assertIn(('exome', 'short-read'), result)
+        self.assertIn(('genome', 'long-read'), result)
+
+    def test_returns_cohort_ids(self):
+        sgs = [
+            {'id': 'SG1', 'type': 'genome', 'technology': 'short-read'},
+        ]
+        mock_cohort_api = self._make_mock_cohort_api('COH999')
+
+        result = asyncio.run(generate_cohorts('proj', sgs, mock_cohort_api))
+
+        self.assertEqual(result[('genome', 'short-read')], 'COH999')
+
+    def test_create_cohort_called_per_pair(self):
+        sgs = [
+            {'id': 'SG1', 'type': 'genome', 'technology': 'short-read'},
+            {'id': 'SG2', 'type': 'exome', 'technology': 'short-read'},
+        ]
+        mock_cohort_api = self._make_mock_cohort_api()
+
+        asyncio.run(generate_cohorts('proj', sgs, mock_cohort_api))
+
+        self.assertEqual(mock_cohort_api.create_cohort_from_criteria.call_count, 2)
+
+
+class TestMain(unittest.TestCase):
+    """Phase 4d: Tests for the main function."""
+
+    @patch('test.data.generate_seqr_project_data.CohortApi')
+    @patch('test.data.generate_seqr_project_data.EnumsApi')
+    @patch('test.data.generate_seqr_project_data.SampleApi')
+    @patch('test.data.generate_seqr_project_data.ProjectApi')
+    @patch('test.data.generate_seqr_project_data.AnalysisApi')
+    @patch('test.data.generate_seqr_project_data.query_async', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_project_pedigree', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_sample_entries', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_cram_analyses', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_cohorts', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_web_report_analyses', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_seqr_loader_analyses', new_callable=AsyncMock)
+    def test_exit_when_no_default_user(
+        self,
+        _mock_seqr_loader,
+        _mock_web_report,
+        _mock_cohorts,
+        _mock_cram,
+        _mock_samples,
+        _mock_pedigree,
+        mock_query,
+        _mock_analysis_cls,
+        mock_project_cls,
+        _mock_sample_cls,
+        mock_enums_cls,
+        _mock_cohort_cls,
+    ):
+        """When SM_LOCALONLY_DEFAULTUSER is not set, main should call sys.exit(1)."""
+        mock_papi = mock_project_cls.return_value
+        mock_papi.get_my_projects_async = AsyncMock(return_value=[])
+        mock_papi.create_project_async = AsyncMock()
+
+        mock_enums_instance = mock_enums_cls.return_value
+        mock_enums_instance.post_analysis_types_async = AsyncMock()
+
+        mock_query.return_value = {'enum': {'sampleType': ['blood']}}
+
+        with patch.dict('os.environ', {}, clear=True), \
+             self.assertRaises(SystemExit) as cm:
+            asyncio.run(main())
+
+        self.assertEqual(cm.exception.code, 1)
+
+    @patch('test.data.generate_seqr_project_data.CohortApi')
+    @patch('test.data.generate_seqr_project_data.EnumsApi')
+    @patch('test.data.generate_seqr_project_data.SampleApi')
+    @patch('test.data.generate_seqr_project_data.ProjectApi')
+    @patch('test.data.generate_seqr_project_data.AnalysisApi')
+    @patch('test.data.generate_seqr_project_data.query_async', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_project_pedigree', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_sample_entries', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_cram_analyses', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_cohorts', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_web_report_analyses', new_callable=AsyncMock)
+    @patch('test.data.generate_seqr_project_data.generate_seqr_loader_analyses', new_callable=AsyncMock)
+    def test_creates_project_when_not_in_existing(
+        self,
+        _mock_seqr_loader,
+        _mock_web_report,
+        mock_cohorts,
+        mock_cram,
+        _mock_samples,
+        mock_pedigree,
+        mock_query,
+        mock_analysis_cls,
+        mock_project_cls,
+        _mock_sample_cls,
+        mock_enums_cls,
+        _mock_cohort_cls,
+    ):
+        """When project not in existing_projects, create_project_async is called."""
+        mock_papi = mock_project_cls.return_value
+        mock_papi.get_my_projects_async = AsyncMock(return_value=[])
+        mock_papi.create_project_async = AsyncMock()
+        mock_papi.update_project_members_async = AsyncMock()
+        mock_papi.update_project_async = AsyncMock()
+
+        mock_enums_instance = mock_enums_cls.return_value
+        mock_enums_instance.post_analysis_types_async = AsyncMock()
+
+        mock_query.return_value = {'enum': {'sampleType': ['blood']}, 'project': {'id': 1}}
+        mock_pedigree.return_value = {}
+        mock_cram.return_value = []
+        mock_cohorts.return_value = {}
+
+        mock_aapi = mock_analysis_cls.return_value
+        mock_aapi.create_analysis_async = AsyncMock()
+
+        with patch.dict('os.environ', {'SM_LOCALONLY_DEFAULTUSER': 'testuser@example.com'}):
+            asyncio.run(main())
+
+        # create_project_async should have been called for each project in PROJECTS
+        self.assertEqual(
+            mock_papi.create_project_async.call_count, len(PROJECTS)
+        )
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Phase 5: Edge case tests."""
+
+    def test_large_num_families_exercises_all_branches(self):
+        """generate_pedigree_rows with large num_families exercises all family-size branches."""
+        random.seed(42)
+        result = generate_pedigree_rows(num_families=20)
+        # Should produce many rows across multiple families
+        self.assertGreater(len(result), 20)
+        # All individual IDs should still be unique
+        individual_ids = [row.individual_id for row in result]
+        self.assertEqual(len(individual_ids), len(set(individual_ids)))
+
+        # Check that we see different family sizes (singleton, duo, trio+)
+        family_ids = {}
+        for row in result:
+            family_ids.setdefault(row.family_id, []).append(row)
+        family_sizes = {len(members) for members in family_ids.values()}
+        # With 20 families and seed 42, we should see at least 2 different sizes
+        self.assertGreaterEqual(len(family_sizes), 2)
+
+    def test_generate_seq_technology_fallback_for_unknown_type(self):
+        """When type doesn't match genome/exome/transcriptome, falls back to rna tech."""
+        random.seed(42)
+        result = generate_seq_technology(
+            ['rna-seq', 'short-read'], 'something_else'
+        )
+        self.assertIn('rna', result)
+
+    def test_generate_web_report_analyses_empty_sgs(self):
+        """
+        generate_web_report_analyses with empty SG list still appends a STRipy index.
+
+        This documents the current behavior: the per-SG loop body is
+        skipped, but the STRipy index analysis (line 668-683) is always
+        appended with an empty sequencing_group_ids list.
+        """
+        random.seed(42)
+        analyses: list[Analysis] = []
+        asyncio.run(
+            generate_web_report_analyses('PROJ', 1, [], analyses)
+        )
+        # Only the STRipy index entry is created
+        self.assertEqual(len(analyses), 1)
+        self.assertEqual(analyses[0].meta.get('stage'), 'MakeIndexPage')
+        self.assertEqual(analyses[0].sequencing_group_ids, [])

--- a/test/test_generate_seqr_project_data.py
+++ b/test/test_generate_seqr_project_data.py
@@ -17,6 +17,7 @@ from test.data.generate_seqr_project_data import (
     SEQ_PLATFORMS,
     SEQ_TECHS,
     SEQ_TYPES,
+    PedigreeRow,
     generate_cohorts,
     generate_cram_analyses,
     generate_pedigree_rows,
@@ -31,7 +32,6 @@ from test.data.generate_seqr_project_data import (
     generate_sequencing_type,
     generate_web_report_analyses,
     main,
-    ped_row,
 )
 
 
@@ -46,11 +46,11 @@ class ValidateSeqrGenerateDataQueries(unittest.TestCase):
 
 
 class TestPedRow(unittest.TestCase):
-    """Phase 1a: Tests for the ped_row class."""
+    """Phase 1a: Tests for the PedigreeRow class."""
 
     def test_construction_from_list(self):
         values = ['FAM1', 'IND1', 'PAT1', 'MAT1', 1, 2]
-        row = ped_row(values)
+        row = PedigreeRow(values)
         self.assertEqual(row.family_id, 'FAM1')
         self.assertEqual(row.individual_id, 'IND1')
         self.assertEqual(row.paternal_id, 'PAT1')
@@ -60,12 +60,12 @@ class TestPedRow(unittest.TestCase):
 
     def test_iter_yields_correct_order(self):
         values = ['FAM1', 'IND1', 'PAT1', 'MAT1', 1, 2]
-        row = ped_row(values)
+        row = PedigreeRow(values)
         self.assertEqual(list(row), values)
 
     def test_field_access(self):
         values = ['FAM_X', 'IND_Y', '', '', 0, 1]
-        row = ped_row(values)
+        row = PedigreeRow(values)
         self.assertEqual(row.family_id, 'FAM_X')
         self.assertEqual(row.individual_id, 'IND_Y')
         self.assertEqual(row.paternal_id, '')
@@ -112,11 +112,11 @@ class TestGeneratePedigreeRows(unittest.TestCase):
         result = generate_pedigree_rows(num_families=1)
         self.assertGreaterEqual(len(result), 1)
 
-    def test_all_rows_are_ped_row_instances(self):
+    def test_all_rows_are_pedigree_row_instances(self):
         random.seed(42)
         result = generate_pedigree_rows(num_families=5)
         for row in result:
-            self.assertIsInstance(row, ped_row)
+            self.assertIsInstance(row, PedigreeRow)
 
     def test_all_individual_ids_unique(self):
         random.seed(42)
@@ -128,7 +128,9 @@ class TestGeneratePedigreeRows(unittest.TestCase):
         """Force a singleton family (1 individual) and check properties."""
         with patch(
             'test.data.generate_seqr_project_data.random.randint',
-            side_effect=lambda a, b: 1 if (a, b) == (1, 5) else random.Random(42).randint(a, b),
+            side_effect=lambda a, b: (
+                1 if (a, b) == (1, 5) else random.Random(42).randint(a, b)
+            ),
         ):
             result = generate_pedigree_rows(num_families=1)
             self.assertEqual(len(result), 1)
@@ -140,15 +142,21 @@ class TestGeneratePedigreeRows(unittest.TestCase):
     def test_duo_family(self):
         """Force a duo family (2 individuals) and check parent-child relationship."""
         rng = random.Random(42)
-        with patch(
-            'test.data.generate_seqr_project_data.random.randint',
-            side_effect=lambda a, b: 2 if (a, b) == (1, 5) else rng.randint(a, b),
-        ), patch(
-            'test.data.generate_seqr_project_data.random.choice',
-            side_effect=rng.choice,
-        ), patch(
-            'test.data.generate_seqr_project_data.random.choices',
-            side_effect=lambda pop, weights=None, k=1: rng.choices(pop, weights=weights, k=k),
+        with (
+            patch(
+                'test.data.generate_seqr_project_data.random.randint',
+                side_effect=lambda a, b: 2 if (a, b) == (1, 5) else rng.randint(a, b),
+            ),
+            patch(
+                'test.data.generate_seqr_project_data.random.choice',
+                side_effect=rng.choice,
+            ),
+            patch(
+                'test.data.generate_seqr_project_data.random.choices',
+                side_effect=lambda pop, weights=None, k=1: rng.choices(
+                    pop, weights=weights, k=k
+                ),
+            ),
         ):
             result = generate_pedigree_rows(num_families=1)
             self.assertEqual(len(result), 2)
@@ -169,15 +177,21 @@ class TestGeneratePedigreeRows(unittest.TestCase):
     def test_trio_plus_family(self):
         """Force a trio+ family (3-5 individuals) and check founders."""
         rng = random.Random(42)
-        with patch(
-            'test.data.generate_seqr_project_data.random.randint',
-            side_effect=lambda a, b: 4 if (a, b) == (1, 5) else rng.randint(a, b),
-        ), patch(
-            'test.data.generate_seqr_project_data.random.choice',
-            side_effect=rng.choice,
-        ), patch(
-            'test.data.generate_seqr_project_data.random.choices',
-            side_effect=lambda pop, weights=None, k=1: rng.choices(pop, weights=weights, k=k),
+        with (
+            patch(
+                'test.data.generate_seqr_project_data.random.randint',
+                side_effect=lambda a, b: 4 if (a, b) == (1, 5) else rng.randint(a, b),
+            ),
+            patch(
+                'test.data.generate_seqr_project_data.random.choice',
+                side_effect=rng.choice,
+            ),
+            patch(
+                'test.data.generate_seqr_project_data.random.choices',
+                side_effect=lambda pop, weights=None, k=1: rng.choices(
+                    pop, weights=weights, k=k
+                ),
+            ),
         ):
             result = generate_pedigree_rows(num_families=1)
             self.assertEqual(len(result), 4)
@@ -193,13 +207,9 @@ class TestGeneratePedigreeRows(unittest.TestCase):
             # Children reference founders
             for child in result[2:]:
                 if child.paternal_id:
-                    self.assertEqual(
-                        child.paternal_id, founder1.individual_id
-                    )
+                    self.assertEqual(child.paternal_id, founder1.individual_id)
                 if child.maternal_id:
-                    self.assertEqual(
-                        child.maternal_id, founder2.individual_id
-                    )
+                    self.assertEqual(child.maternal_id, founder2.individual_id)
 
 
 class TestSequencingGenerators(unittest.TestCase):
@@ -267,9 +277,7 @@ class TestSequencingGenerators(unittest.TestCase):
     def test_respects_weighting(self):
         random.seed(42)
         dist = {10: 0.99, 20: 0.01}
-        results = [
-            generate_random_number_within_distribution(dist) for _ in range(100)
-        ]
+        results = [generate_random_number_within_distribution(dist) for _ in range(100)]
         # With 99% weight, 10 should appear far more often
         self.assertGreater(results.count(10), results.count(20))
 
@@ -303,9 +311,7 @@ class TestGenerateCramAnalyses(unittest.TestCase):
         ):
             # Force all SGs to be selected as aligned
             random.seed(42)
-            result = asyncio.run(
-                generate_cram_analyses('TESTPROJ', 1, analyses)
-            )
+            result = asyncio.run(generate_cram_analyses('TESTPROJ', 1, analyses))
 
         # All SGs returned as aligned (random.sample with k >= len/2)
         self.assertGreater(len(result), 0)
@@ -326,18 +332,19 @@ class TestGenerateCramAnalyses(unittest.TestCase):
         mock_response = {'project': {'sequencingGroups': sgs}}
         analyses: list[Analysis] = []
 
-        with patch(
-            'test.data.generate_seqr_project_data.query_async',
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ), patch(
-            'test.data.generate_seqr_project_data.random.sample',
-            side_effect=lambda population, k: population,  # noqa: ARG005
+        with (
+            patch(
+                'test.data.generate_seqr_project_data.query_async',
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch(
+                'test.data.generate_seqr_project_data.random.sample',
+                side_effect=lambda population, k: population,  # noqa: ARG005
+            ),
         ):
             random.seed(42)
-            result = asyncio.run(
-                generate_cram_analyses('PROJ', 1, analyses)
-            )
+            result = asyncio.run(generate_cram_analyses('PROJ', 1, analyses))
         return analyses, result
 
     def test_cram_path_short_read_genome(self):
@@ -350,9 +357,7 @@ class TestGenerateCramAnalyses(unittest.TestCase):
         sgs = [self._make_sg('SG001', 'exome', 'short-read')]
         analyses, _ = self._run_cram_with_all_aligned(sgs)
         self.assertEqual(len(analyses), 1)
-        self.assertEqual(
-            analyses[0].output, 'FAKE://PROJ/exome/cram/SG001.cram'
-        )
+        self.assertEqual(analyses[0].output, 'FAKE://PROJ/exome/cram/SG001.cram')
 
     def test_cram_path_short_read_transcriptome(self):
         sgs = [self._make_sg('SG001', 'transcriptome', 'short-read')]
@@ -366,17 +371,13 @@ class TestGenerateCramAnalyses(unittest.TestCase):
         sgs = [self._make_sg('SG001', 'genome', 'long-read', 'pacbio')]
         analyses, _ = self._run_cram_with_all_aligned(sgs)
         self.assertEqual(len(analyses), 1)
-        self.assertEqual(
-            analyses[0].output, 'FAKE://PROJ/long_read/SG001.cram'
-        )
+        self.assertEqual(analyses[0].output, 'FAKE://PROJ/long_read/SG001.cram')
 
     def test_cram_path_unknown_technology_fallback(self):
         sgs = [self._make_sg('SG001', 'genome', 'unknown-tech')]
         analyses, _ = self._run_cram_with_all_aligned(sgs)
         self.assertEqual(len(analyses), 1)
-        self.assertEqual(
-            analyses[0].output, 'FAKE://PROJ/crams/SG001.cram'
-        )
+        self.assertEqual(analyses[0].output, 'FAKE://PROJ/crams/SG001.cram')
 
     def test_cram_meta_fields(self):
         sgs = [self._make_sg('SG001', 'genome', 'short-read', 'illumina')]
@@ -388,10 +389,7 @@ class TestGenerateCramAnalyses(unittest.TestCase):
         self.assertIn('size', meta)
 
     def test_returns_subset_of_sgs(self):
-        sgs = [
-            self._make_sg(f'SG{i:03}', 'genome', 'short-read')
-            for i in range(10)
-        ]
+        sgs = [self._make_sg(f'SG{i:03}', 'genome', 'short-read') for i in range(10)]
         mock_response = {'project': {'sequencingGroups': sgs}}
         analyses: list[Analysis] = []
 
@@ -401,9 +399,7 @@ class TestGenerateCramAnalyses(unittest.TestCase):
             return_value=mock_response,
         ):
             random.seed(42)
-            result = asyncio.run(
-                generate_cram_analyses('PROJ', 1, analyses)
-            )
+            result = asyncio.run(generate_cram_analyses('PROJ', 1, analyses))
 
         # Returns between len/2 and len SGs
         self.assertGreaterEqual(len(result), len(sgs) // 2)
@@ -422,9 +418,7 @@ class TestGenerateQcAnalyses(unittest.TestCase):
             ('genome', 'long-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_qc_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_qc_analyses('PROJ', cohort_ids, analyses))
         self.assertEqual(len(analyses), 0)
 
     def test_exome_produces_qc_and_web(self):
@@ -432,9 +426,7 @@ class TestGenerateQcAnalyses(unittest.TestCase):
             ('exome', 'short-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_qc_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_qc_analyses('PROJ', cohort_ids, analyses))
         self.assertEqual(len(analyses), 2)
         types = [(a.type, a.meta.get('stage')) for a in analyses]
         self.assertIn(('qc', 'CramMultiQC'), types)
@@ -445,9 +437,7 @@ class TestGenerateQcAnalyses(unittest.TestCase):
             ('genome', 'short-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_qc_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_qc_analyses('PROJ', cohort_ids, analyses))
         self.assertEqual(len(analyses), 2)
         types = [(a.type, a.meta.get('stage')) for a in analyses]
         self.assertIn(('qc', 'CramMultiQC'), types)
@@ -458,9 +448,7 @@ class TestGenerateQcAnalyses(unittest.TestCase):
             ('transcriptome', 'short-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_qc_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_qc_analyses('PROJ', cohort_ids, analyses))
         self.assertEqual(len(analyses), 0)
 
     def test_mixed_cohorts(self):
@@ -471,9 +459,7 @@ class TestGenerateQcAnalyses(unittest.TestCase):
             ('transcriptome', 'short-read'): 'COH004',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_qc_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_qc_analyses('PROJ', cohort_ids, analyses))
         # genome short-read: 2, exome short-read: 2, long-read: 0, transcriptome: 0
         self.assertEqual(len(analyses), 4)
 
@@ -486,9 +472,7 @@ class TestGenerateSeqrLoaderAnalyses(unittest.TestCase):
             ('genome', 'long-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_seqr_loader_analyses('PROJ', cohort_ids, analyses))
         self.assertEqual(len(analyses), 0)
 
     def test_genome_produces_matrixtable_and_es_index_and_sv(self):
@@ -496,9 +480,7 @@ class TestGenerateSeqrLoaderAnalyses(unittest.TestCase):
             ('genome', 'short-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_seqr_loader_analyses('PROJ', cohort_ids, analyses))
         # matrixtable (AnnotateDataset) + es-index (MtToEs) + es-index (MtToEsSv)
         self.assertEqual(len(analyses), 3)
         types_stages = [(a.type, a.meta.get('stage')) for a in analyses]
@@ -511,9 +493,7 @@ class TestGenerateSeqrLoaderAnalyses(unittest.TestCase):
             ('exome', 'short-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_seqr_loader_analyses('PROJ', cohort_ids, analyses))
         # matrixtable (AnnotateDataset) + es-index (MtToEs) + es-index (MtToEsCNV)
         self.assertEqual(len(analyses), 3)
         types_stages = [(a.type, a.meta.get('stage')) for a in analyses]
@@ -526,16 +506,16 @@ class TestGenerateSeqrLoaderAnalyses(unittest.TestCase):
             ('transcriptome', 'short-read'): 'COH001',
         }
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_seqr_loader_analyses('PROJ', cohort_ids, analyses)
-        )
+        asyncio.run(generate_seqr_loader_analyses('PROJ', cohort_ids, analyses))
         self.assertEqual(len(analyses), 0)
 
 
 class TestGenerateWebReportAnalyses(unittest.TestCase):
     """Phase 3d: Tests for generate_web_report_analyses."""
 
-    def _make_sg(self, sg_id, sg_type='genome', technology='short-read', platform='illumina'):
+    def _make_sg(
+        self, sg_id, sg_type='genome', technology='short-read', platform='illumina'
+    ):
         return {
             'id': sg_id,
             'type': sg_type,
@@ -547,19 +527,13 @@ class TestGenerateWebReportAnalyses(unittest.TestCase):
         random.seed(42)
         sgs = [self._make_sg('SG001'), self._make_sg('SG002')]
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_web_report_analyses('PROJ', 1, sgs, analyses)
-        )
+        asyncio.run(generate_web_report_analyses('PROJ', 1, sgs, analyses))
         # 2 SGs * 2 analyses each + 1 STRipy index = 5
         self.assertEqual(len(analyses), 5)
 
         # Check per-SG analyses
         for sg in sgs:
-            sg_analyses = [
-                a
-                for a in analyses
-                if a.sequencing_group_ids == [sg['id']]
-            ]
+            sg_analyses = [a for a in analyses if a.sequencing_group_ids == [sg['id']]]
             stages = [a.meta.get('stage') for a in sg_analyses]
             self.assertIn('Stripy', stages)
             self.assertIn('MitoReport', stages)
@@ -568,9 +542,7 @@ class TestGenerateWebReportAnalyses(unittest.TestCase):
         random.seed(42)
         sgs = [self._make_sg('SG001'), self._make_sg('SG002'), self._make_sg('SG003')]
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_web_report_analyses('PROJ', 1, sgs, analyses)
-        )
+        asyncio.run(generate_web_report_analyses('PROJ', 1, sgs, analyses))
         # Last analysis is the STRipy index
         index_analysis = analyses[-1]
         self.assertEqual(index_analysis.meta.get('stage'), 'MakeIndexPage')
@@ -581,12 +553,8 @@ class TestGenerateWebReportAnalyses(unittest.TestCase):
         random.seed(42)
         sgs = [self._make_sg('SG001')]
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_web_report_analyses('PROJ', 1, sgs, analyses)
-        )
-        stripy_analyses = [
-            a for a in analyses if a.meta.get('stage') == 'Stripy'
-        ]
+        asyncio.run(generate_web_report_analyses('PROJ', 1, sgs, analyses))
+        stripy_analyses = [a for a in analyses if a.meta.get('stage') == 'Stripy']
         self.assertGreater(len(stripy_analyses), 0)
         for a in stripy_analyses:
             self.assertIn('outliers_detected', a.meta)
@@ -596,9 +564,7 @@ class TestGenerateWebReportAnalyses(unittest.TestCase):
         random.seed(42)
         sgs = [self._make_sg('SG001')]
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_web_report_analyses('PROJ', 1, sgs, analyses)
-        )
+        asyncio.run(generate_web_report_analyses('PROJ', 1, sgs, analyses))
         for a in analyses:
             self.assertEqual(a.type, 'web')
             self.assertEqual(str(a.status), 'completed')
@@ -609,7 +575,9 @@ class TestGenerateProjectPedigree(unittest.TestCase):
 
     @patch('test.data.generate_seqr_project_data.ParticipantApi')
     @patch('test.data.generate_seqr_project_data.FamilyApi')
-    def test_returns_id_map_from_participant_api(self, mock_family_cls, mock_participant_cls):
+    def test_returns_id_map_from_participant_api(
+        self, mock_family_cls, mock_participant_cls
+    ):
         random.seed(42)
         expected_map = {'SOLAR_0042': 1, 'LUNAR_0099': 2}
 
@@ -617,8 +585,8 @@ class TestGenerateProjectPedigree(unittest.TestCase):
         mock_family_instance.import_pedigree_async = AsyncMock()
 
         mock_participant_instance = mock_participant_cls.return_value
-        mock_participant_instance.get_participant_id_map_by_external_ids_async = AsyncMock(
-            return_value=expected_map
+        mock_participant_instance.get_participant_id_map_by_external_ids_async = (
+            AsyncMock(return_value=expected_map)
         )
 
         result = asyncio.run(generate_project_pedigree('test-project'))
@@ -626,15 +594,17 @@ class TestGenerateProjectPedigree(unittest.TestCase):
 
     @patch('test.data.generate_seqr_project_data.ParticipantApi')
     @patch('test.data.generate_seqr_project_data.FamilyApi')
-    def test_import_pedigree_called_with_correct_args(self, mock_family_cls, mock_participant_cls):
+    def test_import_pedigree_called_with_correct_args(
+        self, mock_family_cls, mock_participant_cls
+    ):
         random.seed(42)
 
         mock_family_instance = mock_family_cls.return_value
         mock_family_instance.import_pedigree_async = AsyncMock()
 
         mock_participant_instance = mock_participant_cls.return_value
-        mock_participant_instance.get_participant_id_map_by_external_ids_async = AsyncMock(
-            return_value={}
+        mock_participant_instance.get_participant_id_map_by_external_ids_async = (
+            AsyncMock(return_value={})
         )
 
         asyncio.run(generate_project_pedigree('test-project'))
@@ -647,15 +617,17 @@ class TestGenerateProjectPedigree(unittest.TestCase):
 
     @patch('test.data.generate_seqr_project_data.ParticipantApi')
     @patch('test.data.generate_seqr_project_data.FamilyApi')
-    def test_participant_eids_passed_to_get_id_map(self, mock_family_cls, mock_participant_cls):
+    def test_participant_eids_passed_to_get_id_map(
+        self, mock_family_cls, mock_participant_cls
+    ):
         random.seed(42)
 
         mock_family_instance = mock_family_cls.return_value
         mock_family_instance.import_pedigree_async = AsyncMock()
 
         mock_participant_instance = mock_participant_cls.return_value
-        mock_participant_instance.get_participant_id_map_by_external_ids_async = AsyncMock(
-            return_value={}
+        mock_participant_instance.get_participant_id_map_by_external_ids_async = (
+            AsyncMock(return_value={})
         )
 
         asyncio.run(generate_project_pedigree('test-project'))
@@ -680,7 +652,9 @@ class TestGenerateSampleEntries(unittest.TestCase):
         mock_sapi = AsyncMock()
 
         asyncio.run(
-            generate_sample_entries('test-proj', participant_id_map, fake_enums, mock_sapi)
+            generate_sample_entries(
+                'test-proj', participant_id_map, fake_enums, mock_sapi
+            )
         )
 
         mock_sapi.upsert_samples_async.assert_called_once()
@@ -697,7 +671,9 @@ class TestGenerateSampleEntries(unittest.TestCase):
         mock_sapi = AsyncMock()
 
         asyncio.run(
-            generate_sample_entries('test-proj', participant_id_map, fake_enums, mock_sapi)
+            generate_sample_entries(
+                'test-proj', participant_id_map, fake_enums, mock_sapi
+            )
         )
 
         samples = mock_sapi.upsert_samples_async.call_args[0][1]
@@ -795,12 +771,29 @@ class TestMain(unittest.TestCase):
     @patch('test.data.generate_seqr_project_data.ProjectApi')
     @patch('test.data.generate_seqr_project_data.AnalysisApi')
     @patch('test.data.generate_seqr_project_data.query_async', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_project_pedigree', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_sample_entries', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_cram_analyses', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_cohorts', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_web_report_analyses', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_seqr_loader_analyses', new_callable=AsyncMock)
+    @patch(
+        'test.data.generate_seqr_project_data.generate_project_pedigree',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_sample_entries',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_cram_analyses',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_cohorts', new_callable=AsyncMock
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_web_report_analyses',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_seqr_loader_analyses',
+        new_callable=AsyncMock,
+    )
     def test_exit_when_no_default_user(
         self,
         _mock_seqr_loader,
@@ -826,8 +819,10 @@ class TestMain(unittest.TestCase):
 
         mock_query.return_value = {'enum': {'sampleType': ['blood']}}
 
-        with patch.dict('os.environ', {}, clear=True), \
-             self.assertRaises(SystemExit) as cm:
+        with (
+            patch.dict('os.environ', {}, clear=True),
+            self.assertRaises(SystemExit) as cm,
+        ):
             asyncio.run(main())
 
         self.assertEqual(cm.exception.code, 1)
@@ -838,12 +833,29 @@ class TestMain(unittest.TestCase):
     @patch('test.data.generate_seqr_project_data.ProjectApi')
     @patch('test.data.generate_seqr_project_data.AnalysisApi')
     @patch('test.data.generate_seqr_project_data.query_async', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_project_pedigree', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_sample_entries', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_cram_analyses', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_cohorts', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_web_report_analyses', new_callable=AsyncMock)
-    @patch('test.data.generate_seqr_project_data.generate_seqr_loader_analyses', new_callable=AsyncMock)
+    @patch(
+        'test.data.generate_seqr_project_data.generate_project_pedigree',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_sample_entries',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_cram_analyses',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_cohorts', new_callable=AsyncMock
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_web_report_analyses',
+        new_callable=AsyncMock,
+    )
+    @patch(
+        'test.data.generate_seqr_project_data.generate_seqr_loader_analyses',
+        new_callable=AsyncMock,
+    )
     def test_creates_project_when_not_in_existing(
         self,
         _mock_seqr_loader,
@@ -869,7 +881,10 @@ class TestMain(unittest.TestCase):
         mock_enums_instance = mock_enums_cls.return_value
         mock_enums_instance.post_analysis_types_async = AsyncMock()
 
-        mock_query.return_value = {'enum': {'sampleType': ['blood']}, 'project': {'id': 1}}
+        mock_query.return_value = {
+            'enum': {'sampleType': ['blood']},
+            'project': {'id': 1},
+        }
         mock_pedigree.return_value = {}
         mock_cram.return_value = []
         mock_cohorts.return_value = {}
@@ -877,13 +892,13 @@ class TestMain(unittest.TestCase):
         mock_aapi = mock_analysis_cls.return_value
         mock_aapi.create_analysis_async = AsyncMock()
 
-        with patch.dict('os.environ', {'SM_LOCALONLY_DEFAULTUSER': 'testuser@example.com'}):
+        with patch.dict(
+            'os.environ', {'SM_LOCALONLY_DEFAULTUSER': 'testuser@example.com'}
+        ):
             asyncio.run(main())
 
         # create_project_async should have been called for each project in PROJECTS
-        self.assertEqual(
-            mock_papi.create_project_async.call_count, len(PROJECTS)
-        )
+        self.assertEqual(mock_papi.create_project_async.call_count, len(PROJECTS))
 
 
 class TestEdgeCases(unittest.TestCase):
@@ -900,7 +915,7 @@ class TestEdgeCases(unittest.TestCase):
         self.assertEqual(len(individual_ids), len(set(individual_ids)))
 
         # Check that we see different family sizes (singleton, duo, trio+)
-        family_ids = {}
+        family_ids: dict[str, list[PedigreeRow]] = {}
         for row in result:
             family_ids.setdefault(row.family_id, []).append(row)
         family_sizes = {len(members) for members in family_ids.values()}
@@ -910,9 +925,7 @@ class TestEdgeCases(unittest.TestCase):
     def test_generate_seq_technology_fallback_for_unknown_type(self):
         """When type doesn't match genome/exome/transcriptome, falls back to rna tech."""
         random.seed(42)
-        result = generate_seq_technology(
-            ['rna-seq', 'short-read'], 'something_else'
-        )
+        result = generate_seq_technology(['rna-seq', 'short-read'], 'something_else')
         self.assertIn('rna', result)
 
     def test_generate_web_report_analyses_empty_sgs(self):
@@ -925,9 +938,7 @@ class TestEdgeCases(unittest.TestCase):
         """
         random.seed(42)
         analyses: list[Analysis] = []
-        asyncio.run(
-            generate_web_report_analyses('PROJ', 1, [], analyses)
-        )
+        asyncio.run(generate_web_report_analyses('PROJ', 1, [], analyses))
         # Only the STRipy index entry is created
         self.assertEqual(len(analyses), 1)
         self.assertEqual(analyses[0].meta.get('stage'), 'MakeIndexPage')

--- a/test/test_project_insights.py
+++ b/test/test_project_insights.py
@@ -8,7 +8,6 @@ from models.models import (
     PRIMARY_EXTERNAL_ORG,
     AssayUpsertInternal,
     ParticipantUpsertInternal,
-    ProjectInsightsSummaryInternal,
     SampleUpsertInternal,
     SequencingGroupUpsertInternal,
 )
@@ -93,24 +92,23 @@ class TestProjectInsights(DbIsolatedTest):
             project_names=[self.project_name], sequencing_types=['genome', 'exome']
         )
 
-        expected = [
-            ProjectInsightsSummaryInternal(
-                project=self.project_id,
-                dataset=self.project_name,  # for ProjectInsights, dataset is project.name
-                sequencing_type='genome',
-                sequencing_technology='short-read',
-                total_families=0,
-                total_participants=1,
-                total_samples=1,
-                total_sequencing_groups=1,
-                total_crams=0,
-                latest_annotate_dataset=None,
-                latest_snv_es_index=None,
-                latest_sv_es_index=None,
-            ),
-        ]
-
-        self.assertEqual(result, expected)
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertEqual(row.project, self.project_id)
+        self.assertEqual(row.dataset, self.project_name)
+        self.assertEqual(row.sequencing_type, 'genome')
+        self.assertEqual(row.sequencing_technology, 'short-read')
+        self.assertEqual(row.total_families, 0)
+        self.assertEqual(row.total_participants, 1)
+        self.assertEqual(row.total_samples, 1)
+        self.assertEqual(row.total_sequencing_groups, 1)
+        self.assertEqual(row.total_crams, 0)
+        self.assertIsNone(row.latest_annotate_dataset)
+        self.assertIsNone(row.latest_snv_es_index)
+        self.assertIsNone(row.latest_sv_es_index)
+        self.assertEqual(row.family_ids, [])
+        self.assertEqual(len(row.participant_ids), 1)
+        self.assertEqual(len(row.sample_ids), 1)
 
     @run_as_sync
     async def test_project_insights_details(self):

--- a/test/test_project_insights.py
+++ b/test/test_project_insights.py
@@ -1,11 +1,17 @@
+from datetime import datetime, timezone
+
 from db.python.layers import (
+    AnalysisLayer,
     AssayLayer,
+    FamilyLayer,
     ParticipantLayer,
     ProjectInsightsLayer,
     SampleLayer,
 )
+from models.enums import AnalysisStatus
 from models.models import (
     PRIMARY_EXTERNAL_ORG,
+    AnalysisInternal,
     AssayUpsertInternal,
     ParticipantUpsertInternal,
     SampleUpsertInternal,
@@ -19,6 +25,50 @@ default_assay_meta = {
     'sequencing_technology': 'short-read',
     'sequencing_platform': 'illumina',
 }
+
+
+def make_sample(
+    ext_id: str,
+    sg_type: str = 'genome',
+    sg_technology: str = 'short-read',
+    sg_platform: str = 'illumina',
+    sample_type: str = 'blood',
+) -> SampleUpsertInternal:
+    """Build a sample with one sequencing group and one assay."""
+    return SampleUpsertInternal(
+        external_ids={PRIMARY_EXTERNAL_ORG: ext_id},
+        meta={},
+        type=sample_type,
+        sequencing_groups=[
+            SequencingGroupUpsertInternal(
+                type=sg_type,
+                technology=sg_technology,
+                platform=sg_platform,
+                assays=[
+                    AssayUpsertInternal(
+                        type='sequencing',
+                        meta={
+                            'sequencing_type': sg_type,
+                            'sequencing_technology': sg_technology,
+                            'sequencing_platform': sg_platform,
+                        },
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def make_participant(
+    ext_id: str,
+    samples: list[SampleUpsertInternal],
+) -> ParticipantUpsertInternal:
+    """Build a participant upsert with the given samples."""
+    return ParticipantUpsertInternal(
+        external_ids={PRIMARY_EXTERNAL_ORG: ext_id},
+        meta={},
+        samples=samples,
+    )
 
 
 def get_test_participant():
@@ -81,6 +131,80 @@ class TestProjectInsights(DbIsolatedTest):
         self.pil = ProjectInsightsLayer(self.connection)
         self.sampl = SampleLayer(self.connection)
         self.seql = AssayLayer(self.connection)
+        self.al = AnalysisLayer(self.connection)
+        self.fl = FamilyLayer(self.connection)
+
+    # --- Helper to create a family with participants and SGs ---
+
+    async def create_family_with_participants(
+        self,
+        family_ext_id: str,
+        members: list[dict],
+    ) -> dict[str, int]:
+        """
+        Create participants with samples first, then import pedigree to link them.
+        members: list of dicts with keys: ext_id, paternal_id, maternal_id, sex, affected
+        Returns dict mapping participant ext_id -> sequencing_group internal ID.
+        """
+        # 1. Create participants with samples/SGs first
+        sg_ids = {}
+        for m in members:
+            sample_ext = f'sample_{m["ext_id"]}'
+            sg_type = m.get('sg_type', 'genome')
+            sg_tech = m.get('sg_technology', 'short-read')
+            sg_platform = m.get('sg_platform', 'illumina')
+            p = await self.partl.upsert_participant(
+                make_participant(
+                    m['ext_id'],
+                    [
+                        make_sample(
+                            sample_ext,
+                            sg_type=sg_type,
+                            sg_technology=sg_tech,
+                            sg_platform=sg_platform,
+                        )
+                    ],
+                )
+            )
+            sg_ids[m['ext_id']] = p.samples[0].sequencing_groups[0].id
+
+        # 2. Import pedigree to create family and link participants
+        rows = []
+        for m in members:
+            rows.append(
+                [
+                    family_ext_id,
+                    m['ext_id'],
+                    m.get('paternal_id', ''),
+                    m.get('maternal_id', ''),
+                    str(m.get('sex', '0')),
+                    str(m.get('affected', '0')),
+                ]
+            )
+        await self.fl.import_pedigree(
+            header=None, rows=rows, create_missing_participants=False
+        )
+
+        return sg_ids
+
+    async def create_analysis_with_output(
+        self,
+        analysis: AnalysisInternal,
+        output: str,
+    ) -> int:
+        """
+        Create an analysis and set the output column directly via SQL.
+        This avoids the GCS client interaction that happens when passing
+        output through the normal AnalysisInternal path.
+        """
+        analysis_id = await self.al.create_analysis(analysis)
+        await self.connection.connection.execute(
+            'UPDATE analysis SET output = :output WHERE id = :id',
+            {'output': output, 'id': analysis_id},
+        )
+        return analysis_id
+
+    # --- Existing tests (kept as-is) ---
 
     @run_as_sync
     async def test_project_insights_summary(self):
@@ -120,3 +244,479 @@ class TestProjectInsights(DbIsolatedTest):
         _ = await self.pil.get_project_insights_details(
             project_names=[self.project_name], sequencing_types=['genome', 'exome']
         )
+
+    # --- Phase 2: Summary with rich data ---
+
+    @run_as_sync
+    async def test_summary_with_families_and_crams(self):
+        """Summary with a family of 3, CRAMs for 2 of 3 SGs"""
+        sg_ids = await self.create_family_with_participants(
+            'FAM01',
+            [
+                {'ext_id': 'FATHER', 'sex': '1', 'affected': '1'},
+                {'ext_id': 'MOTHER', 'sex': '2', 'affected': '1'},
+                {
+                    'ext_id': 'PROBAND',
+                    'paternal_id': 'FATHER',
+                    'maternal_id': 'MOTHER',
+                    'sex': '1',
+                    'affected': '2',
+                },
+            ],
+        )
+
+        # Create CRAMs for father and proband only
+        for ext_id in ['FATHER', 'PROBAND']:
+            await self.al.create_analysis(
+                AnalysisInternal(
+                    type='cram',
+                    status=AnalysisStatus.COMPLETED,
+                    sequencing_group_ids=[sg_ids[ext_id]],
+                    meta={'sequencing_type': 'genome'},
+                )
+            )
+
+        result = await self.pil.get_project_insights_summary(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertEqual(row.total_families, 1)
+        self.assertEqual(row.total_participants, 3)
+        self.assertEqual(row.total_samples, 3)
+        self.assertEqual(row.total_sequencing_groups, 3)
+        self.assertEqual(row.total_crams, 2)
+        self.assertEqual(len(row.family_ids), 1)
+        self.assertEqual(len(row.participant_ids), 3)
+        self.assertEqual(len(row.sample_ids), 3)
+
+    @run_as_sync
+    async def test_summary_with_annotate_dataset_and_es_indices(self):
+        """Summary correctly picks the latest analyses and counts SGs"""
+        # Create 2 participants with genome/short-read SGs (no family needed for summary)
+        p1 = await self.partl.upsert_participant(
+            make_participant('P1', [make_sample('sample_p1')])
+        )
+        p2 = await self.partl.upsert_participant(
+            make_participant('P2', [make_sample('sample_p2')])
+        )
+        sg1 = p1.samples[0].sequencing_groups[0].id
+        sg2 = p2.samples[0].sequencing_groups[0].id
+
+        # Older AnnotateDataset covering only sg1
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='CUSTOM',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1],
+                meta={'stage': 'AnnotateDataset', 'sequencing_type': 'genome'},
+                timestamp_completed=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        # Newer AnnotateDataset covering sg1 + sg2
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='CUSTOM',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1, sg2],
+                meta={'stage': 'AnnotateDataset', 'sequencing_type': 'genome'},
+                timestamp_completed=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            )
+        )
+
+        # Older SNV ES-index covering only sg1
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1],
+                meta={'stage': 'MtToEs', 'sequencing_type': 'genome'},
+                timestamp_completed=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        # Newer SNV ES-index covering sg1 + sg2
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1, sg2],
+                meta={'stage': 'MtToEs', 'sequencing_type': 'genome'},
+                timestamp_completed=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            )
+        )
+
+        # SV ES-index covering sg1 only
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1],
+                meta={'stage': 'MtToEsSv', 'sequencing_type': 'genome'},
+                timestamp_completed=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            )
+        )
+
+        result = await self.pil.get_project_insights_summary(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+
+        # Latest AnnotateDataset should be the newer one with 2 SGs
+        self.assertIsNotNone(row.latest_annotate_dataset)
+        self.assertEqual(row.latest_annotate_dataset.sg_count, 2)
+
+        # Latest SNV ES-index should be the newer one with 2 SGs
+        self.assertIsNotNone(row.latest_snv_es_index)
+        self.assertEqual(row.latest_snv_es_index.sg_count, 2)
+
+        # SV ES-index has only 1 SG
+        self.assertIsNotNone(row.latest_sv_es_index)
+        self.assertEqual(row.latest_sv_es_index.sg_count, 1)
+
+    @run_as_sync
+    async def test_summary_non_short_read_excludes_analyses(self):
+        """Non-short-read technology should have counts but no analysis stats"""
+        p = await self.partl.upsert_participant(
+            make_participant(
+                'P1', [make_sample('sample_p1', sg_technology='long-read')]
+            )
+        )
+        sg_id = p.samples[0].sequencing_groups[0].id
+
+        # Create analyses that would match for short-read
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='CUSTOM',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_id],
+                meta={'stage': 'AnnotateDataset', 'sequencing_type': 'genome'},
+            )
+        )
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_id],
+                meta={'stage': 'MtToEs', 'sequencing_type': 'genome'},
+            )
+        )
+
+        result = await self.pil.get_project_insights_summary(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertEqual(row.sequencing_technology, 'long-read')
+        self.assertEqual(row.total_participants, 1)
+        self.assertEqual(row.total_sequencing_groups, 1)
+        # All analysis fields should be None for non-short-read
+        self.assertIsNone(row.latest_annotate_dataset)
+        self.assertIsNone(row.latest_snv_es_index)
+        self.assertIsNone(row.latest_sv_es_index)
+
+    @run_as_sync
+    async def test_summary_exome_sv_uses_cnv_stage(self):
+        """Exome SV ES-index should use MtToEsCNV stage from SV_INDEX_SEQ_TYPE_STAGE_MAP"""
+        p = await self.partl.upsert_participant(
+            make_participant('P1', [make_sample('sample_p1', sg_type='exome')])
+        )
+        sg_id = p.samples[0].sequencing_groups[0].id
+
+        # Create exome-specific SV/gCNV ES-index
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_id],
+                meta={'stage': 'MtToEsCNV', 'sequencing_type': 'exome'},
+            )
+        )
+
+        result = await self.pil.get_project_insights_summary(
+            project_names=[self.project_name], sequencing_types=['exome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertEqual(row.sequencing_type, 'exome')
+        self.assertIsNotNone(row.latest_sv_es_index)
+        self.assertEqual(row.latest_sv_es_index.sg_count, 1)
+
+    @run_as_sync
+    async def test_summary_multiple_seq_types_returns_separate_rows(self):
+        """One participant with genome and exome SGs returns 2 summary rows"""
+        await self.partl.upsert_participant(
+            make_participant(
+                'P1',
+                [
+                    make_sample('sample_genome', sg_type='genome'),
+                    make_sample('sample_exome', sg_type='exome'),
+                ],
+            )
+        )
+
+        result = await self.pil.get_project_insights_summary(
+            project_names=[self.project_name], sequencing_types=['genome', 'exome']
+        )
+
+        self.assertEqual(len(result), 2)
+        types = {r.sequencing_type for r in result}
+        self.assertEqual(types, {'genome', 'exome'})
+        for row in result:
+            self.assertEqual(row.total_participants, 1)
+            self.assertEqual(row.total_samples, 1)
+            self.assertEqual(row.total_sequencing_groups, 1)
+
+    @run_as_sync
+    async def test_summary_multiple_families_counted_correctly(self):
+        """Two families with participants should return total_families=2"""
+        await self.create_family_with_participants(
+            'FAM01',
+            [{'ext_id': 'FAM1_P1', 'sex': '1', 'affected': '1'}],
+        )
+        await self.create_family_with_participants(
+            'FAM02',
+            [{'ext_id': 'FAM2_P1', 'sex': '2', 'affected': '1'}],
+        )
+
+        result = await self.pil.get_project_insights_summary(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertEqual(row.total_families, 2)
+        self.assertEqual(row.total_participants, 2)
+
+    # --- Phase 3: Details with assertions ---
+
+    @run_as_sync
+    async def test_details_basic_with_family_and_cram(self):
+        """Details returns per-SG rows with CRAM data for SGs in families"""
+        sg_ids = await self.create_family_with_participants(
+            'FAM01',
+            [
+                {'ext_id': 'FATHER', 'sex': '1', 'affected': '1'},
+                {'ext_id': 'MOTHER', 'sex': '2', 'affected': '1'},
+            ],
+        )
+
+        # Create CRAM for FATHER's SG only
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='cram',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_ids['FATHER']],
+                meta={'sequencing_type': 'genome'},
+            )
+        )
+
+        result = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 2)
+
+        father_row = [r for r in result if r.participant_ext_id == 'FATHER'][0]
+        self.assertEqual(father_row.family_ext_id, 'FAM01')
+        self.assertEqual(father_row.sequencing_type, 'genome')
+        self.assertEqual(father_row.sequencing_technology, 'short-read')
+        self.assertIsNotNone(father_row.cram['id'])
+        self.assertIsNotNone(father_row.cram['timestamp_completed'])
+
+        mother_row = [r for r in result if r.participant_ext_id == 'MOTHER'][0]
+        self.assertIsNone(mother_row.cram['id'])
+
+    @run_as_sync
+    async def test_details_analysis_boolean_flags(self):
+        """Boolean in_latest_* flags correctly reflect per-SG analysis membership"""
+        sg_ids = await self.create_family_with_participants(
+            'FAM01',
+            [
+                {'ext_id': 'P1', 'sex': '1', 'affected': '1'},
+                {'ext_id': 'P2', 'sex': '2', 'affected': '1'},
+            ],
+        )
+        sg1 = sg_ids['P1']
+        sg2 = sg_ids['P2']
+
+        # AnnotateDataset includes only SG1
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='CUSTOM',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1],
+                meta={'stage': 'AnnotateDataset', 'sequencing_type': 'genome'},
+            )
+        )
+        # SNV ES-index includes both
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg1, sg2],
+                meta={'stage': 'MtToEs', 'sequencing_type': 'genome'},
+            )
+        )
+        # SV ES-index includes only SG2
+        await self.al.create_analysis(
+            AnalysisInternal(
+                type='es-index',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg2],
+                meta={'stage': 'MtToEsSv', 'sequencing_type': 'genome'},
+            )
+        )
+
+        result = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 2)
+
+        p1_row = [r for r in result if r.participant_ext_id == 'P1'][0]
+        self.assertTrue(p1_row.in_latest_annotate_dataset)
+        self.assertTrue(p1_row.in_latest_snv_es_index)
+        self.assertFalse(p1_row.in_latest_sv_es_index)
+
+        p2_row = [r for r in result if r.participant_ext_id == 'P2'][0]
+        self.assertFalse(p2_row.in_latest_annotate_dataset)
+        self.assertTrue(p2_row.in_latest_snv_es_index)
+        self.assertTrue(p2_row.in_latest_sv_es_index)
+
+    @run_as_sync
+    async def test_details_excludes_participants_without_families(self):
+        """Details only returns SGs belonging to participants in families"""
+        # Participant in a family
+        await self.create_family_with_participants(
+            'FAM01',
+            [{'ext_id': 'IN_FAMILY', 'sex': '1', 'affected': '1'}],
+        )
+
+        # Participant NOT in a family
+        await self.partl.upsert_participant(
+            make_participant('NO_FAMILY', [make_sample('sample_no_family')])
+        )
+
+        result = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].participant_ext_id, 'IN_FAMILY')
+
+    # --- Phase 4: Web reports ---
+
+    @run_as_sync
+    async def test_details_stripy_report_with_outliers(self):
+        """Stripy web report includes URL, outlier detection, and outlier loci"""
+        sg_ids = await self.create_family_with_participants(
+            'FAM01',
+            [{'ext_id': 'P1', 'sex': '1', 'affected': '2'}],
+        )
+        sg_id = sg_ids['P1']
+
+        await self.create_analysis_with_output(
+            AnalysisInternal(
+                type='web',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_id],
+                meta={
+                    'stage': 'Stripy',
+                    'outliers_detected': True,
+                    'outlier_loci': ['ATXN1', 'HTT'],
+                },
+            ),
+            output='gs://cpg-test-main-web/stripy/report.html',
+        )
+
+        result = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertIn('stripy', row.web_reports)
+        stripy = row.web_reports['stripy']
+        self.assertIn('main-web', stripy['url'])
+        self.assertIn('/stripy/', stripy['url'])
+        self.assertTrue(stripy['outliers_detected'])
+        self.assertEqual(stripy['outlier_loci'], ['ATXN1', 'HTT'])
+        self.assertIsNotNone(stripy['timestamp_completed'])
+
+    @run_as_sync
+    async def test_details_mito_report(self):
+        """MitoReport web report includes correct URL pattern"""
+        sg_ids = await self.create_family_with_participants(
+            'FAM01',
+            [{'ext_id': 'P1', 'sex': '1', 'affected': '2'}],
+        )
+        sg_id = sg_ids['P1']
+
+        await self.create_analysis_with_output(
+            AnalysisInternal(
+                type='web',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_id],
+                meta={'stage': 'MitoReport'},
+            ),
+            output='gs://cpg-test-main-web/mito/report.html',
+        )
+
+        result = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertIn('mito', row.web_reports)
+        mito = row.web_reports['mito']
+        self.assertIn('/mito/mitoreport-', mito['url'])
+        self.assertIn('/index.html', mito['url'])
+        self.assertIsNotNone(mito['timestamp_completed'])
+
+    @run_as_sync
+    async def test_details_test_web_url_vs_main_web_url(self):
+        """Report URL base differs based on output path containing main-web vs test-web"""
+        sg_ids = await self.create_family_with_participants(
+            'FAM01',
+            [
+                {'ext_id': 'P_MAIN', 'sex': '1', 'affected': '1'},
+                {'ext_id': 'P_TEST', 'sex': '2', 'affected': '1'},
+            ],
+        )
+
+        # Main-web output for P_MAIN's SG
+        await self.create_analysis_with_output(
+            AnalysisInternal(
+                type='web',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_ids['P_MAIN']],
+                meta={'stage': 'Stripy'},
+            ),
+            output='gs://cpg-project-main-web/stripy/report.html',
+        )
+        # Test-web output for P_TEST's SG
+        await self.create_analysis_with_output(
+            AnalysisInternal(
+                type='web',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[sg_ids['P_TEST']],
+                meta={'stage': 'Stripy'},
+            ),
+            output='gs://cpg-project-test-web/stripy/report.html',
+        )
+
+        result = await self.pil.get_project_insights_details(
+            project_names=[self.project_name], sequencing_types=['genome']
+        )
+
+        main_row = [r for r in result if r.participant_ext_id == 'P_MAIN'][0]
+        test_row = [r for r in result if r.participant_ext_id == 'P_TEST'][0]
+
+        self.assertIn('https://main-web', main_row.web_reports['stripy']['url'])
+        self.assertIn('https://test-web', test_row.web_reports['stripy']['url'])

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "metamist",
-    "version": "7.10.3",
+    "version": "7.14.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "metamist",
-            "version": "7.10.3",
+            "version": "7.14.0",
             "dependencies": {
                 "@apollo/client": "^3.11.5",
                 "@duckdb/duckdb-wasm": "^1.29.0",

--- a/web/src/pages/insights/Details.tsx
+++ b/web/src/pages/insights/Details.tsx
@@ -1,33 +1,27 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Button } from 'semantic-ui-react'
 import { PaddedPage } from '../../shared/components/Layout/PaddedPage'
-import { EnumsApi, ProjectApi, ProjectInsightsApi, ProjectInsightsDetails } from '../../sm-api'
+import { EnumsApi, Project, ProjectApi, ProjectInsightsApi, ProjectInsightsDetails } from '../../sm-api'
 import DetailsTable from './DetailsTable'
 import filterData from './FilterData'
 import ProjectAndSeqTypeSelector from './ProjectAndSeqTypeSelector'
+import { useInsightsUrlState } from './useInsightsUrlState'
 
 const Details: React.FC = () => {
-    // Projects come from the project API and the sequencing types from the enums API
-    const [projectNames, setProjectNames] = React.useState<string[]>([])
-    const [seqTypes, setSeqTypes] = React.useState<string[]>([])
-    const [selectedProjects, setSelectedProjects] = useState<string[]>([])
-    const [selectedSeqTypes, setSelectedSeqTypes] = useState<string[]>([])
+    const [projects, setProjects] = useState<Project[]>([])
+    const [seqTypes, setSeqTypes] = useState<string[]>([])
 
-    // State containing all the records fetched from the ProjectInsightsDetails API
+    const { selectedProjects, setSelectedProjects, selectedSeqTypes, setSelectedSeqTypes } =
+        useInsightsUrlState(
+            projects.map((p) => p.name),
+            seqTypes
+        )
+
     const [allData, setAllData] = useState<ProjectInsightsDetails[]>([])
-    // Filtered data based on the selected projects, sequencing types, and column filters
     const { filteredData, getUniqueOptionsForColumn, updateFilter, getSelectedOptionsForColumn } =
         filterData(allData)
 
-    const handleProjectChange = useCallback((selectedProjects: string[]) => {
-        setSelectedProjects(selectedProjects)
-    }, [])
-    const handleSeqTypeChange = useCallback((selectedSeqTypes: string[]) => {
-        setSelectedSeqTypes(selectedSeqTypes)
-    }, [])
-
     const fetchSelectedData = useCallback(async () => {
-        // Fetch the detailed data for the selected projects and sequencing types
         try {
             const detailsResp = await new ProjectInsightsApi().getProjectInsightsDetails({
                 project_names: selectedProjects,
@@ -41,14 +35,13 @@ const Details: React.FC = () => {
 
     useEffect(() => {
         const fetchInitialData = async () => {
-            // Fetch the sequencing types and projects for user selection
             try {
                 const [seqTypesResp, projectsResp] = await Promise.all([
                     new EnumsApi().getSequencingTypes(),
-                    new ProjectApi().getMyProjects({}),
+                    new ProjectApi().getAllProjects(),
                 ])
                 setSeqTypes(seqTypesResp.data)
-                setProjectNames(projectsResp.data)
+                setProjects(projectsResp.data)
             } catch (error) {
                 console.error('Error fetching initial data:', error)
             }
@@ -59,12 +52,12 @@ const Details: React.FC = () => {
     return (
         <PaddedPage>
             <ProjectAndSeqTypeSelector
-                projects={projectNames}
+                projects={projects.map((p) => p.name)}
                 seqTypes={seqTypes}
                 selectedProjects={selectedProjects}
                 selectedSeqTypes={selectedSeqTypes}
-                onProjectChange={handleProjectChange}
-                onSeqTypeChange={handleSeqTypeChange}
+                onProjectChange={setSelectedProjects}
+                onSeqTypeChange={setSelectedSeqTypes}
             />
             <Button
                 primary
@@ -78,7 +71,7 @@ const Details: React.FC = () => {
                 handleSelectionChange={updateFilter}
                 getUniqueOptionsForColumn={getUniqueOptionsForColumn}
                 getSelectedOptionsForColumn={getSelectedOptionsForColumn}
-            ></DetailsTable>
+            />
         </PaddedPage>
     )
 }

--- a/web/src/pages/insights/Details.tsx
+++ b/web/src/pages/insights/Details.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Button } from 'semantic-ui-react'
 import { PaddedPage } from '../../shared/components/Layout/PaddedPage'
-import { EnumsApi, Project, ProjectApi, ProjectInsightsApi, ProjectInsightsDetails } from '../../sm-api'
+import {
+    EnumsApi,
+    Project,
+    ProjectApi,
+    ProjectInsightsApi,
+    ProjectInsightsDetails,
+} from '../../sm-api'
 import DetailsTable from './DetailsTable'
 import filterData from './FilterData'
 import ProjectAndSeqTypeSelector from './ProjectAndSeqTypeSelector'
@@ -52,7 +58,7 @@ const Details: React.FC = () => {
     return (
         <PaddedPage>
             <ProjectAndSeqTypeSelector
-                projects={projects.map((p) => p.name)}
+                projects={projects}
                 seqTypes={seqTypes}
                 selectedProjects={selectedProjects}
                 selectedSeqTypes={selectedSeqTypes}

--- a/web/src/pages/insights/DetailsTable.tsx
+++ b/web/src/pages/insights/DetailsTable.tsx
@@ -23,10 +23,20 @@ const getRowClassName = (sequencingType: string) => {
     }
 }
 
+const getReportLabel = (key: 'stripy' | 'mito', participantExtId: string): string => {
+    if (key === 'stripy') return `Stripy ${participantExtId}`
+    return `MitoReport ${participantExtId}`
+}
+
 const getCellValue = (details: ProjectInsightsDetails, key: ColumnKey): React.ReactNode => {
     if (key === 'stripy' || key === 'mito') {
         const report = details.web_reports?.[key]
-        return report ? <a href={(report as { url: string }).url}>Link</a> : 'N/A'
+        if (!report) return 'N/A'
+        return (
+            <a href={(report as { url: string }).url} target="_blank" rel="noopener noreferrer">
+                {getReportLabel(key, details.participant_ext_id)}
+            </a>
+        )
     }
     if (key === 'cram') {
         // Return the cram timestamp_completed string if it exists, otherwise return 'N/A'
@@ -150,12 +160,13 @@ const DetailsTable: React.FC<DetailsTableProps> = ({
         const url = URL.createObjectURL(blob)
         const link = document.createElement('a')
         link.href = url
-        const currentDate = new Date().toISOString().slice(0, 19)
+        const currentDate = new Date().toISOString().slice(0, 19).replace(/:/g, '-')
         const fileName = `project_insights_details_${currentDate}.${format}`
         link.setAttribute('download', fileName)
         document.body.appendChild(link)
         link.click()
         document.body.removeChild(link)
+        URL.revokeObjectURL(url)
     }
 
     const exportOptions = [
@@ -174,6 +185,8 @@ const DetailsTable: React.FC<DetailsTableProps> = ({
                     icon="download"
                     options={exportOptions}
                     text="Export"
+                    selectOnBlur={false}
+                    value={null}
                     onChange={(_, data) => exportToFile(data.value as 'csv' | 'tsv')}
                 />
             </div>

--- a/web/src/pages/insights/DetailsTable.tsx
+++ b/web/src/pages/insights/DetailsTable.tsx
@@ -186,7 +186,7 @@ const DetailsTable: React.FC<DetailsTableProps> = ({
                     options={exportOptions}
                     text="Export"
                     selectOnBlur={false}
-                    value={null}
+                    value={undefined}
                     onChange={(_, data) => exportToFile(data.value as 'csv' | 'tsv')}
                 />
             </div>

--- a/web/src/pages/insights/FilterData.tsx
+++ b/web/src/pages/insights/FilterData.tsx
@@ -29,6 +29,13 @@ function useFilterData<T extends ProjectInsightsSummary | ProjectInsightsDetails
                     const report = webReports?.[key]
                     return values.has(report ? 'Yes' : 'No')
                 }
+                if (key === 'cram') {
+                    const projectInsightsItem = item as ProjectInsightsDetails
+                    const cram = projectInsightsItem.cram as {
+                        timestamp_completed?: string
+                    }
+                    return values.has(cram?.timestamp_completed || 'N/A')
+                }
                 if (typeof itemValue === 'boolean') {
                     return values.has(itemValue ? 'Yes' : 'No')
                 }

--- a/web/src/pages/insights/HeaderCell.tsx
+++ b/web/src/pages/insights/HeaderCell.tsx
@@ -164,7 +164,7 @@ export const DETAILS_TABLE_HEADER_CELL_CONFIGS: HeaderCellConfig[] = [
         key: 'cram',
         label: 'CRAM',
         sortable: true,
-        tooltip: 'Timestamp of the latest CRAM Analysis (DD-MM-YY)',
+        tooltip: 'Timestamp of the latest CRAM Analysis (YYYY-MM-DD)',
         filterable: true,
     },
     {

--- a/web/src/pages/insights/ProjectAndSeqTypeSelector.tsx
+++ b/web/src/pages/insights/ProjectAndSeqTypeSelector.tsx
@@ -1,17 +1,26 @@
 import React from 'react'
 import { Checkbox, Dropdown, DropdownProps } from 'semantic-ui-react'
+import { Project } from '../../sm-api'
 
-interface SelectorProps {
-    items: string[]
-    selectedItems: string[]
-    onSelectionChange: (selectedItems: string[]) => void
-    title: string
-    specialSelectionLabel?: string
-    specialSelectionItems?: string[]
+interface PresetConfig {
+    label: string
+    getItems: (projects: Project[]) => string[]
+}
+
+interface ProjectSelectorProps {
+    projects: Project[]
+    selectedProjects: string[]
+    onSelectionChange: (selectedProjects: string[]) => void
+}
+
+interface SeqTypeSelectorProps {
+    seqTypes: string[]
+    selectedSeqTypes: string[]
+    onSelectionChange: (selectedSeqTypes: string[]) => void
 }
 
 interface ProjectAndSeqTypeSelectorProps {
-    projects: string[]
+    projects: Project[]
     selectedProjects: string[]
     seqTypes: string[]
     selectedSeqTypes: string[]
@@ -19,61 +28,137 @@ interface ProjectAndSeqTypeSelectorProps {
     onSeqTypeChange: (selectedSeqTypes: string[]) => void
 }
 
-const Selector: React.FC<SelectorProps> = ({
-    items,
-    selectedItems,
+const PROJECT_PRESETS: PresetConfig[] = [
+    {
+        label: 'All projects (excluding test)',
+        getItems: (projects) =>
+            projects.filter((p) => !p.name.endsWith('-test')).map((p) => p.name),
+    },
+    {
+        label: 'Only seqr projects',
+        getItems: (projects) =>
+            projects
+                .filter((p) => {
+                    const meta = p.meta as Record<string, unknown> | null | undefined
+                    return meta?.is_seqr
+                })
+                .map((p) => p.name),
+    },
+]
+
+const SEQ_TYPE_PRESETS: { label: string; items: string[] }[] = [
+    {
+        label: 'WGS & WES only',
+        items: ['genome', 'exome'],
+    },
+]
+
+const ProjectSelector: React.FC<ProjectSelectorProps> = ({
+    projects,
+    selectedProjects,
     onSelectionChange,
-    title,
-    specialSelectionLabel,
-    specialSelectionItems,
 }) => {
-    const handleChange = (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => {
-        const value = data.value as string[]
-        onSelectionChange(value)
+    const projectNames = projects.map((p) => p.name)
+    const options = projectNames.map((name) => ({ key: name, text: name, value: name }))
+
+    const handleChange = (_: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => {
+        onSelectionChange(data.value as string[])
     }
 
-    const handleSpecialSelection = () => {
-        if (specialSelectionItems) {
-            const areAllSpecialItemsSelected = specialSelectionItems.every((item) =>
-                selectedItems.includes(item)
-            )
-            if (areAllSpecialItemsSelected) {
-                onSelectionChange(
-                    selectedItems.filter((item) => !specialSelectionItems.includes(item))
-                )
-            } else {
-                onSelectionChange([...new Set([...selectedItems, ...specialSelectionItems])])
-            }
+    const handlePresetToggle = (presetItems: string[]) => {
+        const allSelected = presetItems.every((item) => selectedProjects.includes(item))
+        if (allSelected) {
+            onSelectionChange(selectedProjects.filter((p) => !presetItems.includes(p)))
+        } else {
+            onSelectionChange([...new Set([...selectedProjects, ...presetItems])])
         }
     }
 
-    const options = items.map((item) => ({
-        key: item,
-        text: item,
-        value: item,
-    }))
-
     return (
         <div style={{ flex: '1', marginRight: '20px' }}>
-            <h2 style={{ fontSize: '18px', marginBottom: '10px' }}>{title}</h2>
+            <h2 style={{ fontSize: '18px', marginBottom: '10px' }}>Projects</h2>
             <Dropdown
-                placeholder={`Select ${title}`}
+                placeholder="Select Projects"
                 fluid
                 multiple
                 search
                 selection
                 options={options}
-                value={selectedItems}
+                value={selectedProjects}
                 onChange={handleChange}
                 style={{ marginBottom: '10px' }}
             />
-            {specialSelectionLabel && (
-                <Checkbox
-                    label={specialSelectionLabel}
-                    checked={specialSelectionItems?.every((item) => selectedItems.includes(item))}
-                    onChange={handleSpecialSelection}
-                />
-            )}
+            {PROJECT_PRESETS.map((preset) => {
+                const presetItems = preset.getItems(projects)
+                if (presetItems.length === 0) return null
+                return (
+                    <div key={preset.label} style={{ marginBottom: '4px' }}>
+                        <Checkbox
+                            label={`${preset.label} (${presetItems.length})`}
+                            checked={
+                                presetItems.length > 0 &&
+                                presetItems.every((item) => selectedProjects.includes(item))
+                            }
+                            onChange={() => handlePresetToggle(presetItems)}
+                        />
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+const SeqTypeSelector: React.FC<SeqTypeSelectorProps> = ({
+    seqTypes,
+    selectedSeqTypes,
+    onSelectionChange,
+}) => {
+    const options = seqTypes.map((st) => ({ key: st, text: st, value: st }))
+
+    const handleChange = (_: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => {
+        onSelectionChange(data.value as string[])
+    }
+
+    const handlePresetToggle = (presetItems: string[]) => {
+        const availableItems = presetItems.filter((item) => seqTypes.includes(item))
+        const allSelected = availableItems.every((item) => selectedSeqTypes.includes(item))
+        if (allSelected) {
+            onSelectionChange(selectedSeqTypes.filter((st) => !availableItems.includes(st)))
+        } else {
+            onSelectionChange([...new Set([...selectedSeqTypes, ...availableItems])])
+        }
+    }
+
+    return (
+        <div style={{ flex: '1' }}>
+            <h2 style={{ fontSize: '18px', marginBottom: '10px' }}>Sequencing Types</h2>
+            <Dropdown
+                placeholder="Select Sequencing Types"
+                fluid
+                multiple
+                search
+                selection
+                options={options}
+                value={selectedSeqTypes}
+                onChange={handleChange}
+                style={{ marginBottom: '10px' }}
+            />
+            {SEQ_TYPE_PRESETS.map((preset) => {
+                const availableItems = preset.items.filter((item) => seqTypes.includes(item))
+                if (availableItems.length === 0) return null
+                return (
+                    <div key={preset.label} style={{ marginBottom: '4px' }}>
+                        <Checkbox
+                            label={preset.label}
+                            checked={
+                                availableItems.length > 0 &&
+                                availableItems.every((item) => selectedSeqTypes.includes(item))
+                            }
+                            onChange={() => handlePresetToggle(availableItems)}
+                        />
+                    </div>
+                )
+            })}
         </div>
     )
 }
@@ -88,22 +173,15 @@ const ProjectAndSeqTypeSelector: React.FC<ProjectAndSeqTypeSelectorProps> = ({
 }) => {
     return (
         <div style={{ display: 'flex', justifyContent: 'space-between', padding: '20px' }}>
-            <Selector
-                items={projects}
-                selectedItems={selectedProjects}
+            <ProjectSelector
+                projects={projects}
+                selectedProjects={selectedProjects}
                 onSelectionChange={onProjectChange}
-                title="Projects"
-                // Special selection for all projects without "-test" suffix
-                specialSelectionLabel="All Projects (excluding test)"
-                specialSelectionItems={projects.filter((project) => !project.endsWith('-test'))}
             />
-            <Selector
-                items={seqTypes}
-                selectedItems={selectedSeqTypes}
+            <SeqTypeSelector
+                seqTypes={seqTypes}
+                selectedSeqTypes={selectedSeqTypes}
                 onSelectionChange={onSeqTypeChange}
-                title="Sequencing Types"
-                specialSelectionLabel="WGS & WES Only"
-                specialSelectionItems={['genome', 'exome']}
             />
         </div>
     )

--- a/web/src/pages/insights/Summary.tsx
+++ b/web/src/pages/insights/Summary.tsx
@@ -1,33 +1,27 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Button } from 'semantic-ui-react'
 import { PaddedPage } from '../../shared/components/Layout/PaddedPage'
-import { EnumsApi, ProjectApi, ProjectInsightsApi, ProjectInsightsSummary } from '../../sm-api'
+import { EnumsApi, Project, ProjectApi, ProjectInsightsApi, ProjectInsightsSummary } from '../../sm-api'
 import filterData from './FilterData'
 import ProjectAndSeqTypeSelector from './ProjectAndSeqTypeSelector'
 import SummaryTable from './SummaryTable'
+import { useInsightsUrlState } from './useInsightsUrlState'
 
 const Summary: React.FC = () => {
-    // States for selected projects and sequencing types
-    const [projectNames, setProjectNames] = React.useState<string[]>([])
-    const [selectedProjects, setSelectedProjects] = React.useState<string[]>([])
-    const [seqTypes, setSeqTypes] = React.useState<string[]>([])
-    const [selectedSeqTypes, setSelectedSeqTypes] = React.useState<string[]>([])
+    const [projects, setProjects] = useState<Project[]>([])
+    const [seqTypes, setSeqTypes] = useState<string[]>([])
 
-    // State containing all the records fetched from the ProjectInsightsSummary API
+    const { selectedProjects, setSelectedProjects, selectedSeqTypes, setSelectedSeqTypes } =
+        useInsightsUrlState(
+            projects.map((p) => p.name),
+            seqTypes
+        )
+
     const [allData, setAllData] = useState<ProjectInsightsSummary[]>([])
-    // Filtered data based on the selected projects, sequencing types, and sequencing technologies
     const { filteredData, updateFilter, getUniqueOptionsForColumn, getSelectedOptionsForColumn } =
         filterData<ProjectInsightsSummary>(allData)
 
-    const handleProjectChange = useCallback((selectedProjects: string[]) => {
-        setSelectedProjects(selectedProjects)
-    }, [])
-    const handleSeqTypeChange = useCallback((selectedSeqTypes: string[]) => {
-        setSelectedSeqTypes(selectedSeqTypes)
-    }, [])
-
     const fetchSelectedData = useCallback(async () => {
-        // Fetch the summary data for the selected projects and sequencing types
         try {
             const detailsResp = await new ProjectInsightsApi().getProjectInsightsSummary({
                 project_names: selectedProjects,
@@ -41,14 +35,13 @@ const Summary: React.FC = () => {
 
     useEffect(() => {
         const fetchInitialData = async () => {
-            // Fetch the sequencing types and projects for user selection
             try {
                 const [seqTypesResp, projectsResp] = await Promise.all([
                     new EnumsApi().getSequencingTypes(),
-                    new ProjectApi().getMyProjects({}),
+                    new ProjectApi().getAllProjects(),
                 ])
                 setSeqTypes(seqTypesResp.data)
-                setProjectNames(projectsResp.data)
+                setProjects(projectsResp.data)
             } catch (error) {
                 console.error('Error fetching initial data:', error)
             }
@@ -59,12 +52,12 @@ const Summary: React.FC = () => {
     return (
         <PaddedPage>
             <ProjectAndSeqTypeSelector
-                projects={projectNames}
+                projects={projects.map((p) => p.name)}
                 seqTypes={seqTypes}
                 selectedProjects={selectedProjects}
                 selectedSeqTypes={selectedSeqTypes}
-                onProjectChange={handleProjectChange}
-                onSeqTypeChange={handleSeqTypeChange}
+                onProjectChange={setSelectedProjects}
+                onSeqTypeChange={setSelectedSeqTypes}
             />
             <div style={{ paddingBottom: '20px' }}>
                 <Button
@@ -80,7 +73,7 @@ const Summary: React.FC = () => {
                 handleSelectionChange={updateFilter}
                 getUniqueOptionsForColumn={getUniqueOptionsForColumn}
                 getSelectedOptionsForColumn={getSelectedOptionsForColumn}
-            ></SummaryTable>
+            />
         </PaddedPage>
     )
 }

--- a/web/src/pages/insights/Summary.tsx
+++ b/web/src/pages/insights/Summary.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Button } from 'semantic-ui-react'
 import { PaddedPage } from '../../shared/components/Layout/PaddedPage'
-import { EnumsApi, Project, ProjectApi, ProjectInsightsApi, ProjectInsightsSummary } from '../../sm-api'
+import {
+    EnumsApi,
+    Project,
+    ProjectApi,
+    ProjectInsightsApi,
+    ProjectInsightsSummary,
+} from '../../sm-api'
 import filterData from './FilterData'
 import ProjectAndSeqTypeSelector from './ProjectAndSeqTypeSelector'
 import SummaryTable from './SummaryTable'
@@ -52,7 +58,7 @@ const Summary: React.FC = () => {
     return (
         <PaddedPage>
             <ProjectAndSeqTypeSelector
-                projects={projects.map((p) => p.name)}
+                projects={projects}
                 seqTypes={seqTypes}
                 selectedProjects={selectedProjects}
                 selectedSeqTypes={selectedSeqTypes}

--- a/web/src/pages/insights/SummaryTable.tsx
+++ b/web/src/pages/insights/SummaryTable.tsx
@@ -289,7 +289,7 @@ const SummaryTable: React.FC<SummaryTableProps> = ({
                     {sortedData.map((summary: ProjectInsightsSummary) => (
                         <SummaryTableRow
                             summary={summary}
-                            key={`${summary.project}_${summary.dataset}`}
+                            key={`${summary.project}_${summary.sequencing_type}_${summary.sequencing_technology}`}
                         />
                     ))}
                 </SUITable.Body>

--- a/web/src/pages/insights/SummaryTableFooterCell.tsx
+++ b/web/src/pages/insights/SummaryTableFooterCell.tsx
@@ -63,17 +63,17 @@ export const footerCellConfigs: FooterCellConfig[] = [
     {
         key: 'total-families',
         label: 'Total Families',
-        calculateValue: (data) => data.reduce((acc, curr) => acc + curr.total_families, 0),
+        calculateValue: (data) => new Set(data.flatMap((curr) => curr.family_ids ?? [])).size,
     },
     {
         key: 'total-participants',
         label: 'Total Participants',
-        calculateValue: (data) => data.reduce((acc, curr) => acc + curr.total_participants, 0),
+        calculateValue: (data) => new Set(data.flatMap((curr) => curr.participant_ids ?? [])).size,
     },
     {
         key: 'total-samples',
         label: 'Total Samples',
-        calculateValue: (data) => data.reduce((acc, curr) => acc + curr.total_samples, 0),
+        calculateValue: (data) => new Set(data.flatMap((curr) => curr.sample_ids ?? [])).size,
     },
     {
         key: 'total-sequencing-groups',

--- a/web/src/pages/insights/useInsightsUrlState.ts
+++ b/web/src/pages/insights/useInsightsUrlState.ts
@@ -78,9 +78,7 @@ export function useInsightsUrlState(
             }
 
             const paramString = searchParams.toString()
-            const newUrl = paramString
-                ? `${location.pathname}?${paramString}`
-                : location.pathname
+            const newUrl = paramString ? `${location.pathname}?${paramString}` : location.pathname
             navigate(newUrl, { replace: true })
         },
         [location.pathname, navigate]

--- a/web/src/pages/insights/useInsightsUrlState.ts
+++ b/web/src/pages/insights/useInsightsUrlState.ts
@@ -31,6 +31,12 @@ export function useInsightsUrlState(
     const [selectedProjects, setSelectedProjectsState] = useState<string[]>([])
     const [selectedSeqTypes, setSelectedSeqTypesState] = useState<string[]>([])
 
+    // Refs to track latest values, avoiding stale closures in callbacks
+    const selectedProjectsRef = useRef(selectedProjects)
+    const selectedSeqTypesRef = useRef(selectedSeqTypes)
+    selectedProjectsRef.current = selectedProjects
+    selectedSeqTypesRef.current = selectedSeqTypes
+
     // Initialize from URL once available options are loaded
     useEffect(() => {
         if (
@@ -45,7 +51,6 @@ export function useInsightsUrlState(
         const urlProjects = parseCommaSeparated(searchParams.get(PROJECTS_PARAM))
         const urlSeqTypes = parseCommaSeparated(searchParams.get(SEQ_TYPES_PARAM))
 
-        // Filter to only valid values the user has access to
         const validProjects = urlProjects.filter((p) => availableProjectNames.includes(p))
         const validSeqTypes = urlSeqTypes.filter((st) => availableSeqTypes.includes(st))
 
@@ -57,23 +62,19 @@ export function useInsightsUrlState(
         }
 
         isInitialized.current = true
-    }, [availableProjectNames, availableSeqTypes, location.search])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [availableProjectNames, availableSeqTypes])
 
-    // Write selection to URL
     const updateUrl = useCallback(
         (projects: string[], seqTypes: string[]) => {
-            const searchParams = new URLSearchParams(location.search)
+            const searchParams = new URLSearchParams()
 
             if (projects.length > 0) {
                 searchParams.set(PROJECTS_PARAM, encodeCommaSeparated(projects))
-            } else {
-                searchParams.delete(PROJECTS_PARAM)
             }
 
             if (seqTypes.length > 0) {
                 searchParams.set(SEQ_TYPES_PARAM, encodeCommaSeparated(seqTypes))
-            } else {
-                searchParams.delete(SEQ_TYPES_PARAM)
             }
 
             const paramString = searchParams.toString()
@@ -82,23 +83,23 @@ export function useInsightsUrlState(
                 : location.pathname
             navigate(newUrl, { replace: true })
         },
-        [location.search, location.pathname, navigate]
+        [location.pathname, navigate]
     )
 
     const setSelectedProjects = useCallback(
         (projects: string[]) => {
             setSelectedProjectsState(projects)
-            updateUrl(projects, selectedSeqTypes)
+            updateUrl(projects, selectedSeqTypesRef.current)
         },
-        [updateUrl, selectedSeqTypes]
+        [updateUrl]
     )
 
     const setSelectedSeqTypes = useCallback(
         (seqTypes: string[]) => {
             setSelectedSeqTypesState(seqTypes)
-            updateUrl(selectedProjects, seqTypes)
+            updateUrl(selectedProjectsRef.current, seqTypes)
         },
-        [updateUrl, selectedProjects]
+        [updateUrl]
     )
 
     return {

--- a/web/src/pages/insights/useInsightsUrlState.ts
+++ b/web/src/pages/insights/useInsightsUrlState.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+const PROJECTS_PARAM = 'projects'
+const SEQ_TYPES_PARAM = 'seqTypes'
+
+function parseCommaSeparated(param: string | null): string[] {
+    if (!param) return []
+    return param.split(',').filter(Boolean)
+}
+
+function encodeCommaSeparated(values: string[]): string {
+    return values.join(',')
+}
+
+interface UseInsightsUrlStateResult {
+    selectedProjects: string[]
+    setSelectedProjects: (projects: string[]) => void
+    selectedSeqTypes: string[]
+    setSelectedSeqTypes: (seqTypes: string[]) => void
+}
+
+export function useInsightsUrlState(
+    availableProjectNames: string[],
+    availableSeqTypes: string[]
+): UseInsightsUrlStateResult {
+    const location = useLocation()
+    const navigate = useNavigate()
+    const isInitialized = useRef(false)
+
+    const [selectedProjects, setSelectedProjectsState] = useState<string[]>([])
+    const [selectedSeqTypes, setSelectedSeqTypesState] = useState<string[]>([])
+
+    // Initialize from URL once available options are loaded
+    useEffect(() => {
+        if (
+            isInitialized.current ||
+            availableProjectNames.length === 0 ||
+            availableSeqTypes.length === 0
+        ) {
+            return
+        }
+
+        const searchParams = new URLSearchParams(location.search)
+        const urlProjects = parseCommaSeparated(searchParams.get(PROJECTS_PARAM))
+        const urlSeqTypes = parseCommaSeparated(searchParams.get(SEQ_TYPES_PARAM))
+
+        // Filter to only valid values the user has access to
+        const validProjects = urlProjects.filter((p) => availableProjectNames.includes(p))
+        const validSeqTypes = urlSeqTypes.filter((st) => availableSeqTypes.includes(st))
+
+        if (validProjects.length > 0) {
+            setSelectedProjectsState(validProjects)
+        }
+        if (validSeqTypes.length > 0) {
+            setSelectedSeqTypesState(validSeqTypes)
+        }
+
+        isInitialized.current = true
+    }, [availableProjectNames, availableSeqTypes, location.search])
+
+    // Write selection to URL
+    const updateUrl = useCallback(
+        (projects: string[], seqTypes: string[]) => {
+            const searchParams = new URLSearchParams(location.search)
+
+            if (projects.length > 0) {
+                searchParams.set(PROJECTS_PARAM, encodeCommaSeparated(projects))
+            } else {
+                searchParams.delete(PROJECTS_PARAM)
+            }
+
+            if (seqTypes.length > 0) {
+                searchParams.set(SEQ_TYPES_PARAM, encodeCommaSeparated(seqTypes))
+            } else {
+                searchParams.delete(SEQ_TYPES_PARAM)
+            }
+
+            const paramString = searchParams.toString()
+            const newUrl = paramString
+                ? `${location.pathname}?${paramString}`
+                : location.pathname
+            navigate(newUrl, { replace: true })
+        },
+        [location.search, location.pathname, navigate]
+    )
+
+    const setSelectedProjects = useCallback(
+        (projects: string[]) => {
+            setSelectedProjectsState(projects)
+            updateUrl(projects, selectedSeqTypes)
+        },
+        [updateUrl, selectedSeqTypes]
+    )
+
+    const setSelectedSeqTypes = useCallback(
+        (seqTypes: string[]) => {
+            setSelectedSeqTypesState(seqTypes)
+            updateUrl(selectedProjects, seqTypes)
+        },
+        [updateUrl, selectedProjects]
+    )
+
+    return {
+        selectedProjects,
+        setSelectedProjects,
+        selectedSeqTypes,
+        setSelectedSeqTypes,
+    }
+}


### PR DESCRIPTION
Updates the Project Insights dashboards / data layers and the `test/data/generate_seqr_project_data.py` script and implements unit tests for both

---

# Overview

The insights dashboards are designed to let users access live information from Metamist quickly. The are essentially DB views with useful data surfaced. Users can access dashboards which display:
- A **summary** of project data with accurate stats (numbers of families, participants, samples, sequencing groups, etc)
- The **details** of project data, at the sequencing group level - each sequencing group's attributes (type, technology, platform), it's parent sample, participant, and family; and links to the sequencing group's web reports.

The `generate_seqr_project_data.py` script is designed to be run on a local Metamist deploy to populate the database with a number of dummy projects, each containing a semi-random amount of families, participants, samples, sequencing groups, and analyses created by the RD pipelines for the purposes of seqr. This dummy data is useful for testing the insights dashboards in local Metamist installs.

---

# Changes

## Project Insights data layer & dashboard 

### General
- Filter out inactive SGs
- Add query parameters (selected projects, seq types) to URL, dynamically update this with user selection
- Fetch the `Projects` from `get_all_projects` API endpoint, this lets us use project meta information, compared to `get_my_projects`, which only gives a list of string project names
- Add in new default option "All seqr projects" which selects for projects where `meta.is_seqr = True`

### Summary dashboard
- Fix the GRAND TOTAL row counting
  - Collect sets of the family / participant / sample IDs and use these to calculate the grand total sum for each dataset, avoids double counting the same families between different seq types.
- Fix the "Technology" filter by keying rows on dataset, seq type, and seq tech, so that the filter actually works and doesn't create duplicate rows

### Details dashboard
- Fix to display and filtering of CRAM timestamp
- Fix to the swapping of "Technology" and "Platform" columns
- Fix to allow export of dashboard more than once per session
- Open web report links in new tab by default
- Display useful information (Participant external ID) in the web-report hyperlinks, instead of just the text "Link"

### Unit tests: `test/test_project_insights.py`
- Implemented comprehensive testing for the project insights data layer and logic

## Generate seqr project data 

### Data generating script: `test/data/generate_seqr_project_data.py` 
- Generate better fake cram output paths
- Generate custom cohorts for the test datasets, and use the cohort ids to populate the analysis records 
- Generate QC / web analyses for each dataset using the custom cohorts

### Unit tests: `test/test_generate_seqr_project_data.py` unit tests
- Implemented comprehensive testing for the data generating script