### PR TITLE
Enable non-hail jobs to show on page Billing Cost By Analysis.

### DIFF
--- a/db/python/tables/bq/billing_ar_batch.py
+++ b/db/python/tables/bq/billing_ar_batch.py
@@ -43,12 +43,11 @@ class BillingArBatchTable(BillingBaseTable):
         """
         _query = f"""
         SELECT
-            batch_id,
+            CASE WHEN batch_id IS NOT NULL THEN batch_id ELSE 'NA' END as batch_id,
             MIN(min_day) as start_day,
             MAX(max_day) as end_day
         FROM `{self.table_name}`
         WHERE ar_guid = @ar_guid
-        AND batch_id IS NOT NULL
         GROUP BY batch_id
         ORDER BY batch_id;
         """

--- a/db/python/tables/bq/billing_daily_extended.py
+++ b/db/python/tables/bq/billing_daily_extended.py
@@ -99,8 +99,9 @@ class BillingDailyExtendedTable(BillingBaseTable):
             -- get all data we need for aggregations in one go
             WITH d AS (
                     SELECT topic, ar_guid,
-                    CASE WHEN compute_category IS NULL AND batch_id IS NOT NULL THEN
-                    'hail batch' ELSE compute_category END AS category,
+                    CASE WHEN compute_category IS NULL AND batch_id IS NOT NULL THEN 'hail batch'
+                    ELSE CASE WHEN compute_category IS NULL THEN 'unknown'
+                    ELSE compute_category END END AS category,
                     batch_id, CAST(job_id AS INT) job_id,
                     sku, cost,
                     usage_start_time, usage_end_time, sequencing_group, stage, wdl_task_name, cromwell_sub_workflow_name, cromwell_workflow_id,


### PR DESCRIPTION
This small change enables jobs created by Seqera trial to show in metamist.
Billing was originally built around Hail Batch Ids, ar-guid were optional.
When transitioning to Seqera we would need to display jobs which have batchId null.