### PR TITLE
Fix number 2 for Billing Cost page, bug introduced with conversion to pg.

### DIFF
--- a/db/python/tables/sample.py
+++ b/db/python/tables/sample.py
@@ -754,7 +754,7 @@ class SampleTable(DbBase):
 
         _query = t"""
         WITH t AS(
-            SELECT project, sample.id, MIN(lower(s.sys_period)) as sample_first_date
+            SELECT project, sample.id, MIN(lower(sample_hist.sys_period)) as sample_first_date
             FROM sample
             INNER JOIN (
                 SELECT id, sys_period FROM sample

--- a/db/python/tables/sample.py
+++ b/db/python/tables/sample.py
@@ -754,7 +754,7 @@ class SampleTable(DbBase):
 
         _query = t"""
         WITH t AS(
-            SELECT project, id, MIN(lower(s.sys_period)) as sample_first_date
+            SELECT project, sample.id, MIN(lower(s.sys_period)) as sample_first_date
             FROM sample
             INNER JOIN (
                 SELECT id, sys_period FROM sample


### PR DESCRIPTION
One more fix for the same SQL, this time:
`psycopg.errors.UndefinedTable: missing FROM-clause entry for table "s"`