### PR TITLE
Increase GQL async client execute timeout and fix some scripts

### DIFF
--- a/packages/metamist/src/metamist/graphql/__init__.py
+++ b/packages/metamist/src/metamist/graphql/__init__.py
@@ -85,7 +85,7 @@ async def configure_async_client(
     schema: str = None,
     auth_token: str = None,
     force_recreate=False,
-    execute_timeout: int | float | None = 30,
+    execute_timeout: int | float = 30,
 ) -> Client:
     """Configure an async client for use with the Metamist GraphQL API"""
     global _async_client  # noqa: PLW0603

--- a/packages/metamist/src/metamist/graphql/__init__.py
+++ b/packages/metamist/src/metamist/graphql/__init__.py
@@ -81,7 +81,11 @@ def configure_sync_client(
 
 
 async def configure_async_client(
-    url: str = None, schema: str = None, auth_token: str = None, force_recreate=False
+    url: str = None,
+    schema: str = None,
+    auth_token: str = None,
+    force_recreate=False,
+    execute_timeout: int | float | None = 30,
 ) -> Client:
     """Configure an async client for use with the Metamist GraphQL API"""
     global _async_client  # noqa: PLW0603
@@ -102,7 +106,10 @@ async def configure_async_client(
         )
 
     _async_client = Client(
-        transport=transport, schema=schema, fetch_schema_from_transport=schema is None
+        transport=transport,
+        schema=schema,
+        fetch_schema_from_transport=schema is None,
+        execute_timeout=execute_timeout,
     )
     # await _async_client.connect_async()
     return _async_client

--- a/scripts/create_test_subset.py
+++ b/scripts/create_test_subset.py
@@ -719,6 +719,7 @@ def transfer_analyses(
                 existing_data, s.get('externalId'), sg.get('type')
             )
             existing_sgid = existing_sg.get('id') if existing_sg else None
+            copied_analysis_files = set()
             for analysis in sg['analyses']:
                 # Newer analyses store the path in the structured `outputs` field;
                 # older ones use the plain `output` string. Prefer the former.
@@ -727,6 +728,15 @@ def transfer_analyses(
                     if isinstance(analysis.get('outputs'), dict)
                     else None
                 ) or analysis['output']
+
+                if analysis_path in copied_analysis_files:
+                    # Avoid copying the same file multiple times if it was linked to multiple analyses
+                    logger.info(
+                        f'Skipping copy of analysis output file at {analysis_path} since it was already copied from another analysis'
+                    )
+                    continue
+                copied_analysis_files.add(analysis_path)
+
                 existing_analysis: dict = {}
                 if existing_sgid:
                     existing_analysis = get_existing_analysis(

--- a/scripts/duplicate_sequencing_group.py
+++ b/scripts/duplicate_sequencing_group.py
@@ -362,6 +362,11 @@ def get_unrecorded_analysis_files(
     else:
         source_bucket_name = f'cpg-{source_dataset}-main'
 
+    if new_dataset.endswith('-test'):
+        destination_bucket_name = f'cpg-{new_dataset}'
+    else:
+        destination_bucket_name = f'cpg-{new_dataset}-main'
+
     files_to_move = []
     for source_path_template in UNRECORDED_ANALYSIS_FILES + UNRECORDED_ANALYSIS_FOLDERS:
         source_path = source_path_template.format(
@@ -384,7 +389,7 @@ def get_unrecorded_analysis_files(
             file_paths = []  # File does not exist
 
         for source_path in file_paths:  # Rename and add to move list
-            new_path = source_path.replace(source_dataset, new_dataset).replace(
+            new_path = source_path.replace(source_bucket_name, destination_bucket_name).replace(
                 source_sequencing_group_id, new_sequencing_group_id
             )
             files_to_move.append((to_path(source_path), to_path(new_path)))

--- a/scripts/duplicate_sequencing_group.py
+++ b/scripts/duplicate_sequencing_group.py
@@ -389,9 +389,9 @@ def get_unrecorded_analysis_files(
             file_paths = []  # File does not exist
 
         for source_path in file_paths:  # Rename and add to move list
-            new_path = source_path.replace(source_bucket_name, destination_bucket_name).replace(
-                source_sequencing_group_id, new_sequencing_group_id
-            )
+            new_path = source_path.replace(
+                source_bucket_name, destination_bucket_name
+            ).replace(source_sequencing_group_id, new_sequencing_group_id)
             files_to_move.append((to_path(source_path), to_path(new_path)))
 
     return files_to_move


### PR DESCRIPTION
Increase the GQL async client default execute timeout and fix edge cases in the `create_test_subset` and `duplicate_sequencing_group` script s

## GQL async client
- Current timeout for the async client is 10 seconds which is ridiculously short. For samples with a number of assays and analyses this quickly triggers the timeout, e.g. https://batch.hail.populationgenomics.org.au/batches/1132974/jobs/1
- Changing this to 30s is a very minor and completely and backwards compatible change 

## create_test_subset.py 
- Only copy one of each unique analysis output to avoid cases where the same file is pointlessly copied and reheadered multiple times, e.g. in [this driver](https://batch.hail.populationgenomics.org.au/batches/1132984/jobs/1) and [submitted batch](https://batch.hail.populationgenomics.org.au/batches/1132986)

## duplicate_sequencing_group.py 
- Allow destination dataset to be a `-test` dataset - previously this was incompatible due to the find and replace of old dataset name with new dataset name when formulating the new file paths, leading to destination bucket paths like `cpg-dataset-test-main`, e.g. https://batch.hail.populationgenomics.org.au/batches/1132976/jobs/1
