### PR TITLE
[PG] fix `latest-complete` endpoint

### DIFF
--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -349,7 +349,7 @@ class AnalysisTable(DbBase):
         meta_query = t''
         if meta:
             for k, v in meta.items():
-                meta_query += t" AND meta::json->>{k} = {v}"
+                meta_query += t' AND meta::json->>{k} = {v}'
 
         _query = t"""
             SELECT a.id as id, a.type as type, a.status as status,

--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -347,15 +347,15 @@ class AnalysisTable(DbBase):
         """Find the most recent completed analysis for some analysis type"""
         values = {'project': project, 'type': analysis_type}
 
-        meta_str = ''
+        meta_query = t''
         if meta:
             for k, v in meta.items():
-                k_replacer = f'meta_{k}'
-                meta_str += f" AND json_extract(meta, '$.{k}') = :{k_replacer}"
-                if v is None:
-                    # mariadb does a bad cast for NULL
-                    v = 'null'  # noqa: PLW2901
-                values[k_replacer] = v
+                # k_replacer = f'meta_{k}'
+                meta_query += t" AND json_extract(meta, '$.{k}') = {v}"
+                # if v is None:
+                #     # mariadb does a bad cast for NULL
+                #     v = 'null'  # noqa: PLW2901
+                # values[k_replacer] = v
 
         _query = t"""
             SELECT a.id as id, a.type as type, a.status as status,
@@ -367,7 +367,7 @@ class AnalysisTable(DbBase):
             INNER JOIN sequencing_group sg ON a_sg.sequencing_group_id = sg.id
             WHERE a.id = (
                 SELECT id FROM analysis
-                WHERE active AND type = LOWER({analysis_type.lower()}) AND project = {project} AND status = 'completed' AND timestamp_completed IS NOT NULL {meta_str}
+                WHERE active AND type = LOWER({analysis_type.lower()}) AND project = {project} AND status = 'completed' AND timestamp_completed IS NOT NULL {meta_query:q}
                 ORDER BY timestamp_completed DESC
                 LIMIT 1
             )

--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -349,7 +349,10 @@ class AnalysisTable(DbBase):
         meta_query = t''
         if meta:
             for k, v in meta.items():
-                meta_query += t' AND meta::json->>{k} = {v}'
+                if v is None:
+                    meta_query += t' AND meta::json->>{k} IS NULL'    
+                else:
+                    meta_query += t' AND meta::json->>{k} = {v}'
 
         _query = t"""
             SELECT a.id as id, a.type as type, a.status as status,

--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -351,7 +351,7 @@ class AnalysisTable(DbBase):
         if meta:
             for k, v in meta.items():
                 # k_replacer = f'meta_{k}'
-                meta_query += t" AND json_extract(meta, '$.{k}') = {v}"
+                meta_query += t" AND meta::json->>{k} = {v}"
                 # if v is None:
                 #     # mariadb does a bad cast for NULL
                 #     v = 'null'  # noqa: PLW2901

--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -345,17 +345,11 @@ class AnalysisTable(DbBase):
         meta: dict[str, Any] | None = None,
     ):
         """Find the most recent completed analysis for some analysis type"""
-        values = {'project': project, 'type': analysis_type}
 
         meta_query = t''
         if meta:
             for k, v in meta.items():
-                # k_replacer = f'meta_{k}'
                 meta_query += t" AND meta::json->>{k} = {v}"
-                # if v is None:
-                #     # mariadb does a bad cast for NULL
-                #     v = 'null'  # noqa: PLW2901
-                # values[k_replacer] = v
 
         _query = t"""
             SELECT a.id as id, a.type as type, a.status as status,

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -494,7 +494,7 @@ class TestAnalysis:
     @pytest.mark.project_roles(['reader', 'writer'])
     async def test_get_latest_complete_analysis(self):
         """
-        Test getting an analysis by id
+        Test getting the most recently completed analysis' id
         """
         analysis_first_id = await self.al.create_analysis(
             AnalysisInternal(

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -490,3 +490,33 @@ class TestAnalysis:
         assert len(analyses) == 1
         assert analyses[0].id == analysis_id
         assert not analyses[0].active
+
+    @pytest.mark.project_roles(['reader', 'writer'])
+    async def test_get_analysis_by_id(self):
+        """
+        Test getting an analysis by id
+        """
+        analysis_first_id = await self.al.create_analysis(
+            AnalysisInternal(
+                type='cram',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[self.genome_sequencing_group_id],
+                meta={'sequencing_type': 'genome', 'size': 1024},
+                timestamp_completed=datetime(2025, 12, 31)
+            )
+        )
+
+        analysis_last_id = await self.al.create_analysis(
+            AnalysisInternal(
+                type='cram',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[self.exome_sequencing_group_id],
+                meta={'sequencing_type': 'genome', 'size': 1024},
+                timestamp_completed=datetime(2026, 1, 1)
+            )
+        )
+
+        assert analysis_first_id != analysis_last_id
+
+        latest_complete = await self.al.get_latest_complete_analysis_for_type(self.project_id, 'cram')
+        assert latest_complete.id == analysis_last_id

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -496,7 +496,7 @@ class TestAnalysis:
         """
         Test getting the most recently completed analysis' id
         """
-        analysis_first_id = await self.al.create_analysis(
+        analysis_first = await self.al.create_analysis(
             AnalysisInternal(
                 type='cram',
                 status=AnalysisStatus.COMPLETED,
@@ -506,19 +506,35 @@ class TestAnalysis:
             )
         )
 
-        analysis_last_id = await self.al.create_analysis(
+        # This analysis is not the absolutel last to be completed, but it is the last that matches
+        # the meta filtering criteria, so it should be selected
+        analysis_last_matching_meta = await self.al.create_analysis(
+            AnalysisInternal(
+                type='cram',
+                status=AnalysisStatus.COMPLETED,
+                sequencing_group_ids=[self.exome_sequencing_group_id],
+                meta={'sequencing_type': 'genome', 'size': None},
+                timestamp_completed=datetime(2026, 1, 1),
+            )
+        )
+
+        # This is the absolute last to be completed, but its meta does not match the filter
+        # so it should not be selected
+        analysis_last = await self.al.create_analysis(
             AnalysisInternal(
                 type='cram',
                 status=AnalysisStatus.COMPLETED,
                 sequencing_group_ids=[self.exome_sequencing_group_id],
                 meta={'sequencing_type': 'genome', 'size': 1024},
-                timestamp_completed=datetime(2026, 1, 1),
+                timestamp_completed=datetime(2026, 1, 2),
             )
         )
 
-        assert analysis_first_id != analysis_last_id
+        assert analysis_last_matching_meta != analysis_first
+        assert analysis_last_matching_meta != analysis_last
 
         latest_complete = await self.al.get_latest_complete_analysis_for_type(
-            self.project_id, 'cram'
+            self.project_id, 'cram', {'sequencing_type': 'genome', 'size': None}
         )
-        assert latest_complete.id == analysis_last_id
+
+        assert latest_complete.id == analysis_last_matching_meta

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -492,7 +492,7 @@ class TestAnalysis:
         assert not analyses[0].active
 
     @pytest.mark.project_roles(['reader', 'writer'])
-    async def test_get_analysis_by_id(self):
+    async def test_get_latest_complete_analysis(self):
         """
         Test getting an analysis by id
         """
@@ -502,7 +502,7 @@ class TestAnalysis:
                 status=AnalysisStatus.COMPLETED,
                 sequencing_group_ids=[self.genome_sequencing_group_id],
                 meta={'sequencing_type': 'genome', 'size': 1024},
-                timestamp_completed=datetime(2025, 12, 31)
+                timestamp_completed=datetime(2025, 12, 31),
             )
         )
 
@@ -512,11 +512,13 @@ class TestAnalysis:
                 status=AnalysisStatus.COMPLETED,
                 sequencing_group_ids=[self.exome_sequencing_group_id],
                 meta={'sequencing_type': 'genome', 'size': 1024},
-                timestamp_completed=datetime(2026, 1, 1)
+                timestamp_completed=datetime(2026, 1, 1),
             )
         )
 
         assert analysis_first_id != analysis_last_id
 
-        latest_complete = await self.al.get_latest_complete_analysis_for_type(self.project_id, 'cram')
+        latest_complete = await self.al.get_latest_complete_analysis_for_type(
+            self.project_id, 'cram'
+        )
         assert latest_complete.id == analysis_last_id


### PR DESCRIPTION
The query for this endpoint was still using MariaDB conventions. This PR updates the query and surrounding code to work with postgres.