### PR TITLE
SET-1185 Metamist individual-metadata-seqr API point throws Exception

### DIFF
--- a/db/python/tables/participant_phenotype.py
+++ b/db/python/tables/participant_phenotype.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 from typing import Any
 

--- a/db/python/tables/participant_phenotype.py
+++ b/db/python/tables/participant_phenotype.py
@@ -109,6 +109,6 @@ class ParticipantPhenotypeTable(DbBase):
             pid = row['participant_id']
             key = row['description']
             value = row['value']
-            formed_key_value_pairs[pid][key] = json.loads(value)
+            formed_key_value_pairs[pid][key] = value
 
         return formed_key_value_pairs


### PR DESCRIPTION
This is PR is fixing small bug in ParticipantPhenotypeTable.
In Postgres db, participant_phenotypes.value is stored as jsonb, not as the old mysql where it was text.
