### PR TITLE
Update analysis moving script to skip analyses with old project

### DIFF
--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -48,6 +48,9 @@ ANALYSES_QUERY = gql(
                     type
                     meta
                     outputs
+                    project {
+                        name
+                    }
                 }
             }
         }
@@ -134,6 +137,10 @@ def get_analyses_to_update_and_files_to_move(
     files_to_move = []
     for sg in analysis_query_result['project']['sequencingGroups']:
         for analysis in sg['analyses']:
+            if analysis['project']['name'] != new_dataset:
+                # This skips the analyses that haven't been updated with the new project
+                continue
+
             if (
                 analysis['type'] == 'sv'
                 and analysis['meta'].get('stage') != 'GatherSampleEvidence'

--- a/scripts/move_analyses_across_projects.py
+++ b/scripts/move_analyses_across_projects.py
@@ -101,6 +101,7 @@ UNRECORDED_ANALYSIS_FILES = [
     # Stripy stage files
     'gs://{bucket_name}-analysis/stripy/{sg_id}.stripy.json',
     'gs://{bucket_name}-analysis/stripy/{sg_id}.stripy.log.txt',
+    'gs://cpg-{bucket_name}-main-web/stripy/{sg_id}.stripy.html',  # latest global report
     # MitoReport stage files
     'gs://{bucket_name}-analysis/mito/{sg_id}.coverage_mean.txt',
     'gs://{bucket_name}-analysis/mito/{sg_id}.coverage_median.txt',


### PR DESCRIPTION
Updates the analysis mover script so that analyses that are still in the old project don't get touched.

For example, the STRipy index pages produced in the old project that include many SGs, including the one targeted. We don't want to move these multi-SG analyses, but they are picked up when you search for `analysis.type='web'` (Although we may want to archive those analyses and create them fresh, since they now have SGs across multiple dataset)

Caught on a dry run: https://batch.hail.populationgenomics.org.au/batches/1127974/jobs/1
```
Analysis: 123456. SG: CPGXXXXXX. Type: web.
    New outputs path: gs://cpg-{new_dataset}-main-web/stripy/1.2/{new_dataset}_index.html
    New meta dataset: {new_dataset}
DRY RUN :: Skipping updating analysis 123456
```

In this case, analysis 123456 is associated with the old project, so by adding this condition it becomes out of scope.