### PR TITLE
SET 1103 - [PG] Sequencing groups upsert does not insert new assays

### DIFF
--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -243,11 +243,6 @@ class SequencingGroupLayer(BaseLayer):
                     to_update.append(sg)
                     continue
 
-                # if we need to insert any assays, then the group will have to change
-                if any(not assay.id for assay in sg.assays):
-                    to_replace.append(sg)
-                    continue
-
                 assert sg.id is not None
                 existing_sequences = set(sequence_to_group.get(int(sg.id), []))
                 new_assay_ids = set(sq.id for sq in sg.assays)
@@ -276,7 +271,7 @@ class SequencingGroupLayer(BaseLayer):
             )
 
         for sg in to_replace:
-            await self.recreate_sequencing_group_with_new_assays(
+            sg.id = await self.recreate_sequencing_group_with_new_assays(
                 sequencing_group_id=int(ensure_nonnone(sg.id)),
                 assays=[s.id for s in sg.assays] if sg.assays else [],
                 meta=sg.meta or {},

--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -271,6 +271,7 @@ class SequencingGroupLayer(BaseLayer):
             )
 
         for sg in to_replace:
+            # Ensure that all assays have been correctly added to the DB
             new_assay_ids = []
             for assay in sg.assays or []:
                 if assay.id is None:
@@ -278,6 +279,7 @@ class SequencingGroupLayer(BaseLayer):
                         'Attempting to replace sequencing-group using non-existent assays'
                     )
                 new_assay_ids.append(assay.id)
+            # Recreate the sequencing group with the new assays in the DB
             sg.id = await self.recreate_sequencing_group_with_new_assays(
                 sequencing_group_id=int(ensure_nonnone(sg.id)),
                 assays=new_assay_ids,

--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -271,9 +271,16 @@ class SequencingGroupLayer(BaseLayer):
             )
 
         for sg in to_replace:
+            new_assay_ids = []
+            for assay in sg.assays or []:
+                if assay.id is None:
+                    raise ValueError(
+                        'Attempting to replace sequencing-group using non-existent assays'
+                    )
+                new_assay_ids.append(assay.id)
             sg.id = await self.recreate_sequencing_group_with_new_assays(
                 sequencing_group_id=int(ensure_nonnone(sg.id)),
-                assays=[s.id for s in sg.assays] if sg.assays else [],
+                assays=new_assay_ids,
                 meta=sg.meta or {},
             )
 

--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -271,18 +271,10 @@ class SequencingGroupLayer(BaseLayer):
             )
 
         for sg in to_replace:
-            # Ensure that all assays have been correctly added to the DB
-            new_assay_ids = []
-            for assay in sg.assays or []:
-                if assay.id is None:
-                    raise ValueError(
-                        'Attempting to replace sequencing-group using non-existent assays'
-                    )
-                new_assay_ids.append(assay.id)
             # Recreate the sequencing group with the new assays in the DB
             sg.id = await self.recreate_sequencing_group_with_new_assays(
                 sequencing_group_id=int(ensure_nonnone(sg.id)),
-                assays=new_assay_ids,
+                assays=[ensure_nonnone(a.id) for a in sg.assays] if sg.assays else [],
                 meta=sg.meta or {},
             )
 

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -421,10 +421,10 @@ class SequencingGroupTable(DbBase):
                 assay_id_insert_values = [
                     {
                         'seqgroup': new_sg_id['id'],
-                        'assayid': s,
+                        'assayid': a_id,
                         'audit_log_id': await self.audit_log_id(),
                     }
-                    for s in assay_ids
+                    for a_id in assay_ids
                 ]
                 async with conn.cursor() as cur:
                     await cur.executemany(_sg_assay_linker, assay_id_insert_values)

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -216,8 +216,8 @@ class TestSequencingGroup:
             [initial_sg_id]
         )
         new_sg_assays = await a_layer.get_assays_for_sequencing_group_ids([new_sg_id])
-        old_sg_assays_ids = set([a.id for a in old_sg_assays[initial_sg_id]])
-        new_sg_assays_ids = set([a.id for a in new_sg_assays[new_sg_id]])
+        old_sg_assays_ids = set(a.id for a in old_sg_assays[initial_sg_id])
+        new_sg_assays_ids = set(a.id for a in new_sg_assays[new_sg_id])
         assert len(old_sg_assays_ids) == 1
         assert (
             len(new_sg_assays_ids) == 2

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -7,7 +7,7 @@ from psycopg import sql
 
 from db.python.connect import Connection
 from db.python.filters import GenericFilter
-from db.python.layers import SampleLayer, SequencingGroupLayer
+from db.python.layers import AssayLayer, SampleLayer, SequencingGroupLayer
 from db.python.tables.sequencing_group import (
     SequencingGroupFilter,
     SequencingGroupTable,
@@ -157,6 +157,68 @@ class TestSequencingGroup:
         sg_from_db = await sg_layer.get_sequencing_group_by_id(initial_sg[0].id)
 
         assert sg_from_db.meta == {'another-meta': 'field', 'meta-key': 'meta-value'}
+
+    @pytest.mark.asyncio
+    @pytest.mark.project_roles(['writer'])
+    async def test_update_with_new_assays(
+        self,
+        connection_with_project: Connection,
+        sequencing_group_model: SequencingGroupUpsertInternal,
+        test_sample: int,
+    ):
+        """Test updating metadata on a sequencing group"""
+        sg_layer = SequencingGroupLayer(connection_with_project)
+        a_layer = AssayLayer(connection_with_project)
+        # Create the initial SG
+        initial_sg = await sg_layer.upsert_sequencing_groups([sequencing_group_model])
+        initial_sg_id = initial_sg[0].id
+        assert initial_sg_id
+        assert initial_sg[0].assays
+        assert initial_sg[0].assays[0].id
+
+        # Create an updated model for upsert
+        upsert_sg_model = SequencingGroupUpsertInternal(
+            id=initial_sg[0].id,
+            sample_id=test_sample,
+            assays=[
+                AssayUpsertInternal(
+                    id=initial_sg[0].assays[0].id,
+                    type='sequencing',
+                    external_ids={},
+                    meta={
+                        'sequencing_type': 'genome',
+                        'sequencing_platform': 'short-read',
+                        'sequencing_technology': 'illumina',
+                    },
+                ),
+                AssayUpsertInternal(
+                    type='sequencing',
+                    external_ids={},
+                    meta={
+                        'sequencing_type': 'exome',
+                        'sequencing_platform': 'short-read',
+                        'sequencing_technology': 'illumina',
+                    },
+                )
+            ],
+        )
+
+        # When updating the assays of an existing sequencing group, the sg is archived and a new
+        # copy is created with the updated assays
+        # Check that the sequencing group is given a new ID
+        new_sg = await sg_layer.upsert_sequencing_groups([upsert_sg_model])
+        new_sg_id = new_sg[0].id
+        assert new_sg_id
+        assert new_sg_id != initial_sg_id
+
+        # Check that the first assay belongs to both the old and new sequencing group
+        old_sg_assays = (await a_layer.get_assays_for_sequencing_group_ids([initial_sg_id]))
+        new_sg_assays = (await a_layer.get_assays_for_sequencing_group_ids([new_sg_id]))
+        old_sg_assays_ids = set([a.id for a in old_sg_assays[initial_sg_id]])
+        new_sg_assays_ids = set([a.id for a in new_sg_assays[new_sg_id]])
+        assert len(old_sg_assays_ids) == 1
+        assert len(new_sg_assays_ids) == 2 # Using sets ensures that the sg has two unique assays
+        assert old_sg_assays_ids.intersection(new_sg_assays_ids) == {initial_sg[0].assays[0].id}
 
     @pytest.mark.asyncio
     @pytest.mark.project_roles(['writer'])

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -199,7 +199,7 @@ class TestSequencingGroup:
                         'sequencing_platform': 'short-read',
                         'sequencing_technology': 'illumina',
                     },
-                )
+                ),
             ],
         )
 
@@ -212,13 +212,19 @@ class TestSequencingGroup:
         assert new_sg_id != initial_sg_id
 
         # Check that the first assay belongs to both the old and new sequencing group
-        old_sg_assays = (await a_layer.get_assays_for_sequencing_group_ids([initial_sg_id]))
-        new_sg_assays = (await a_layer.get_assays_for_sequencing_group_ids([new_sg_id]))
+        old_sg_assays = await a_layer.get_assays_for_sequencing_group_ids(
+            [initial_sg_id]
+        )
+        new_sg_assays = await a_layer.get_assays_for_sequencing_group_ids([new_sg_id])
         old_sg_assays_ids = set([a.id for a in old_sg_assays[initial_sg_id]])
         new_sg_assays_ids = set([a.id for a in new_sg_assays[new_sg_id]])
         assert len(old_sg_assays_ids) == 1
-        assert len(new_sg_assays_ids) == 2 # Using sets ensures that the sg has two unique assays
-        assert old_sg_assays_ids.intersection(new_sg_assays_ids) == {initial_sg[0].assays[0].id}
+        assert (
+            len(new_sg_assays_ids) == 2
+        )  # Using sets ensures that the sg has two unique assays
+        assert old_sg_assays_ids.intersection(new_sg_assays_ids) == {
+            initial_sg[0].assays[0].id
+        }
 
     @pytest.mark.asyncio
     @pytest.mark.project_roles(['writer'])

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -216,8 +216,8 @@ class TestSequencingGroup:
             [initial_sg_id]
         )
         new_sg_assays = await a_layer.get_assays_for_sequencing_group_ids([new_sg_id])
-        old_sg_assays_ids = set(a.id for a in old_sg_assays[initial_sg_id])
-        new_sg_assays_ids = set(a.id for a in new_sg_assays[new_sg_id])
+        old_sg_assays_ids = {a.id for a in old_sg_assays[initial_sg_id]}
+        new_sg_assays_ids = {a.id for a in new_sg_assays[new_sg_id]}
         assert len(old_sg_assays_ids) == 1
         assert (
             len(new_sg_assays_ids) == 2


### PR DESCRIPTION
The behavior of sequencing groups when being upserted is unclear when looking at some of the code in the `upsert_sequencing_groups` layer function. What should happen is that the existing sequencing group is archived and the upsert assays are attached to a new SG.
This PR removes logic that obfuscates this functionality. Additionally a test has been added to ensure functionality is as expected when modifying a sequencing group's assays.