### PR TITLE
Allow internet ingress add uri

### DIFF
--- a/deploy/infra/server.py
+++ b/deploy/infra/server.py
@@ -57,9 +57,9 @@ def create_server_resources(
     cloud_run = gcp.cloudrunv2.Service(
         'metamist',
         name=f'metamist-{config.stack}',
-        ingress='INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER',
+        ingress='INGRESS_TRAFFIC_ALL',
         location=config.region,
-        default_uri_disabled=True,
+        default_uri_disabled=False,
         template=gcp.cloudrunv2.ServiceTemplateArgs(
             service_account=service_account.email,
             timeout='300s',


### PR DESCRIPTION
Allow internet ingress to Cloud Run api service

This feature is currently enabled on our production sample-metadata-api cloud run function. The reasoning for this being enabled is to have an SSO free endpoint for our cloud run function metamist-dev in the analysis runner to be able to make requests to the metamist api.

The cloud run invoker permissions are still required to be able to invoke the cloud run function. The public url does not allow unauthenticated invocations, but it does allow invocations from any source that has the correct permissions.

In this case, the sample-metadata@analysis-runner service account that runs the cloud function in the analysis-runner project has been granted invoker permissions on the metamist-development cloud run function as a one-time setup.

Below is the exiting setup in sample-metadata-api. This pulumi code change will reflect the same settings in metamist-development.

<img width="1326" height="475" alt="Screenshot 2026-05-21 at 4 49 52 pm" src="https://github.com/user-attachments/assets/6c60ac4f-9656-428e-b94a-baa0f0d187a4" />
