### PR TITLE
[PG] `not-included-sample-ids` endpoint fix

### DIFF
--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -409,9 +409,9 @@ class AnalysisTable(DbBase):
 
         _query = t"""
             SELECT sg.id as id
-            FROM sequencing_group sg
-            WHERE sg.project = {project_id} AND
-                id NOT IN (
+            FROM sequencing_group sg INNER JOIN sample s ON sg.sample_id = s.id
+            WHERE s.project = {project_id} AND
+                sg.id NOT IN (
                     SELECT a_sg.sequencing_group_id FROM analysis_sequencing_group a_sg
                     LEFT JOIN analysis a ON a_sg.analysis_id = a.id
                     WHERE a.type = LOWER({analysis_type.lower()}) AND a.active

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -490,3 +490,24 @@ class TestAnalysis:
         assert len(analyses) == 1
         assert analyses[0].id == analysis_id
         assert not analyses[0].active
+
+    @pytest.mark.project_roles(['reader', 'writer'])
+    async def test_get_sg_without_given_type(self):
+        """
+        Test getting an analysis by id
+        """
+        analysis_id = await self.al.create_analysis(
+            AnalysisInternal(
+                type='cram',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[self.genome_sequencing_group_id],
+                meta={'sequencing_type': 'genome', 'size': 1024},
+            )
+        )
+
+        analysis = await self.al.get_analysis_by_id(analysis_id)
+        assert analysis.id == analysis_id
+        
+        sg_without_type = await self.al.get_all_sequencing_group_ids_without_analysis_type(self.project_id, 'cram')
+        assert len(sg_without_type) == 1
+        assert sg_without_type[0] == self.exome_sequencing_group_id

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -494,7 +494,7 @@ class TestAnalysis:
     @pytest.mark.project_roles(['reader', 'writer'])
     async def test_get_sg_without_given_type(self):
         """
-        Test getting an analysis by id
+        Test getting sequencing group IDs whose associated analysis is not of a given type
         """
         analysis_id = await self.al.create_analysis(
             AnalysisInternal(

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -507,7 +507,11 @@ class TestAnalysis:
 
         analysis = await self.al.get_analysis_by_id(analysis_id)
         assert analysis.id == analysis_id
-        
-        sg_without_type = await self.al.get_all_sequencing_group_ids_without_analysis_type(self.project_id, 'cram')
+
+        sg_without_type = (
+            await self.al.get_all_sequencing_group_ids_without_analysis_type(
+                self.project_id, 'cram'
+            )
+        )
         assert len(sg_without_type) == 1
         assert sg_without_type[0] == self.exome_sequencing_group_id


### PR DESCRIPTION
The query for this endpoint was attempting to access a column that didn't exist on the `sequencing_group` table. This PR adds a `JOIN` statement to allow the information to be accessed.