### PR TITLE
Reinstate function that was erroneously thought to be unused

### DIFF
--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -122,6 +122,28 @@ class SequencingGroupLayer(BaseLayer):
         """
         return await self.seqgt.get_all_sequencing_group_ids_by_sample_ids_by_type()
 
+    async def get_participant_ids_sequencing_group_ids_for_sequencing_type(
+        self, sequencing_type: str
+    ) -> dict[int, list[int]]:
+        """
+        Get list of participant IDs for a specific sequence type,
+        useful for synchronisation seqr projects
+        """
+        (
+            projects,
+            pids,
+        ) = await self.seqgt.get_participant_ids_and_sequencing_group_ids_for_sequencing_type(
+            sequencing_type
+        )
+        if not pids:
+            return {}
+
+        self.connection.check_access_to_projects_for_ids(
+            projects, allowed_roles=ReadAccessRoles
+        )
+
+        return pids
+
     async def get_type_numbers_for_project(self, project: ProjectId) -> dict[str, int]:
         """Get sequencing type numbers (of groups) for a project"""
         return await self.seqgt.get_type_numbers_for_project(project)

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -256,6 +256,33 @@ class SequencingGroupTable(DbBase):
 
         return sequencing_group_ids_by_sample_ids_by_type
 
+    async def get_participant_ids_and_sequencing_group_ids_for_sequencing_type(
+        self, sequencing_type: str
+    ) -> tuple[set[ProjectId], dict[int, list[int]]]:
+        """
+        Get participant IDs for a specific sequence type.
+        Particularly useful for seqr like cases
+        """
+        _query = """
+        SELECT s.project as project, sg.id as sid, s.participant_id as pid
+        FROM sequencing_group sg
+        INNER JOIN sample s ON sg.sample_id = s.id
+        WHERE sg.type = :seqtype AND project = :project
+        """
+
+        rows = list(
+            await self.connection.fetch_all(
+                _query, {'seqtype': sequencing_type, 'project': self.project_id}
+            )
+        )
+
+        projects = set(r['project'] for r in rows)
+        participant_id_to_sids: dict[int, list[int]] = defaultdict(list)
+        for r in rows:
+            participant_id_to_sids[r['pid']].append(r['sid'])
+
+        return projects, participant_id_to_sids
+
     async def get_samples_create_date_from_sgs(
         self, sequencing_group_ids: list[int]
     ) -> dict[SequencingGroupInternalId, date]:

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -263,18 +263,15 @@ class SequencingGroupTable(DbBase):
         Get participant IDs for a specific sequence type.
         Particularly useful for seqr like cases
         """
-        _query = """
+        _query = t"""
         SELECT s.project as project, sg.id as sid, s.participant_id as pid
         FROM sequencing_group sg
         INNER JOIN sample s ON sg.sample_id = s.id
-        WHERE sg.type = :seqtype AND project = :project
+        WHERE sg.type = {sequencing_type} AND project = {self.project_id}
         """
 
-        rows = list(
-            await self.connection.fetch_all(
-                _query, {'seqtype': sequencing_type, 'project': self.project_id}
-            )
-        )
+        cur = await self.connection.pg_connection.execute(_query)
+        rows = await cur.fetchall()
 
         projects = set(r['project'] for r in rows)
         participant_id_to_sids: dict[int, list[int]] = defaultdict(list)


### PR DESCRIPTION
`get_participant_ids_sequencing_group_ids_for_sequencing_type()` was removed in #1204 on the basis that it was unused, but in fact it is used in `SeqrLayer.sync_dataset()`.

This PR reinstates it and converts it to use a Postgres query.