### PR TITLE
Take 3 to fix for Billing Cost page, bug introduced with conversion to pg.

### DIFF
--- a/db/python/tables/sample.py
+++ b/db/python/tables/sample.py
@@ -754,7 +754,7 @@ class SampleTable(DbBase):
 
         _query = t"""
         WITH t AS(
-            SELECT project, sample.id, MIN(lower(s.sys_period)) as sample_first_date
+            SELECT project, sample.id, MIN(lower(sample_hist.sys_period)) as sample_first_date
             FROM sample
             INNER JOIN (
                 SELECT id, sys_period FROM sample

--- a/db/python/tables/sample.py
+++ b/db/python/tables/sample.py
@@ -762,7 +762,7 @@ class SampleTable(DbBase):
                 SELECT id, sys_period FROM sample_history
             ) sample_hist ON sample.id = sample_hist.id
             {where_str:q}
-            GROUP BY project,id
+            GROUP BY project, sample.id
         )
         SELECT project,
         CAST(EXTRACT(YEAR FROM sample_first_date) AS INTEGER) AS year,

--- a/db/python/tables/sample.py
+++ b/db/python/tables/sample.py
@@ -754,7 +754,7 @@ class SampleTable(DbBase):
 
         _query = t"""
         WITH t AS(
-            SELECT project, id, MIN(lower(s.sys_period)) as sample_first_date
+            SELECT project, sample.id, MIN(lower(s.sys_period)) as sample_first_date
             FROM sample
             INNER JOIN (
                 SELECT id, sys_period FROM sample


### PR DESCRIPTION
Another `psycopg.errors.AmbiguousColumn: column reference "id" is ambiguous`, should be the last one.