### PR TITLE
SET-1046 Add Total column to Cost Across Invoice Months (Topic only)

### DIFF
--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -438,7 +438,6 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                         const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_STORAGE_COST]
                         return val === undefined ? '' : val.toFixed(2)
                     }),
-                    categoryTotal(topic, CloudSpendCategory.SAMPLE_STORAGE_COST),
                 ]
                 matrix.push(sampleCostStorageRow)
 
@@ -449,7 +448,6 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                         const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_COMPUTE_COST]
                         return val === undefined ? '' : val.toFixed(2)
                     }),
-                    categoryTotal(topic, CloudSpendCategory.SAMPLE_COMPUTE_COST),
                 ]
                 matrix.push(sampleComputeCostRow)
             }

--- a/web/src/pages/billing/BillingCostByMonth.tsx
+++ b/web/src/pages/billing/BillingCostByMonth.tsx
@@ -383,7 +383,11 @@ const BillingCostByMonth: React.FunctionComponent = () => {
     const exportToFile = (format: 'csv' | 'tsv') => {
         // Export all topics
         const allTopics = getOrderedTopics()
-        const headerFields = ['Topic', 'Cost Type', ...months]
+        const headerFields = ['Topic', 'Cost Type', ...months, 'Total']
+
+        // Sum a category across all exported months for a topic (the row total).
+        const categoryTotal = (topic: string, category: CloudSpendCategory): string =>
+            months.reduce((sum, m) => sum + (data[topic]?.[m]?.[category] ?? 0), 0).toFixed(2)
 
         const matrix: string[][] = []
 
@@ -395,6 +399,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                     const val = data[topic]?.[m]?.[CloudSpendCategory.COMPUTE_COST]
                     return val === undefined ? '' : val.toFixed(2)
                 }),
+                categoryTotal(topic, CloudSpendCategory.COMPUTE_COST),
             ]
             matrix.push(computeRow)
 
@@ -405,6 +410,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                     const val = data[topic]?.[m]?.[CloudSpendCategory.STORAGE_COST]
                     return val === undefined ? '' : val.toFixed(2)
                 }),
+                categoryTotal(topic, CloudSpendCategory.STORAGE_COST),
             ]
             matrix.push(storageRow)
 
@@ -415,6 +421,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                     const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_STORAGE_COST]
                     return val === undefined ? '' : val.toFixed(2)
                 }),
+                categoryTotal(topic, CloudSpendCategory.SAMPLE_STORAGE_COST),
             ]
             matrix.push(sampleCostStorageRow)
 
@@ -425,6 +432,7 @@ const BillingCostByMonth: React.FunctionComponent = () => {
                     const val = data[topic]?.[m]?.[CloudSpendCategory.SAMPLE_COMPUTE_COST]
                     return val === undefined ? '' : val.toFixed(2)
                 }),
+                categoryTotal(topic, CloudSpendCategory.SAMPLE_COMPUTE_COST),
             ]
             matrix.push(sampleComputeCostRow)
         })

--- a/web/src/pages/billing/components/BillingCostByMonthTable.tsx
+++ b/web/src/pages/billing/components/BillingCostByMonthTable.tsx
@@ -65,6 +65,10 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
         return orderedTopics
     }
 
+    // Sum a single row (topic + compute type) across all visible invoice months.
+    const rowTotal = (key: string, compType: string): number =>
+        months.reduce((sum, month) => sum + (data[key]?.[month]?.[compType] ?? 0), 0)
+
     const dataToBody = (data: DataDict) => {
         const allTopics = getAllTopics()
 
@@ -89,6 +93,9 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
                                         : null}
                                 </SUITable.Cell>
                             ))}
+                            <SUITable.Cell key={`${key}-${index}-total`}>
+                                <b>{formatMoney(rowTotal(key, compType))}</b>
+                            </SUITable.Cell>
                         </SUITable.Row>
                     )
                 )}
@@ -110,6 +117,7 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
                         <SUITable.HeaderCell colSpan={months.length}>
                             Invoice Month
                         </SUITable.HeaderCell>
+                        <SUITable.HeaderCell></SUITable.HeaderCell>
                     </SUITable.Row>
                     <SUITable.Row>
                         <SUITable.HeaderCell>Topic</SUITable.HeaderCell>
@@ -119,6 +127,7 @@ const BillingCostByMonthTable: React.FunctionComponent<IBillingCostByMonthTableP
                                 {date2Month(month)}
                             </SUITable.HeaderCell>
                         ))}
+                        <SUITable.HeaderCell>Total</SUITable.HeaderCell>
                     </SUITable.Row>
                 </SUITable.Header>
                 <SUITable.Body>{dataToBody(data)}</SUITable.Body>


### PR DESCRIPTION
## Summary

The PM team requested a per-row summary on the **Cost Across Invoice Months (Topic only)** report (`/billing/costByMonth`). This adds a final **Total** column that sums each row across all visible invoice months.

## Changes

- **`BillingCostByMonthTable.tsx`** (on-screen table)
  - New `rowTotal(key, compType)` helper — null-safe sum of `data[key][month][compType]` across all months.
  - Added a bold `Total` cell as the last cell of every body row.
  - Added the matching `Total` header, plus a spacer cell in the top "Invoice Month" header row to keep columns aligned.
- **`BillingCostByMonth.tsx`** (CSV/TSV export)
  - Added `'Total'` to the header fields and a `categoryTotal()` helper, appending the per-row total to all four exported row types so the export mirrors the table exactly.

Existing behaviour preserved: the synthetic "All Topics" row and the Avg. Sample Cost row-skipping logic are unchanged.

## Testing

- ESLint: clean on both files.
- `tsc`: 14 errors on clean `dev` vs 14 with these changes — identical, and none in the edited regions. The pre-existing errors are in unrelated billing files (`BillingCostBySample`, `BillingHome`, `SequencingGroupsByMonth`) plus a stale `sm-api` model mismatch — not introduced here.