### PR TITLE
[SET-1184] Inconsistent sample_type filtering in create_cohort_from_criteria

### DIFF
--- a/db/python/layers/cohort.py
+++ b/db/python/layers/cohort.py
@@ -238,6 +238,10 @@ class CohortLayer(BaseLayer):
 
             _, samples = await self.sampt.query(sample_filter)
             sample_ids = [s.id for s in samples]
+            if not samples:
+                raise ValueError(
+                    'Cohort creation criteria resulted in no samples matching sample_type criteria.'
+                )
 
         sg_filter = get_sg_filter(
             projects=projects,

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -397,6 +397,25 @@ class TestCohortData(DbIsolatedTest):
         self.assertIn(self.sgB_raw, result.sequencing_group_ids)
 
     @run_as_sync
+    async def test_create_cohort_fails_when_no_matching_sample(self):
+        """Create cohort from a sample type with no matching samples"""
+        with self.assertRaises(ValueError):
+            await self.cohortl.create_cohort_from_criteria(
+                project_to_write=self.project_id,
+                description='Missing samples of type',
+                cohort_name='Missing samples of type cohort 1',
+                dry_run=False,
+                cohort_criteria=CohortCriteriaInternal(
+                    projects=[self.project_id],
+                    excluded_sgs_internal_raw=[self.sgA_raw],
+                    sg_technology=['short-read'],
+                    sg_platform=['illumina'],
+                    sg_type=['genome'],
+                    sample_type=['non_existent'],
+                ),
+            )
+
+    @run_as_sync
     async def test_create_duplicate_cohort(self):
         """Can't create cohorts with duplicate names"""
         _ = await self.cohortl.create_cohort_from_criteria(

--- a/test/test_cohort_status.py
+++ b/test/test_cohort_status.py
@@ -271,7 +271,7 @@ class TestCohortStatusGraphQL(DbIsolatedTest):
                     },
                     'cohortCriteria': {
                         'projects': [self.project_name],
-                        'sampleType': ['blood'],
+                        'sampleType': ['saliva'],
                     },
                 },
             )
@@ -368,7 +368,7 @@ class TestCohortStatusGraphQL(DbIsolatedTest):
                     },
                     'cohortCriteria': {
                         'projects': [self.project_name],
-                        'sampleType': ['blood'],
+                        'sampleType': ['saliva'],
                     },
                 },
             )


### PR DESCRIPTION
**Current behaviour** 
When creating a cohort using the **sample_type** criterion (optionally combined with other cohort criteria), if no samples match the requested sample_type, Metamist silently ignores the sample_type filter and applies only the remaining criteria to filter the SGs.

**Expected behaviour**
The created cohort should contain only SGs that satisfy both the requested sample_type and any other specified cohort criteria.

**Fix**
The API now validates the requested sample_type before creating the cohort. If no samples in the database match the specified sample_type, it returns an error instead of silently dropping the filter. 

For more details, See https://cpg-populationanalysis.atlassian.net/browse/SET-1184
