### PR TITLE
Revert "Allow internet ingress add uri" SET-1174

### DIFF
--- a/deploy/infra/server.py
+++ b/deploy/infra/server.py
@@ -57,9 +57,9 @@ def create_server_resources(
     cloud_run = gcp.cloudrunv2.Service(
         'metamist',
         name=f'metamist-{config.stack}',
-        ingress='INGRESS_TRAFFIC_ALL',
+        ingress='INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER',
         location=config.region,
-        default_uri_disabled=False,
+        default_uri_disabled=True,
         template=gcp.cloudrunv2.ServiceTemplateArgs(
             service_account=service_account.email,
             timeout='300s',


### PR DESCRIPTION
Reverts populationgenomics/metamist#1275

The way that the analysis runner currently communicates with metamist is an outdated and fragile way of connecting to the server. We will update to using the DNS instead. See [this slack thread](https://garvan.enterprise.slack.com/archives/C03FZL2EF24/p1783651118558749).
