### PR TITLE
Support multi-SG-type samples in create_test_subset.py

### DIFF
--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -234,11 +234,12 @@ def get_sids_by_random_sampling(
     logger.info(f'Querying all samples in {project}')
     sid_output = query(SG_ID_QUERY, variables={'project': project})
 
-    # all_sids here is a set of all internal IDs in the project, minus any we already selected
+    # all_sids here is a set of all internal IDs in the project, minus any we already selected.
+    # Samples with no active sequencing groups are skipped — nothing to transfer.
     all_sids = {
         sid['id']
         for sid in sid_output.get('project').get('samples')
-        if sid.get('sequencingGroups')  # skip samples with no active SGs — nothing to transfer
+        if sid.get('sequencingGroups')
     } - samples_so_far
 
     logger.info(
@@ -249,7 +250,7 @@ def get_sids_by_random_sampling(
     return random.sample(sorted(all_sids), sample_count)
 
 
-def main(
+def main(  # noqa: PLR0913
     project: str,
     samples_n: int,
     families_n: int,
@@ -1135,7 +1136,7 @@ def extra_file_commands(batch, job, new_path: str):
         batch.write_output(job.new_md5, new_path)
 
 
-def copy_files_in_dict(
+def copy_files_in_dict(  # noqa: PLR0911
     d,
     dataset: str,
     sid_replacement: tuple[str, str] = None,
@@ -1207,7 +1208,9 @@ def copy_files_in_dict(
     if isinstance(d, list):
         return [copy_files_in_dict(x, dataset, skip_gcs=skip_gcs) for x in d]
     if isinstance(d, dict):
-        return {k: copy_files_in_dict(v, dataset, skip_gcs=skip_gcs) for k, v in d.items()}
+        return {
+            k: copy_files_in_dict(v, dataset, skip_gcs=skip_gcs) for k, v in d.items()
+        }
     return d
 
 

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -236,7 +236,9 @@ def get_sids_by_random_sampling(
 
     # all_sids here is a set of all internal IDs in the project, minus any we already selected
     all_sids = {
-        sid['id'] for sid in sid_output.get('project').get('samples')
+        sid['id']
+        for sid in sid_output.get('project').get('samples')
+        if sid.get('sequencingGroups')  # skip samples with no active SGs — nothing to transfer
     } - samples_so_far
 
     logger.info(

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -257,12 +257,15 @@ def main(
     cohorts: set[str],
     skip_ped: bool,
     update_embedded_ids: bool,
+    local_mode: bool = False,
+    dry_run: bool = False,
 ):
     """
     Script creates a test subset for a given project.
     A new project with a suffix -test is created, and for any files in sample/meta,
     sequence/meta, or analysis/output a copy in the -test namespace is created.
     """
+    skip_gcs = local_mode or dry_run
     if not any(
         [additional_families, additional_samples, samples_n, families_n, cohorts]
     ):
@@ -333,16 +336,31 @@ def main(
         upserted_participant_map = transfer_participants(
             target_project=target_project,
             participant_data=participant_data,
+            dry_run=dry_run,
         )
 
     else:
         logger.info(f'Transferring {len(participant_data)} participants. ')
         family_ids = transfer_families(
-            project, target_project, internal_participant_ids
+            project, target_project, internal_participant_ids, dry_run=dry_run
         )
-        upserted_participant_map = transfer_ped(project, target_project, family_ids)
+        upserted_participant_map = transfer_ped(
+            project,
+            target_project,
+            family_ids,
+            participant_data=participant_data,
+            dry_run=dry_run,
+        )
 
     existing_data = query(EXISTING_DATA_QUERY, {'project': target_project})
+
+    # Skipping GCS means no real files to reheader; disable the Hail Batch jobs.
+    if skip_gcs and update_embedded_ids:
+        logger.info(
+            '--local-mode / --dry-run: disabling --update-embedded-ids '
+            '(no real files to reheader)'
+        )
+        update_embedded_ids = False
 
     # Create batch if needed for running header updating jobs
     if update_embedded_ids:
@@ -360,6 +378,8 @@ def main(
         upserted_participant_map=upserted_participant_map,
         target_project=target_project,
         project=project,
+        skip_gcs=skip_gcs,
+        dry_run=dry_run,
     )
 
     logger.info('Transferring analyses')
@@ -371,6 +391,8 @@ def main(
         old_sid_to_new_sid,
         sample_to_sg_attribute_map,
         update_embedded_ids,
+        skip_gcs=skip_gcs,
+        dry_run=dry_run,
     )
     logger.info('Subset generation complete!')
 
@@ -385,6 +407,8 @@ def transfer_samples_sgs_assays(
     upserted_participant_map: dict[str, int],
     target_project: str,
     project: str,
+    skip_gcs: bool = False,
+    dry_run: bool = False,
 ):
     """
     Transfer samples, sequencing groups, and assays from the original project to the
@@ -411,30 +435,39 @@ def transfer_samples_sgs_assays(
 
         existing_pid: int | None = None
         if s['participant']:
-            existing_pid = upserted_participant_map[s['participant']['externalId']]
+            existing_pid = upserted_participant_map.get(s['participant']['externalId'])
 
         sample_upsert = SampleUpsert(
             external_ids=s['externalIds'],
             type=sample_type or None,
-            meta=(copy_files_in_dict(s['meta'], project) or {}),
+            meta=(copy_files_in_dict(s['meta'], project, skip_gcs=skip_gcs) or {}),
             participant_id=existing_pid,
-            sequencing_groups=upsert_sequencing_groups(s, existing_data, project),
+            sequencing_groups=upsert_sequencing_groups(
+                s, existing_data, project, skip_gcs=skip_gcs
+            ),
             id=existing_sid,
         )
 
         logger.info(f'Processing sample {s["id"]}')
-        logger.info('Creating test sample entry')
-        new_sample_id = sapi.create_sample(
-            project=target_project,
-            sample_upsert=sample_upsert,
-        )
+        if dry_run:
+            logger.info(
+                f'[dry-run] Would sapi.create_sample(project={target_project!r}): {sample_upsert}'
+            )
+            # Placeholder so downstream path-rewrites still work; old==new for dry-run.
+            new_sample_id = s['id']
+        else:
+            logger.info('Creating test sample entry')
+            new_sample_id = sapi.create_sample(
+                project=target_project,
+                sample_upsert=sample_upsert,
+            )
         old_sid_to_new_sid[s['id']] = new_sample_id
 
     return old_sid_to_new_sid, sample_to_sg_attribute_map
 
 
 def upsert_sequencing_groups(
-    sample: dict, existing_data: dict, project: str
+    sample: dict, existing_data: dict, project: str, skip_gcs: bool = False
 ) -> list[SequencingGroupUpsert]:
     """Create SG Upsert Objects for a sample"""
     sgs_to_upsert: list[SequencingGroupUpsert] = []
@@ -451,7 +484,12 @@ def upsert_sequencing_groups(
             technology=sg.get('technology'),
             type=sg.get('type'),
             assays=upsert_assays(
-                sg, existing_sgid, existing_data, sample.get('externalId'), project
+                sg,
+                existing_sgid,
+                existing_data,
+                sample.get('externalId'),
+                project,
+                skip_gcs=skip_gcs,
             ),
         )
         sgs_to_upsert.append(sg_upsert)
@@ -465,6 +503,7 @@ def upsert_assays(
     existing_data: dict,
     sample_external_id,
     project: str,
+    skip_gcs: bool = False,
 ) -> list[AssayUpsert]:
     """Create Assay Upsert Objects for a sequencing group"""
     print(sg)
@@ -481,7 +520,7 @@ def upsert_assays(
             type=assay.get('type'),
             id=existing_assay_id,
             external_ids=assay.get('externalIds') or {},
-            meta=copy_files_in_dict(assay.get('meta'), project),
+            meta=copy_files_in_dict(assay.get('meta'), project, skip_gcs=skip_gcs),
         )
 
         assays_to_upsert.append(assay_upsert)
@@ -561,11 +600,36 @@ def transfer_analyses(
     old_sid_to_new_sid: dict[str, str],
     sample_to_sg_attribute_map: dict[tuple, dict[tuple, str]],
     update_embedded_ids: bool,
+    skip_gcs: bool = False,
+    dry_run: bool = False,
 ):
     """
     This function will transfer the analyses from the original project to the test project.
     """
-    new_sg_data = query(SG_ID_QUERY, {'project': target_project})
+    if dry_run:
+        # Target has no new SGs in dry-run; reuse source IDs as the "new" ids.
+        new_sg_data = {
+            'project': {
+                'samples': [
+                    {
+                        'id': old_sid_to_new_sid.get(s['id'], s['id']),
+                        'externalId': s['externalId'],
+                        'sequencingGroups': [
+                            {
+                                'id': sg['id'],
+                                'type': sg['type'],
+                                'platform': sg['platform'],
+                                'technology': sg['technology'],
+                            }
+                            for sg in s['sequencingGroups']
+                        ],
+                    }
+                    for s in samples
+                ]
+            }
+        }
+    else:
+        new_sg_data = query(SG_ID_QUERY, {'project': target_project})
 
     for s in samples:
         for sg in s['sequencingGroups']:
@@ -608,6 +672,7 @@ def transfer_analyses(
                             project,
                             (str(sg['id']), new_sequencing_group_id[0]),
                             update_embedded_ids,
+                            skip_gcs=skip_gcs,
                         ),
                         status=AnalysisStatus(
                             analysis['status'].lower().replace('_', '-')
@@ -615,10 +680,15 @@ def transfer_analyses(
                         sequencing_group_ids=new_sequencing_group_id,
                         meta=analysis['meta'],
                     )
-                    aapi.update_analysis(
-                        analysis_id=existing_analysis_id,
-                        analysis_update_model=am,
-                    )
+                    if dry_run:
+                        logger.info(
+                            f'[dry-run] Would aapi.update_analysis(analysis_id={existing_analysis_id}): {am}'
+                        )
+                    else:
+                        aapi.update_analysis(
+                            analysis_id=existing_analysis_id,
+                            analysis_update_model=am,
+                        )
                 else:
                     am = Analysis(
                         type=analysis['type'],
@@ -627,6 +697,7 @@ def transfer_analyses(
                             project,
                             (str(sg['id']), new_sequencing_group_id[0]),
                             update_embedded_ids,
+                            skip_gcs=skip_gcs,
                         ),
                         status=AnalysisStatus(
                             analysis['status'].lower().replace('_', '-')
@@ -635,8 +706,15 @@ def transfer_analyses(
                         meta=analysis['meta'],
                     )
 
-                    logger.info(f'Creating {analysis["type"]}analysis entry in test')
-                    aapi.create_analysis(project=target_project, analysis=am)
+                    if dry_run:
+                        logger.info(
+                            f'[dry-run] Would aapi.create_analysis(project={target_project!r}): {am}'
+                        )
+                    else:
+                        logger.info(
+                            f'Creating {analysis["type"]} analysis entry in test'
+                        )
+                        aapi.create_analysis(project=target_project, analysis=am)
 
 
 def get_existing_sample(data: dict, sample_id: str) -> dict | None:
@@ -795,7 +873,10 @@ def get_sids_for_cohorts(
 
 
 def transfer_families(
-    initial_project: str, target_project: str, internal_participant_ids: list[int]
+    initial_project: str,
+    target_project: str,
+    internal_participant_ids: list[int],
+    dry_run: bool = False,
 ) -> list[int]:
     """Pull relevant families from the input project, and copy to target_project"""
     family_data = query(
@@ -831,14 +912,24 @@ def transfer_families(
                 ]
             )
 
-    with open(tmp_family_tsv) as family_file:  # noqa: PTH123
-        fapi.import_families(file=family_file, project=target_project)
+    if dry_run:
+        with open(tmp_family_tsv) as family_file:  # noqa: PTH123
+            logger.info(
+                f'[dry-run] Would fapi.import_families(project={target_project!r}) with TSV:\n{family_file.read()}'
+            )
+    else:
+        with open(tmp_family_tsv) as family_file:  # noqa: PTH123
+            fapi.import_families(file=family_file, project=target_project)
 
     return family_ids
 
 
 def transfer_ped(
-    initial_project: str, target_project: str, family_ids: list[int]
+    initial_project: str,
+    target_project: str,
+    family_ids: list[int],
+    participant_data: list[dict] | None = None,
+    dry_run: bool = False,
 ) -> dict[str, int]:
     """Pull pedigree from the input project, and copy to target_project"""
     ped_tsv = fapi.get_pedigree(
@@ -850,6 +941,17 @@ def transfer_ped(
     # Work-around as import_pedigree takes a file.
     with open(tmp_ped_tsv, 'w') as tmp_ped:  # noqa: PTH123
         tmp_ped.write(ped_tsv)
+
+    if dry_run:
+        logger.info(
+            f'[dry-run] Would fapi.import_pedigree(project={target_project!r}) with TSV:\n{ped_tsv}'
+        )
+        # Target has no participants in dry-run; reuse source IDs.
+        return {
+            alt_id: participant['id']
+            for participant in (participant_data or [])
+            for alt_id in participant['externalIds'].values()
+        }
 
     with open(tmp_ped_tsv) as ped_file:  # noqa: PTH123
         fapi.import_pedigree(
@@ -871,6 +973,7 @@ def transfer_ped(
 def transfer_participants(
     target_project: str,
     participant_data,
+    dry_run: bool = False,
 ) -> dict[str, int]:
     """Transfers relevant participants between projects"""
 
@@ -902,6 +1005,19 @@ def transfer_participants(
             }
             # Participants are being created before the samples are, so this will be empty for now.
             participants_to_transfer.append(transfer_participant)
+
+    if dry_run:
+        logger.info(
+            f'[dry-run] Would papi.upsert_participants(project={target_project!r}) with {len(participants_to_transfer)} participants:'
+        )
+        for p in participants_to_transfer:
+            logger.info(f'[dry-run]   {p}')
+        # Reuse source IDs as placeholders.
+        return {
+            alt_id: participant['id']
+            for participant in participant_data
+            for alt_id in participant['externalIds'].values()
+        }
 
     upserted_participants = papi.upsert_participants(
         target_project, participant_upsert=participants_to_transfer
@@ -1021,21 +1137,20 @@ def copy_files_in_dict(
     dataset: str,
     sid_replacement: tuple[str, str] = None,
     update_embedded_ids: bool = False,
+    skip_gcs: bool = False,
 ):
     """
     Replaces all `gs://cpg-{project}-main*/` paths
     into `gs://cpg-{project}-test*/` and creates copies if needed
     If `d` is dict or list, recursively calls this function on every element
     If `d` is str, replaces the path
+
+    `skip_gcs` rewrites the path but skips all GCS calls.
     """
     if not d:
         return d
     if isinstance(d, str) and d.startswith(f'gs://cpg-{dataset}-main'):
-        logger.info(f'Looking for analysis file {d}')
         old_path = d
-        if not file_exists(old_path):
-            logger.warning(f'File {old_path} does not exist')
-            return d
         new_path = old_path.replace(
             f'gs://cpg-{dataset}-main', f'gs://cpg-{dataset}-test'
         )
@@ -1043,6 +1158,15 @@ def copy_files_in_dict(
         # With the new internal sample ID from the test project
         if sid_replacement is not None:
             new_path = new_path.replace(sid_replacement[0], sid_replacement[1])
+
+        if skip_gcs:
+            logger.info(f'[skip-gcs] Would rewrite {old_path} -> {new_path}')
+            return new_path
+
+        logger.info(f'Looking for analysis file {old_path}')
+        if not file_exists(old_path):
+            logger.warning(f'File {old_path} does not exist')
+            return d
 
         job = None
 
@@ -1078,9 +1202,9 @@ def copy_files_in_dict(
                 logger.error(f'{new_path} already exists')
         return new_path
     if isinstance(d, list):
-        return [copy_files_in_dict(x, dataset) for x in d]
+        return [copy_files_in_dict(x, dataset, skip_gcs=skip_gcs) for x in d]
     if isinstance(d, dict):
-        return {k: copy_files_in_dict(v, dataset) for k, v in d.items()}
+        return {k: copy_files_in_dict(v, dataset, skip_gcs=skip_gcs) for k, v in d.items()}
     return d
 
 
@@ -1159,6 +1283,16 @@ if __name__ == '__main__':
         help='Update IDs embedded within CRAM and VCF files (on by default)',
         default=True,
     )
+    parser.add_argument(
+        '--local-mode',
+        action='store_true',
+        help='Skip GCS calls; still upsert to metamist.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Implies --local-mode; log metamist upserts without executing them.',
+    )
     args, fail = parser.parse_known_args()
     if fail:
         parser.print_help()
@@ -1174,4 +1308,6 @@ if __name__ == '__main__':
         skip_ped=args.skip_ped,
         cohorts=set(args.cohorts),
         update_embedded_ids=args.update_embedded_ids,
+        local_mode=args.local_mode,
+        dry_run=args.dry_run,
     )

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -269,6 +269,17 @@ def main(  # noqa: PLR0913
     sequence/meta, or analysis/output a copy in the -test namespace is created.
     """
     skip_gcs = local_mode or dry_run
+
+    # --local-mode is for seeding a local metamist instance only. Refuse otherwise so we
+    # don't accidentally write subset records into a non-local instance with no real
+    # files behind them.
+    if local_mode:
+        sm_environment = os.environ.get('SM_ENVIRONMENT', '').lower()
+        if sm_environment != 'local':
+            raise RuntimeError(
+                f'--local-mode requires SM_ENVIRONMENT=local, got {sm_environment!r}.'
+            )
+
     if not any(
         [additional_families, additional_samples, samples_n, families_n, cohorts]
     ):
@@ -1297,12 +1308,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--local-mode',
         action='store_true',
-        help='Skip GCS calls; still upsert to metamist.',
+        help='Run against a local metamist instance only (requires SM_ENVIRONMENT=local). Skips GCS calls.',
     )
     parser.add_argument(
         '--dry-run',
         action='store_true',
-        help='Implies --local-mode; log metamist upserts without executing them.',
+        help='Log metamist writes without executing them. Skips GCS calls. Safe against any environment.',
     )
     args, fail = parser.parse_known_args()
     if fail:

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -913,10 +913,9 @@ def transfer_families(
             )
 
     if dry_run:
-        with open(tmp_family_tsv) as family_file:  # noqa: PTH123
-            logger.info(
-                f'[dry-run] Would fapi.import_families(project={target_project!r}) with TSV:\n{family_file.read()}'
-            )
+        logger.info(
+            f'[dry-run] Would fapi.import_families(project={target_project!r}) with {len(families)} families'
+        )
     else:
         with open(tmp_family_tsv) as family_file:  # noqa: PTH123
             fapi.import_families(file=family_file, project=target_project)
@@ -943,10 +942,10 @@ def transfer_ped(
         tmp_ped.write(ped_tsv)
 
     if dry_run:
+        ped_row_count = max(0, ped_tsv.count('\n') - 1)
         logger.info(
-            f'[dry-run] Would fapi.import_pedigree(project={target_project!r}) with TSV:\n{ped_tsv}'
+            f'[dry-run] Would fapi.import_pedigree(project={target_project!r}) with {ped_row_count} pedigree rows across {len(family_ids)} families'
         )
-        # Target has no participants in dry-run; reuse source IDs.
         return {
             alt_id: participant['id']
             for participant in (participant_data or [])
@@ -1012,10 +1011,8 @@ def transfer_participants(
 
     if dry_run:
         logger.info(
-            f'[dry-run] Would papi.upsert_participants(project={target_project!r}) with {len(participants_to_transfer)} participants:'
+            f'[dry-run] Would papi.upsert_participants(project={target_project!r}) with {len(participants_to_transfer)} participants'
         )
-        for p in participants_to_transfer:
-            logger.info(f'[dry-run]   {p}')
         # Reuse source IDs as placeholders.
         return {
             alt_id: participant['id']

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -79,11 +79,12 @@ QUERY_ALL_DATA = gql(
                         meta
                         type
                     }
-                    analyses(type: {in_: ["cram", "gvcf"]}) {
+                    analyses(type: {in_: ["cram", "gvcf", "genotypingarray_gtc"]}) {
                         active
                         id
                         meta
                         output
+                        outputs
                         status
                         timestampCompleted
                         type
@@ -566,13 +567,6 @@ def transfer_analyses(
     """
     new_sg_data = query(SG_ID_QUERY, {'project': target_project})
 
-    new_sg_map = {}
-    for s in new_sg_data.get('project').get('samples'):
-        sg_ids: list = []
-        for sg in s.get('sequencingGroups'):
-            sg_ids.append(sg.get('id'))
-        new_sg_map[s.get('externalId')] = sg_ids
-
     for s in samples:
         for sg in s['sequencingGroups']:
             new_sg_attributes = sg.get('type'), sg.get('platform'), sg.get('technology')
@@ -591,6 +585,13 @@ def transfer_analyses(
             )
             existing_sgid = existing_sg.get('id') if existing_sg else None
             for analysis in sg['analyses']:
+                # Newer analyses store the path in the structured `outputs` field;
+                # older ones use the plain `output` string. Prefer the former.
+                analysis_path = (
+                    analysis['outputs'].get('path')
+                    if isinstance(analysis.get('outputs'), dict)
+                    else None
+                ) or analysis['output']
                 existing_analysis: dict = {}
                 if existing_sgid:
                     existing_analysis = get_existing_analysis(
@@ -603,15 +604,15 @@ def transfer_analyses(
                     am = AnalysisUpdateModel(
                         type=analysis['type'],
                         output=copy_files_in_dict(
-                            analysis['output'],
+                            analysis_path,
                             project,
-                            (str(sg['id']), new_sg_map[s['externalId']][0]),
+                            (str(sg['id']), new_sequencing_group_id[0]),
                             update_embedded_ids,
                         ),
                         status=AnalysisStatus(
                             analysis['status'].lower().replace('_', '-')
                         ),
-                        sequencing_group_ids=new_sg_map[s['externalId']],
+                        sequencing_group_ids=new_sequencing_group_id,
                         meta=analysis['meta'],
                     )
                     aapi.update_analysis(
@@ -622,9 +623,9 @@ def transfer_analyses(
                     am = Analysis(
                         type=analysis['type'],
                         output=copy_files_in_dict(
-                            analysis['output'],
+                            analysis_path,
                             project,
-                            (str(sg['id']), new_sg_map[s['externalId']][0]),
+                            (str(sg['id']), new_sequencing_group_id[0]),
                             update_embedded_ids,
                         ),
                         status=AnalysisStatus(

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -317,14 +317,19 @@ def main(  # noqa: PLR0913
         QUERY_ALL_DATA, {'project': project, 'sids': list(additional_samples)}
     )
 
-    # Pull Participant Data
-    participant_data = []
-    internal_participant_ids: list = []
-    for sg in original_project_subset_data.get('project').get('samples', []):
-        participant = sg.get('participant')
+    # Pull Participant Data. One donor can have multiple samples (e.g. a whole-blood
+    # sample and a PBMC sample), so two of the returned samples can point at the same
+    # participant. Keying by participant id keeps one entry per participant. If a
+    # participant shows up twice, both copies hold the same data, so overwriting is
+    # safe — but it does happen silently, with no warning.
+    participants_by_id: dict[int, dict] = {}
+    for sample in original_project_subset_data.get('project').get('samples', []):
+        participant = sample.get('participant')
         if participant:
-            participant_data.append(participant)
-            internal_participant_ids.append(participant.get('id'))
+            participants_by_id[participant['id']] = participant
+
+    participant_data = list(participants_by_id.values())
+    internal_participant_ids: list[int] = list(participants_by_id.keys())
 
     # Populating test project
     target_project = project + '-test'

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -45,6 +45,71 @@ aapi = AnalysisApi()
 fapi = FamilyApi()
 papi = ParticipantApi()
 
+
+class DryRunAnalysisApi(AnalysisApi):
+    """Dry-run AnalysisApi that merely logs update methods."""
+
+    def create_analysis(self, project, analysis):
+        logger.info(f'[dry-run] Would aapi.create_analysis({project=}): {analysis}')
+
+    def update_analysis(self, analysis_id, analysis_update_model):
+        logger.info(
+            f'[dry-run] Would aapi.update_analysis({analysis_id=}): {analysis_update_model}'
+        )
+
+
+class DryRunFamilyApi(FamilyApi):
+    """Dry-run FamilyApi that merely logs update methods."""
+
+    def import_families(self, file, project):
+        families = file.readlines()
+        logger.info(
+            f'[dry-run] Would fapi.import_families({project=}) with {len(families)} families'
+        )
+
+    def import_pedigree(self, file, has_header, project, create_missing_participants):  # noqa: ARG002
+        ped_row_count = max(0, file.read().count('\n') - 1)
+        logger.info(
+            f'[dry-run] Would fapi.import_pedigree({project=}) with {ped_row_count} pedigree rows'
+        )
+
+
+class DryRunParticipantApi(ParticipantApi):
+    """Dry-run ParticipantApi that merely logs update methods."""
+
+    def __init__(self):
+        super().__init__()
+        self.count = 100000
+
+    def _new_id(self, pid):
+        if pid:
+            return pid
+        self.count += 1
+        return self.count
+
+    def upsert_participants(self, project, participant_upsert):
+        logger.info(
+            f'[dry-run] Would papi.upsert_participants({project=}) with {len(participant_upsert)} participants'
+        )
+        # Return with >100000 placeholder ids for "newly created" participants
+        return [{**p, 'id': self._new_id(p.get('id'))} for p in participant_upsert]
+
+
+class DryRunSampleApi(SampleApi):
+    """Dry-run SampleApi that merely logs update methods."""
+
+    def __init__(self):
+        super().__init__()
+        self.count = 0
+
+    def create_sample(self, project, sample_upsert):
+        logger.info(f'[dry-run] Would sapi.create_sample({project=}): {sample_upsert}')
+        if sample_upsert.id is not None:
+            return sample_upsert.id
+        self.count += 1
+        return f'NEWSAMPLE{self.count}'
+
+
 DEFAULT_SAMPLES_N = 10
 
 PRIMARY_EXTERNAL_ORG = ''
@@ -268,6 +333,14 @@ def main(  # noqa: PLR0913
     A new project with a suffix -test is created, and for any files in sample/meta,
     sequence/meta, or analysis/output a copy in the -test namespace is created.
     """
+    if dry_run:
+        # Replace FooApi globals with dry-run versions that merely log updates.
+        global sapi, aapi, fapi, papi  # noqa: PLW0603
+        sapi = DryRunSampleApi()
+        aapi = DryRunAnalysisApi()
+        fapi = DryRunFamilyApi()
+        papi = DryRunParticipantApi()
+
     skip_gcs = local_mode or dry_run
 
     # --local-mode is for seeding a local metamist instance only. Refuse otherwise so we
@@ -355,20 +428,17 @@ def main(  # noqa: PLR0913
         upserted_participant_map = transfer_participants(
             target_project=target_project,
             participant_data=participant_data,
-            dry_run=dry_run,
         )
 
     else:
         logger.info(f'Transferring {len(participant_data)} participants. ')
         family_ids = transfer_families(
-            project, target_project, internal_participant_ids, dry_run=dry_run
+            project, target_project, internal_participant_ids
         )
         upserted_participant_map = transfer_ped(
             project,
             target_project,
             family_ids,
-            participant_data=participant_data,
-            dry_run=dry_run,
         )
 
     existing_data = query(EXISTING_DATA_QUERY, {'project': target_project})
@@ -398,7 +468,6 @@ def main(  # noqa: PLR0913
         target_project=target_project,
         project=project,
         skip_gcs=skip_gcs,
-        dry_run=dry_run,
     )
 
     logger.info('Transferring analyses')
@@ -427,7 +496,6 @@ def transfer_samples_sgs_assays(
     target_project: str,
     project: str,
     skip_gcs: bool = False,
-    dry_run: bool = False,
 ):
     """
     Transfer samples, sequencing groups, and assays from the original project to the
@@ -468,18 +536,11 @@ def transfer_samples_sgs_assays(
         )
 
         logger.info(f'Processing sample {s["id"]}')
-        if dry_run:
-            logger.info(
-                f'[dry-run] Would sapi.create_sample(project={target_project!r}): {sample_upsert}'
-            )
-            # Placeholder so downstream path-rewrites still work; old==new for dry-run.
-            new_sample_id = s['id']
-        else:
-            logger.info('Creating test sample entry')
-            new_sample_id = sapi.create_sample(
-                project=target_project,
-                sample_upsert=sample_upsert,
-            )
+        logger.info('Creating test sample entry')
+        new_sample_id = sapi.create_sample(
+            project=target_project,
+            sample_upsert=sample_upsert,
+        )
         old_sid_to_new_sid[s['id']] = new_sample_id
 
     return old_sid_to_new_sid, sample_to_sg_attribute_map
@@ -699,15 +760,10 @@ def transfer_analyses(
                         sequencing_group_ids=new_sequencing_group_id,
                         meta=analysis['meta'],
                     )
-                    if dry_run:
-                        logger.info(
-                            f'[dry-run] Would aapi.update_analysis(analysis_id={existing_analysis_id}): {am}'
-                        )
-                    else:
-                        aapi.update_analysis(
-                            analysis_id=existing_analysis_id,
-                            analysis_update_model=am,
-                        )
+                    aapi.update_analysis(
+                        analysis_id=existing_analysis_id,
+                        analysis_update_model=am,
+                    )
                 else:
                     am = Analysis(
                         type=analysis['type'],
@@ -725,15 +781,8 @@ def transfer_analyses(
                         meta=analysis['meta'],
                     )
 
-                    if dry_run:
-                        logger.info(
-                            f'[dry-run] Would aapi.create_analysis(project={target_project!r}): {am}'
-                        )
-                    else:
-                        logger.info(
-                            f'Creating {analysis["type"]} analysis entry in test'
-                        )
-                        aapi.create_analysis(project=target_project, analysis=am)
+                    logger.info(f'Creating {analysis["type"]} analysis entry in test')
+                    aapi.create_analysis(project=target_project, analysis=am)
 
 
 def get_existing_sample(data: dict, sample_id: str) -> dict | None:
@@ -895,7 +944,6 @@ def transfer_families(
     initial_project: str,
     target_project: str,
     internal_participant_ids: list[int],
-    dry_run: bool = False,
 ) -> list[int]:
     """Pull relevant families from the input project, and copy to target_project"""
     family_data = query(
@@ -931,13 +979,8 @@ def transfer_families(
                 ]
             )
 
-    if dry_run:
-        logger.info(
-            f'[dry-run] Would fapi.import_families(project={target_project!r}) with {len(families)} families'
-        )
-    else:
-        with open(tmp_family_tsv) as family_file:  # noqa: PTH123
-            fapi.import_families(file=family_file, project=target_project)
+    with open(tmp_family_tsv) as family_file:  # noqa: PTH123
+        fapi.import_families(file=family_file, project=target_project)
 
     return family_ids
 
@@ -946,8 +989,6 @@ def transfer_ped(
     initial_project: str,
     target_project: str,
     family_ids: list[int],
-    participant_data: list[dict] | None = None,
-    dry_run: bool = False,
 ) -> dict[str, int]:
     """Pull pedigree from the input project, and copy to target_project"""
     ped_tsv = fapi.get_pedigree(
@@ -960,17 +1001,6 @@ def transfer_ped(
     with open(tmp_ped_tsv, 'w') as tmp_ped:  # noqa: PTH123
         tmp_ped.write(ped_tsv)
 
-    if dry_run:
-        ped_row_count = max(0, ped_tsv.count('\n') - 1)
-        logger.info(
-            f'[dry-run] Would fapi.import_pedigree(project={target_project!r}) with {ped_row_count} pedigree rows across {len(family_ids)} families'
-        )
-        return {
-            alt_id: participant['id']
-            for participant in (participant_data or [])
-            for alt_id in participant['externalIds'].values()
-        }
-
     with open(tmp_ped_tsv) as ped_file:  # noqa: PTH123
         fapi.import_pedigree(
             file=ped_file,
@@ -978,6 +1008,8 @@ def transfer_ped(
             project=target_project,
             create_missing_participants=True,
         )
+
+    # TODO Special-case for dry_run if we want to see SampleUpsert participant_id values.
 
     # Get map of external participant id to internal
     participant_output = query(PARTICIPANT_QUERY, {'project': target_project})
@@ -991,7 +1023,6 @@ def transfer_ped(
 def transfer_participants(
     target_project: str,
     participant_data,
-    dry_run: bool = False,
 ) -> dict[str, int]:
     """Transfers relevant participants between projects"""
 
@@ -1027,17 +1058,6 @@ def transfer_participants(
                 'samples': [],
             }
         )
-
-    if dry_run:
-        logger.info(
-            f'[dry-run] Would papi.upsert_participants(project={target_project!r}) with {len(participants_to_transfer)} participants'
-        )
-        # Reuse source IDs as placeholders.
-        return {
-            alt_id: participant['id']
-            for participant in participant_data
-            for alt_id in participant['externalIds'].values()
-        }
 
     upserted_participants = papi.upsert_participants(
         target_project, participant_upsert=participants_to_transfer

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -315,7 +315,7 @@ def get_sids_by_random_sampling(
     return random.sample(sorted(all_sids), sample_count)
 
 
-def main(  # noqa: PLR0913
+def main(
     project: str,
     samples_n: int,
     families_n: int,
@@ -325,7 +325,6 @@ def main(  # noqa: PLR0913
     cohorts: set[str],
     skip_ped: bool,
     update_embedded_ids: bool,
-    local_mode: bool = False,
     dry_run: bool = False,
 ):
     """
@@ -341,17 +340,9 @@ def main(  # noqa: PLR0913
         fapi = DryRunFamilyApi()
         papi = DryRunParticipantApi()
 
-    skip_gcs = local_mode or dry_run
-
-    # --local-mode is for seeding a local metamist instance only. Refuse otherwise so we
-    # don't accidentally write subset records into a non-local instance with no real
-    # files behind them.
-    if local_mode:
-        sm_environment = os.environ.get('SM_ENVIRONMENT', '').lower()
-        if sm_environment != 'local':
-            raise RuntimeError(
-                f'--local-mode requires SM_ENVIRONMENT=local, got {sm_environment!r}.'
-            )
+    # Skip GCS when seeding a local instance (no real files) or doing a dry-run.
+    sm_environment = os.environ.get('SM_ENVIRONMENT', '').lower()
+    skip_gcs = (sm_environment == 'local') or dry_run
 
     if not any(
         [additional_families, additional_samples, samples_n, families_n, cohorts]
@@ -446,7 +437,7 @@ def main(  # noqa: PLR0913
     # Skipping GCS means no real files to reheader; disable the Hail Batch jobs.
     if skip_gcs and update_embedded_ids:
         logger.info(
-            '--local-mode / --dry-run: disabling --update-embedded-ids '
+            'SM_ENVIRONMENT == "local" / --dry-run: disabling --update-embedded-ids '
             '(no real files to reheader)'
         )
         update_embedded_ids = False
@@ -1326,11 +1317,6 @@ if __name__ == '__main__':
         default=True,
     )
     parser.add_argument(
-        '--local-mode',
-        action='store_true',
-        help='Run against a local metamist instance only (requires SM_ENVIRONMENT=local). Skips GCS calls.',
-    )
-    parser.add_argument(
         '--dry-run',
         action='store_true',
         help='Log metamist writes without executing them. Skips GCS calls. Safe against any environment.',
@@ -1350,6 +1336,5 @@ if __name__ == '__main__':
         skip_ped=args.skip_ped,
         cohorts=set(args.cohorts),
         update_embedded_ids=args.update_embedded_ids,
-        local_mode=args.local_mode,
         dry_run=args.dry_run,
     )

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -987,24 +987,28 @@ def transfer_participants(
 
     participants_to_transfer = []
     for participant in participant_data:
-        for alt_id in participant['externalIds'].values():
-            if alt_id in target_project_pid_map:
-                # Participants with id field will be updated & those without will be inserted
-                participant['id'] = target_project_pid_map[alt_id]
-            else:
-                del participant['id']
-            transfer_participant = {
+        # Match a single target participant if any of this source participant's
+        # external_ids already exists there; otherwise leave id None to insert.
+        target_id = next(
+            (
+                target_project_pid_map[alt_id]
+                for alt_id in participant['externalIds'].values()
+                if alt_id in target_project_pid_map
+            ),
+            None,
+        )
+        participants_to_transfer.append(
+            {
                 'external_ids': participant['externalIds'],
                 'meta': participant.get('meta') or {},
                 'karyotype': participant.get('karyotype'),
                 'reported_gender': participant.get('reportedGender'),
                 'reported_sex': participant.get('reportedSex'),
                 'phenotypes': participant.get('phenotypes'),
-                'id': participant.get('id'),
+                'id': target_id,
                 'samples': [],
             }
-            # Participants are being created before the samples are, so this will be empty for now.
-            participants_to_transfer.append(transfer_participant)
+        )
 
     if dry_run:
         logger.info(


### PR DESCRIPTION
## Summary
- Pull every sequencing group (and its assays + analyses) for each selected sample, so test subsets can include co-located SG types — specifically WGS + genotyping array on the same sample.
- Fix `transfer_analyses` to attach each analysis to the SG matched by `(type, platform, technology)` instead of the arbitrary first SG of the sample (the previous behaviour produced wrong `sequencing_group_ids` on the update path and wrong SG-id substitution in the rewritten file path).
- Source analysis paths from `outputs.path` (the structured field) with a fallback to the legacy `output` string, so newer-style records — including the `genotypingarray_gtc` analyses on array SGs whose `output` is empty — aren't silently dropped on transfer.
- Widen the analyses-type filter on `QUERY_ALL_DATA` to `["cram", "gvcf", "genotypingarray_gtc"]`.

## Context
Needed to produce local test data for [single_sample_qc_popgen#13](https://github.com/populationgenomics/single_sample_qc_popgen/pull/13), which compares WGS and genotyping-array SGs for the same sample.

## Test plan
- [ ] Run locally against a real source project: confirm both genome and genotypingarray SGs (plus assays) land in `-test` for a sample that has both.
- [ ] Confirm CRAM/gVCF and GTC files are copied to `gs://cpg-<project>-test/...` and that each new analysis is attached to the correct SG (not both).
- [ ] Confirm the rewritten file paths use the correct new SG id per analysis (no cross-wiring between genome and array).

🤖 Generated with [Claude Code](https://claude.com/claude-code)