### PR TITLE
SET-1045: Add toggle for Avg. Sample Cost rows in Cost Across Invoice Months

### DIFF
--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -1,9 +1,16 @@
-import { Box, Link as MuiLink, Modal as MuiModal, Typography } from '@mui/material'
+import {
+    Box,
+    FormControlLabel,
+    Link as MuiLink,
+    Modal as MuiModal,
+    Switch,
+    Typography,
+} from '@mui/material'
 import { SelectChangeEvent } from '@mui/material/Select'
 import { debounce } from 'lodash'
 import * as React from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
-import { Button, Card, Checkbox, Dropdown, Grid, Message } from 'semantic-ui-react'
+import { Button, Card, Dropdown, Grid, Message } from 'semantic-ui-react'
 
 import { PaddedPage } from '../../shared/components/Layout/PaddedPage'
 import LoadingDucks from '../../shared/components/LoadingDucks/LoadingDucks'
@@ -486,34 +493,73 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                         </MuiLink>
                     </Box>
 
-                    <Dropdown
-                        button
-                        className="icon"
-                        floating
-                        labeled
-                        icon="download"
-                        text="Export"
-                        style={{
-                            minWidth: '115px',
-                            maxWidth: '115px',
-                            height: '36px',
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 2,
+                            flexWrap: 'wrap',
+                            justifyContent: 'flex-end',
                         }}
                     >
-                        <Dropdown.Menu>
-                            <Dropdown.Item
-                                key="csv"
-                                text="Export to CSV"
-                                icon="file excel"
-                                onClick={() => exportToFile('csv')}
-                            />
-                            <Dropdown.Item
-                                key="tsv"
-                                text="Export to TSV"
-                                icon="file text outline"
-                                onClick={() => exportToFile('tsv')}
-                            />
-                        </Dropdown.Menu>
-                    </Dropdown>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={includeAvgSampleCost}
+                                    onChange={(e) => {
+                                        const next = e.target.checked
+                                        setIncludeAvgSampleCost(next)
+                                        const url = generateUrl(location, {
+                                            start,
+                                            end,
+                                            topics:
+                                                selectedTopics.length > 0
+                                                    ? selectedTopics.join(',')
+                                                    : undefined,
+                                            includeAvgSampleCost: next ? undefined : 'false',
+                                        })
+                                        navigate(url)
+                                    }}
+                                    size="small"
+                                    color="primary"
+                                />
+                            }
+                            label={
+                                <Typography variant="body2">
+                                    Include Avg. Sample Cost (Est.)
+                                </Typography>
+                            }
+                            sx={{ mr: 0 }}
+                        />
+                        <Dropdown
+                            button
+                            className="icon"
+                            floating
+                            labeled
+                            icon="download"
+                            text="Export"
+                            style={{
+                                minWidth: '115px',
+                                maxWidth: '115px',
+                                height: '36px',
+                            }}
+                        >
+                            <Dropdown.Menu>
+                                <Dropdown.Item
+                                    key="csv"
+                                    text="Export to CSV"
+                                    icon="file excel"
+                                    onClick={() => exportToFile('csv')}
+                                />
+                                <Dropdown.Item
+                                    key="tsv"
+                                    text="Export to TSV"
+                                    icon="file text outline"
+                                    onClick={() => exportToFile('tsv')}
+                                />
+                            </Dropdown.Menu>
+                        </Dropdown>
+                    </Box>
                 </div>
 
                 <Grid columns="equal" stackable doubling>
@@ -546,28 +592,6 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                         />
                     </Grid.Column>
                 </Grid>
-
-                <div style={{ marginTop: '15px' }}>
-                    <Checkbox
-                        toggle
-                        label="Include Avg. Sample Cost (Est.) rows"
-                        checked={includeAvgSampleCost}
-                        onChange={(_, { checked }) => {
-                            const next = Boolean(checked)
-                            setIncludeAvgSampleCost(next)
-                            const url = generateUrl(location, {
-                                start,
-                                end,
-                                topics:
-                                    selectedTopics.length > 0
-                                        ? selectedTopics.join(',')
-                                        : undefined,
-                                includeAvgSampleCost: next ? undefined : 'false',
-                            })
-                            navigate(url)
-                        }}
-                    />
-                </div>
             </Card>
 
             {messageComponent()}

--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -64,7 +64,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
 
     // Toggle to include/exclude Avg Sample Cost (Est.) rows in the table and exports
     const [includeAvgSampleCost, setIncludeAvgSampleCost] = React.useState<boolean>(
-        searchParams.get('includeAvgSampleCost') !== 'false'
+        searchParams.get('includeAvgSampleCost') === 'true'
     )
 
     // use navigate and update url params
@@ -91,6 +91,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
             start: st,
             end: ed,
             topics: topics && topics.length > 0 ? topics.join(',') : undefined,
+            includeAvgSampleCost: includeAvgSampleCost ? 'true' : undefined,
         })
         navigate(url)
     }
@@ -516,7 +517,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                                                 selectedTopics.length > 0
                                                     ? selectedTopics.join(',')
                                                     : undefined,
-                                            includeAvgSampleCost: next ? undefined : 'false',
+                                            includeAvgSampleCost: next ? 'true' : undefined,
                                         })
                                         navigate(url)
                                     }}

--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -3,7 +3,7 @@ import { SelectChangeEvent } from '@mui/material/Select'
 import { debounce } from 'lodash'
 import * as React from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
-import { Button, Card, Dropdown, Grid, Message } from 'semantic-ui-react'
+import { Button, Card, Checkbox, Dropdown, Grid, Message } from 'semantic-ui-react'
 
 import { PaddedPage } from '../../shared/components/Layout/PaddedPage'
 import LoadingDucks from '../../shared/components/LoadingDucks/LoadingDucks'
@@ -54,6 +54,11 @@ const BillingCostByMonth: React.FunctionComponent = () => {
     // Topic filtering state
     const [selectedTopics, setSelectedTopics] = React.useState<string[]>(initialTopics)
     const [availableTopics, setAvailableTopics] = React.useState<string[]>([])
+
+    // Toggle to include/exclude Avg Sample Cost (Est.) rows in the table and exports
+    const [includeAvgSampleCost, setIncludeAvgSampleCost] = React.useState<boolean>(
+        searchParams.get('includeAvgSampleCost') !== 'false'
+    )
 
     // use navigate and update url params
     const location = useLocation()
@@ -338,6 +343,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                         data={data}
                         months={months}
                         orderedTopics={getOrderedTopics()}
+                        includeAvgSampleCost={includeAvgSampleCost}
                     />
                 </Card>
             </>
@@ -408,25 +414,29 @@ const BillingCostByMonth: React.FunctionComponent = () => {
             ]
             matrix.push(storageRow)
 
-            const sampleCostStorageRow: [string, string, ...string[]] = [
-                topic,
-                CloudSpendCategory.SAMPLE_STORAGE_COST.toString(),
-                ...months.map((m) => {
-                    const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_STORAGE_COST]
-                    return val === undefined ? '' : val.toFixed(2)
-                }),
-            ]
-            matrix.push(sampleCostStorageRow)
+            // Only include Avg. Sample Cost rows when the user opts in. The All Topics row
+            // never has these values, matching the table view.
+            if (includeAvgSampleCost && topic !== 'All Topics') {
+                const sampleCostStorageRow: [string, string, ...string[]] = [
+                    topic,
+                    CloudSpendCategory.SAMPLE_STORAGE_COST.toString(),
+                    ...months.map((m) => {
+                        const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_STORAGE_COST]
+                        return val === undefined ? '' : val.toFixed(2)
+                    }),
+                ]
+                matrix.push(sampleCostStorageRow)
 
-            const sampleComputeCostRow: [string, string, ...string[]] = [
-                topic,
-                CloudSpendCategory.SAMPLE_COMPUTE_COST.toString(),
-                ...months.map((m) => {
-                    const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_COMPUTE_COST]
-                    return val === undefined ? '' : val.toFixed(2)
-                }),
-            ]
-            matrix.push(sampleComputeCostRow)
+                const sampleComputeCostRow: [string, string, ...string[]] = [
+                    topic,
+                    CloudSpendCategory.SAMPLE_COMPUTE_COST.toString(),
+                    ...months.map((m) => {
+                        const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_COMPUTE_COST]
+                        return val === undefined ? '' : val.toFixed(2)
+                    }),
+                ]
+                matrix.push(sampleComputeCostRow)
+            }
         })
 
         exportTable(
@@ -536,6 +546,28 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                         />
                     </Grid.Column>
                 </Grid>
+
+                <div style={{ marginTop: '15px' }}>
+                    <Checkbox
+                        toggle
+                        label="Include Avg. Sample Cost (Est.) rows"
+                        checked={includeAvgSampleCost}
+                        onChange={(_, { checked }) => {
+                            const next = Boolean(checked)
+                            setIncludeAvgSampleCost(next)
+                            const url = generateUrl(location, {
+                                start,
+                                end,
+                                topics:
+                                    selectedTopics.length > 0
+                                        ? selectedTopics.join(',')
+                                        : undefined,
+                                includeAvgSampleCost: next ? undefined : 'false',
+                            })
+                            navigate(url)
+                        }}
+                    />
+                </div>
             </Card>
 
             {messageComponent()}

--- a/web/src/pages/billing/components/BillingCostByMonthTable.tsx
+++ b/web/src/pages/billing/components/BillingCostByMonthTable.tsx
@@ -36,6 +36,7 @@ interface IBillingCostByMonthTableProps {
     data: DataDict
     months: string[]
     orderedTopics: string[]
+    includeAvgSampleCost?: boolean
 }
 
 const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableProps> = ({
@@ -45,6 +46,7 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
     data,
     months,
     orderedTopics,
+    includeAvgSampleCost = true,
 }) => {
     if (isLoading) {
         return (
@@ -53,12 +55,14 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
             </div>
         )
     }
-    const compTypes = [
-        'Compute Cost',
-        'Storage Cost',
-        'Avg. Sample Storage Cost (Est.)',
-        'Avg. Sample Compute Cost (Est.)',
-    ]
+    const compTypes = includeAvgSampleCost
+        ? [
+              'Compute Cost',
+              'Storage Cost',
+              'Avg. Sample Storage Cost (Est.)',
+              'Avg. Sample Compute Cost (Est.)',
+          ]
+        : ['Compute Cost', 'Storage Cost']
 
     // Get all topics in the order they were provided
     const getAllTopics = () => {

--- a/web/src/pages/billing/components/BillingCostByMonthTable.tsx
+++ b/web/src/pages/billing/components/BillingCostByMonthTable.tsx
@@ -46,7 +46,7 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
     data,
     months,
     orderedTopics,
-    includeAvgSampleCost = true,
+    includeAvgSampleCost = false,
 }) => {
     if (isLoading) {
         return (


### PR DESCRIPTION
## Summary

Adds a toggle on the **Cost Across Invoice Months (Topic only)** page (`/billing/costByMonth`) that lets users include or exclude the `Avg. Sample Storage Cost (Est.)` and `Avg. Sample Compute Cost (Est.)` rows in both the displayed table and CSV/TSV exports.

PM team currently deletes these rows from every export — this toggle removes that manual step.

## Behaviour

- New `Include Avg. Sample Cost (Est.) rows` toggle, rendered under the date/topic filters.
- Defaults to **on** so existing behaviour is preserved.
- When off, the two `Avg. Sample …` rows are hidden from the table *and* omitted from CSV / TSV exports.
- Setting persists in the URL (`?includeAvgSampleCost=false`) so users can bookmark/share their preferred view.
- All-Topics row is unchanged (it never carried the Avg. Sample Cost values).

## Files

- `web/src/pages/billing/BillingCostByMonth.tsx`
- `web/src/pages/billing/components/BillingCostByMonthTable.tsx`

## Test plan

- [x] Load `/billing/costByMonth`; confirm Avg. Sample Storage/Compute rows render by default
- [x] Toggle off; confirm the two Avg. Sample rows disappear from the table and the URL gains `includeAvgSampleCost=false`
- [x] Export to CSV with toggle off — confirm the exported file contains only `Compute Cost` and `Storage Cost` rows per topic
- [x] Export to TSV with toggle on — confirm Avg. Sample rows are present (unchanged behaviour)
- [x] Reload page with `?includeAvgSampleCost=false` in URL; confirm toggle initialises to off