### PR TITLE
SET 1097 - [PG] sequencing groups upsert does not handle external ids

### DIFF
--- a/db/python/layers/sequencing_group.py
+++ b/db/python/layers/sequencing_group.py
@@ -173,6 +173,7 @@ class SequencingGroupLayer(BaseLayer):
                 technology=ensure_nonnone(seqgroup.technology),
                 platform=ensure_nonnone(seqgroup.platform),
                 meta={**seqgroup.meta, **meta} if seqgroup.meta else meta,
+                external_ids=seqgroup.external_ids,
                 assay_ids=assays,
             )
 
@@ -267,6 +268,7 @@ class SequencingGroupLayer(BaseLayer):
                 technology=ensure_nonnone(sg.technology),
                 platform=ensure_nonnone(sg.platform),
                 meta=sg.meta,
+                external_ids=sg.external_ids,
                 assay_ids=assay_ids,
             )
 

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -425,7 +425,7 @@ class SequencingGroupTable(DbBase):
             new_sg_id = await cur.fetchone()
             if not new_sg_id:
                 raise InternalError('A new sequencing_group row was not created')
-            
+
             if external_ids:
                 eid_values = [
                     {

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Mapping
 from datetime import date
 from string.templatelib import Template
 
@@ -357,7 +358,7 @@ class SequencingGroupTable(DbBase):
         technology: str,
         platform: str,
         assay_ids: list[int],
-        external_ids: dict[str, str] | None = None,
+        external_ids: Mapping[str, str | None] | None = None,
         meta: dict | None = None,
     ) -> int:
         """Create sequence group"""
@@ -404,9 +405,9 @@ class SequencingGroupTable(DbBase):
 
         external_id_query = """
         INSERT INTO sequencing_group_external_id
-            (project, sequencing_group_id, external_id, name, null_if_archived, audit_log_id)
+            (project, sequencing_group_id, external_id, name, audit_log_id)
         VALUES
-            (%(project)s, %(sequencing_group_id)s, %(external_id)s, %(name)s, %(null_if_archived)s, %(audit_log_id)s)
+            (%(project)s, %(sequencing_group_id)s, %(external_id)s, %(name)s, %(audit_log_id)s)
         """
 
         _sg_assay_linker = """
@@ -429,7 +430,7 @@ class SequencingGroupTable(DbBase):
                 eid_values = [
                     {
                         'project': self.connection.project_id,
-                        'sequencing_group_id': new_sg_id,
+                        'sequencing_group_id': new_sg_id['id'],
                         'name': name.lower(),
                         'external_id': eid,
                         'audit_log_id': audit_log_id,

--- a/db/python/tables/sequencing_group.py
+++ b/db/python/tables/sequencing_group.py
@@ -357,6 +357,7 @@ class SequencingGroupTable(DbBase):
         technology: str,
         platform: str,
         assay_ids: list[int],
+        external_ids: dict[str, str] | None = None,
         meta: dict | None = None,
     ) -> int:
         """Create sequence group"""
@@ -401,6 +402,13 @@ class SequencingGroupTable(DbBase):
         RETURNING id;
         """
 
+        external_id_query = """
+        INSERT INTO sequencing_group_external_id
+            (project, sequencing_group_id, external_id, name, null_if_archived, audit_log_id)
+        VALUES
+            (%(project)s, %(sequencing_group_id)s, %(external_id)s, %(name)s, %(null_if_archived)s, %(audit_log_id)s)
+        """
+
         _sg_assay_linker = """
         INSERT INTO sequencing_group_assay
             (sequencing_group_id, assay_id, audit_log_id)
@@ -416,6 +424,21 @@ class SequencingGroupTable(DbBase):
             new_sg_id = await cur.fetchone()
             if not new_sg_id:
                 raise InternalError('A new sequencing_group row was not created')
+            
+            if external_ids:
+                eid_values = [
+                    {
+                        'project': self.connection.project_id,
+                        'sequencing_group_id': new_sg_id,
+                        'name': name.lower(),
+                        'external_id': eid,
+                        'audit_log_id': audit_log_id,
+                    }
+                    for name, eid in external_ids.items()
+                    if eid is not None
+                ]
+                async with conn.cursor() as cur:
+                    await cur.executemany(external_id_query, eid_values)
 
             if assay_ids:
                 assay_id_insert_values = [

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -62,7 +62,7 @@ def sequencing_group_model(test_sample: int) -> SequencingGroupUpsertInternal:
             'meta-key': 'meta-value',
         },
         sample_id=test_sample,
-        external_ids={'ext': 'some-ext-id'},
+        external_ids={'ext': 'some-ext-id', '': 'some-other-ext-id'},
         assays=[
             AssayUpsertInternal(
                 type='sequencing',
@@ -132,31 +132,6 @@ class TestSequencingGroup:
 
     @pytest.mark.asyncio
     @pytest.mark.project_roles(['writer'])
-    async def test_insert_sequencing_group_with_external_ids(
-        self,
-        connection_with_project: Connection,
-        test_sample: int,
-    ):
-        """Test that external IDs are properly attached during sequencing group upsert"""
-        sg_layer = SequencingGroupLayer(connection_with_project)
-
-        external_ids = {'ext1': 'test-external-id1', 'ext2': 'test-external-id2'}
-        sg_upsert = SequencingGroupUpsertInternal(
-            type='genome',
-            technology='short-read',
-            platform='ILLUMINA',
-            sample_id=test_sample,
-            external_ids=external_ids
-        )
-
-        new_sg = await sg_layer.upsert_sequencing_groups([sg_upsert])
-        assert new_sg[0].id is not None
-
-        sg = await sg_layer.get_sequencing_group_by_id(new_sg[0].id)
-        assert sg.external_ids == external_ids
-
-    @pytest.mark.asyncio
-    @pytest.mark.project_roles(['writer'])
     async def test_update_sequencing_group(
         self,
         connection_with_project: Connection,
@@ -182,6 +157,53 @@ class TestSequencingGroup:
         sg_from_db = await sg_layer.get_sequencing_group_by_id(initial_sg[0].id)
 
         assert sg_from_db.meta == {'another-meta': 'field', 'meta-key': 'meta-value'}
+
+    @pytest.mark.asyncio
+    @pytest.mark.project_roles(['writer'])
+    async def test_insert_sequencing_group_with_external_ids(
+        self,
+        connection_with_project: Connection,
+        sequencing_group_model: SequencingGroupUpsertInternal,
+    ):
+        """Test that external IDs are properly attached during sequencing group upsert"""
+        sg_layer = SequencingGroupLayer(connection_with_project)
+
+        # Test that external IDs are correctly attached to the sequencing group
+        initial_sg = await sg_layer.upsert_sequencing_groups([sequencing_group_model])
+        assert initial_sg[0].id is not None
+
+        sg = await sg_layer.get_sequencing_group_by_id(initial_sg[0].id)
+        assert sg.external_ids == initial_sg[0].external_ids
+
+        # Now test that when sequencing groups are recreated, the new sg has the same external IDs
+
+        # Recreate with new assays
+        updated_sg = SequencingGroupUpsertInternal(
+            id=initial_sg[0].id,
+            sample_id=sequencing_group_model.sample_id,
+            type='genome',
+            technology='short-read',
+            platform='ILLUMINA',
+            assays=[
+                AssayUpsertInternal(
+                    type='sequencing',
+                    external_ids={},
+                    meta={**DEFAULT_SEQUENCING_META, 'sequencing_type': 'exome'},
+                )
+            ],
+        )
+
+        updated_sg = await sg_layer.upsert_sequencing_groups([updated_sg])
+        assert updated_sg[0].id is not None
+        assert updated_sg[0].id != initial_sg[0].id
+
+        # Verify the old sg is archived
+        archived_sg = await sg_layer.get_sequencing_group_by_id(initial_sg[0].id)
+        assert archived_sg.archived
+
+        # Verify the new sg has same external IDs
+        new_sg = await sg_layer.get_sequencing_group_by_id(updated_sg[0].id)
+        assert new_sg.external_ids == initial_sg[0].external_ids
 
     @pytest.mark.asyncio
     @pytest.mark.project_roles(['writer'])

--- a/test/test_sequencing_groups.py
+++ b/test/test_sequencing_groups.py
@@ -132,6 +132,31 @@ class TestSequencingGroup:
 
     @pytest.mark.asyncio
     @pytest.mark.project_roles(['writer'])
+    async def test_insert_sequencing_group_with_external_ids(
+        self,
+        connection_with_project: Connection,
+        test_sample: int,
+    ):
+        """Test that external IDs are properly attached during sequencing group upsert"""
+        sg_layer = SequencingGroupLayer(connection_with_project)
+
+        external_ids = {'ext1': 'test-external-id1', 'ext2': 'test-external-id2'}
+        sg_upsert = SequencingGroupUpsertInternal(
+            type='genome',
+            technology='short-read',
+            platform='ILLUMINA',
+            sample_id=test_sample,
+            external_ids=external_ids
+        )
+
+        new_sg = await sg_layer.upsert_sequencing_groups([sg_upsert])
+        assert new_sg[0].id is not None
+
+        sg = await sg_layer.get_sequencing_group_by_id(new_sg[0].id)
+        assert sg.external_ids == external_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.project_roles(['writer'])
     async def test_update_sequencing_group(
         self,
         connection_with_project: Connection,


### PR DESCRIPTION
Though the sequencing group model has a field for external IDs, this is never used during upsert. This PR adds a query to insert the sequencing group's external IDs to the `sequencing_group_external_id` table. Additionally a test has been added to ensure that this functions as expected.