### PR TITLE
Add CHX to SG.meta for RNAseq ingestion

### DIFF
--- a/packages/metamist/src/metamist/parser/generic_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_parser.py
@@ -1215,6 +1215,7 @@ class GenericParser(CloudHelper):
                     'sequencing_library',
                     'read_end_type',
                     'read_length',
+                    'chx',
                 )
             elif assay.meta.get('sequencing_technology') == 'long-read':
                 # lift all assay meta into the sequencing group meta for long-read


### PR DESCRIPTION
Simple one liner - when ingesting RNAseq data with the `parser`, expect the `chx` field to exist in the `assay.meta` and copy it into the `sg.meta` for easy access to this value