### PR TITLE
Parser more flexible sample type

### DIFF
--- a/packages/metamist/src/metamist/parser/generic_metadata_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_metadata_parser.py
@@ -114,7 +114,7 @@ class GenericMetadataParser(GenericParser):
         # Default values
         default_reference_assembly_location: str | None = None,
         ora_reference_assembly_location: str | None = None,
-        default_sample_type: str | None = None,
+        default_sample_type: str | None = 'unknown',
         default_sequencing=DefaultSequencing(
             seq_type='genome', technology='short-read', platform='illumina'
         ),
@@ -277,16 +277,26 @@ class GenericMetadataParser(GenericParser):
         """Get internal cpg id from a row using get_sample_id and an api call"""
         return row.get(self.cpg_id_column, None)
 
+    def get_sample_type_from_row(self, row: SingleRow) -> str | None:
+        """Get sample type from row"""
+        if self.sample_type_column and self.sample_type_column in row:
+            value = row[self.sample_type_column]
+            if value:
+                return str(value).lower()
+        return self.default_sample_type
+
     def get_sample_type(self, row: GroupedRow) -> str:
         """Get sample type from row or default"""
-        value = (
-            row.get(self.sample_type_column, None)
-            or self.default_sample_type
-        )
-        value = value.lower()
-        if value:
-            return value
-        return None
+        if isinstance(row, dict):
+            return self.get_sample_type_from_row(row)
+        types = [
+            self.get_sample_type_from_row(r) for r in row
+        ]
+        if len(set(types)) > 1:
+            raise ValueError(
+                f'Conflicting sample types for sample {self.get_primary_sample_id(row[0])}: {types}'
+            )
+        return types[0] if types else self.default_sample_type
 
     def get_sequencing_types(self, row: GroupedRow) -> list[str]:
         """

--- a/packages/metamist/src/metamist/parser/generic_metadata_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_metadata_parser.py
@@ -55,6 +55,7 @@ and we want to achieve the following:
 python parse_generic_metadata.py \
     --project $dataset \
     --sample-name-column "Sample ID" \
+    --sample-type-column "unknown" \
     --reads-column "Fastqs" \
     --sample-meta-field-map "sample-collection-date" "collection_date" \
     --assay-meta-field "depth" \
@@ -81,6 +82,7 @@ class GenericMetadataParser(GenericParser):
         search_locations: list[str],
         # sample columns
         sample_primary_eid_column: str,
+        sample_type_column: str | None = None,
         sample_external_id_column_map: dict[str, str] | None = None,
         # Participant columns
         participant_primary_eid_column: str | None = None,
@@ -131,6 +133,7 @@ class GenericMetadataParser(GenericParser):
                 A list of locations to search for unqualified files in.
 
             sample_primary_eid_column (str): The name of the column containing the sample name.
+            sample_type_column (str | None, optional): The name of the column containing the sample type.
             sample_external_id_column_map (str | None, optional):
                 {column: eid_name} mapping for sample external_ids. This should NOT
                 include the sample_primary_eid_column.
@@ -221,6 +224,7 @@ class GenericMetadataParser(GenericParser):
 
         self.cpg_id_column = 'Internal CPG Sequencing Group ID'
         self.sample_primary_eid_column = sample_primary_eid_column
+        self.sample_type_column = sample_type_column
         self.sample_external_id_column_map = sample_external_id_column_map or {}
 
         # Participant columns
@@ -273,10 +277,15 @@ class GenericMetadataParser(GenericParser):
         """Get internal cpg id from a row using get_sample_id and an api call"""
         return row.get(self.cpg_id_column, None)
 
-    def get_sample_type(self, row: GroupedRow) -> str:  # noqa: ARG002
-        """Get sample type from row"""
-        if self.default_sample_type:
-            return self.default_sample_type
+    def get_sample_type(self, row: GroupedRow) -> str:
+        """Get sample type from row or default"""
+        value = (
+            row.get(self.sample_type_column, None)
+            or self.default_sample_type
+        )
+        value = value.lower()
+        if value:
+            return value
         return None
 
     def get_sequencing_types(self, row: GroupedRow) -> list[str]:
@@ -1066,7 +1075,7 @@ class GenericMetadataParser(GenericParser):
     multiple=True,
     help='Two arguments per listing, eg: --qc-meta-field "name-in-manifest" "name-in-analysis.meta"',
 )
-@click.option('--default-sample-type', default='blood')
+@click.option('--default-sample-type', default='unknown')
 @click.option(
     '--confirm', is_flag=True, help='Confirm with user input before updating server'
 )

--- a/packages/metamist/src/metamist/parser/generic_metadata_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_metadata_parser.py
@@ -55,7 +55,7 @@ and we want to achieve the following:
 python parse_generic_metadata.py \
     --project $dataset \
     --sample-name-column "Sample ID" \
-    --sample-type-column "unknown" \
+    --default-sample-type "unknown" \
     --reads-column "Fastqs" \
     --sample-meta-field-map "sample-collection-date" "collection_date" \
     --assay-meta-field "depth" \

--- a/packages/metamist/src/metamist/parser/generic_metadata_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_metadata_parser.py
@@ -287,8 +287,6 @@ class GenericMetadataParser(GenericParser):
 
     def get_sample_type(self, row: GroupedRow) -> str:
         """Get sample type from row or default"""
-        if isinstance(row, dict):
-            return self.get_sample_type_from_row(row)
         types = [
             self.get_sample_type_from_row(r) for r in row
         ]

--- a/packages/metamist/src/metamist/parser/generic_metadata_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_metadata_parser.py
@@ -287,9 +287,7 @@ class GenericMetadataParser(GenericParser):
 
     def get_sample_type(self, row: GroupedRow) -> str:
         """Get sample type from row or default"""
-        types = [
-            self.get_sample_type_from_row(r) for r in row
-        ]
+        types = [self.get_sample_type_from_row(r) for r in row]
         if len(set(types)) > 1:
             raise ValueError(
                 f'Conflicting sample types for sample {self.get_primary_sample_id(row[0])}: {types}'

--- a/packages/metamist/src/metamist/parser/generic_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_parser.py
@@ -504,7 +504,9 @@ class GenericParser(CloudHelper):
         self.default_sequencing = default_sequencing
         self.default_read_end_type: str | None = default_read_end_type
         self.default_read_length: str | int | None = default_read_length
-        self.default_sample_type: str | None = default_sample_type.lower() if default_sample_type else default_sample_type
+        self.default_sample_type: str | None = (
+            default_sample_type.lower() if default_sample_type else default_sample_type
+        )
         self.default_analysis_type: str | None = default_analysis_type
         self.default_analysis_status: str | None = default_analysis_status
 

--- a/packages/metamist/src/metamist/parser/generic_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_parser.py
@@ -504,7 +504,7 @@ class GenericParser(CloudHelper):
         self.default_sequencing = default_sequencing
         self.default_read_end_type: str | None = default_read_end_type
         self.default_read_length: str | int | None = default_read_length
-        self.default_sample_type: str | None = default_sample_type
+        self.default_sample_type: str | None = default_sample_type.lower() if default_sample_type else default_sample_type
         self.default_analysis_type: str | None = default_analysis_type
         self.default_analysis_status: str | None = default_analysis_status
 

--- a/packages/metamist/src/metamist/parser/generic_parser.py
+++ b/packages/metamist/src/metamist/parser/generic_parser.py
@@ -263,6 +263,8 @@ class ParsedSample:
             )
         self.external_sids = external_sids
 
+        if not sample_type:
+            raise ValueError(f'Sample type is required for sample {self.external_sids}')
         self.sample_type = sample_type
         self.meta = meta
 
@@ -474,7 +476,7 @@ class GenericParser(CloudHelper):
         path_prefix: str | None,
         search_paths: list[str],
         project: str,
-        default_sample_type: str | None = None,
+        default_sample_type: str | None = 'unknown',
         default_sequencing: DefaultSequencing = DefaultSequencing(),
         default_read_end_type: str | None = None,
         default_read_length: str | int | None = None,
@@ -788,12 +790,13 @@ class GenericParser(CloudHelper):
                 sg_details = {
                     'Participant': participant if participant else '',
                     'Sample': sample,
+                    'Sample Type': sg.sample.sample_type,
                     'Sequencing Type': sg.sequencing_type,
                     'Assays': sum(1 for a in sg.assays if not a.internal_id),
                 }
                 details.append(sg_details)
 
-        headers = ['Participant', 'Sample', 'Sequencing Type', 'Assays']
+        headers = ['Participant', 'Sample', 'Sample Type', 'Sequencing Type', 'Assays']
         table = list(list(detail.values()) for detail in details)  # noqa: C400
 
         print(tabulate(table, headers=headers, tablefmt='grid'))

--- a/packages/metamist/src/metamist/parser/sample_file_map_parser.py
+++ b/packages/metamist/src/metamist/parser/sample_file_map_parser.py
@@ -30,7 +30,7 @@ KeyMap = {
         'agha_study_id',
     ],
     SAMPLE_ID_COL_NAME: ['sample_id', 'sample', 'sample id'],
-    SAMPLE_TYPE_COL_NAME: ['sample_type', 'sample type', 'tissue', 'tissue_type', 'tissue type'],
+    SAMPLE_TYPE_COL_NAME: ['sample_type', 'sample type', 'sampletype'],
     READS_COL_NAME: ['filename', 'filenames', 'files', 'file'],
     SEQ_TYPE_COL_NAME: ['type', 'types', 'sequencing type', 'sequencing_type'],
     SEQ_FACILITY_COL_NAME: ['facility', 'sequencing facility', 'sequencing_facility'],

--- a/packages/metamist/src/metamist/parser/sample_file_map_parser.py
+++ b/packages/metamist/src/metamist/parser/sample_file_map_parser.py
@@ -9,6 +9,7 @@ from metamist.parser.generic_parser import DefaultSequencing, SingleRow
 
 PARTICIPANT_COL_NAME = 'individual_id'
 SAMPLE_ID_COL_NAME = 'sample_id'
+SAMPLE_TYPE_COL_NAME = 'sample_type'
 READS_COL_NAME = 'filenames'
 SEQ_TYPE_COL_NAME = 'type'
 CHECKSUM_COL_NAME = 'checksum'
@@ -29,6 +30,7 @@ KeyMap = {
         'agha_study_id',
     ],
     SAMPLE_ID_COL_NAME: ['sample_id', 'sample', 'sample id'],
+    SAMPLE_TYPE_COL_NAME: ['sample_type', 'sample type', 'tissue', 'tissue_type', 'tissue type'],
     READS_COL_NAME: ['filename', 'filenames', 'files', 'file'],
     SEQ_TYPE_COL_NAME: ['type', 'types', 'sequencing type', 'sequencing_type'],
     SEQ_FACILITY_COL_NAME: ['facility', 'sequencing facility', 'sequencing_facility'],
@@ -69,7 +71,8 @@ The SampleFileMapParser is used for parsing files with format:
 - ['Individual ID']
 - 'Sample ID'
 - 'Filenames'
-- ['Type']
+- ['Sequencing Type']
+- ['Sample Type']
 - 'Checksum'
 - ['Sequencing Facility'] - needed for exome & rna samples
 - ['Library Type'] - needed for exome & rna samples
@@ -87,11 +90,11 @@ Example with optional columns
 Note: Individual ID column must contain values in every row
 Note: Any missing values in Type will default to the default_sequencing_type ('genome')
 e.g.
-    Individual ID	Sample ID	    Filenames	                                                                    Type
-    Demeter	        sample_id001	sample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz	            WGS
-    Demeter	        sample_id001	sample_id001.exome.filename-R1.fastq.gz,sample_id001.exome.filename-R2.fastq.gz	WES
-    Apollo	        sample_id002	sample_id002.filename-R1.fastq.gz	                                            WGS
-    Apollo	        sample_id002	sample_id002.filename-R2.fastq.gz	                                            WGS
+    Individual ID	Sample ID	    Filenames	                                                                    Sequencing Type  Sample Type
+    Demeter	        sample_id001	sample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz	            WGS              blood
+    Demeter	        sample_id001	sample_id001.exome.filename-R1.fastq.gz,sample_id001.exome.filename-R2.fastq.gz	WES              saliva
+    Apollo	        sample_id002	sample_id002.filename-R1.fastq.gz	                                            WGS              skin
+    Apollo	        sample_id002	sample_id002.filename-R2.fastq.gz	                                            WGS              muscle
     Athena	        sample_id003	sample_id003.filename-R1.fastq.gz
     Athena	        sample_id003	sample_id003.filename-R2.fastq.gz
     Apollo	        sample_id004	sample_id004.filename-R1.fastq.gz
@@ -99,9 +102,9 @@ e.g.
 
 Example with optional columns for RNA samples
 e.g.
-    Individual ID	Sample ID	    Filenames	                                                            Type        Facility  Library    End Type  Read Length
-    Hera            sample_id001	sample_id001_TSStrtRNA_R1.fastq.gz,sample_id001_TSStrtRNA_R2.fastq.gz	totalrna    VCGS      TSStrtRNA  paired    151
-    Hestia          sample_id002	sample_id002_TSStrmRNA_R1.fastq.gz,sample_id002_TSStrmRNA_R2.fastq.gz	polyarna    VCGS      TSStrmRNA  paired    151
+    Individual ID	Sample ID	    Filenames	                                                            Sequencing Type  Sample Type     Facility  Library    End Type  Read Length
+    Hera            sample_id001	sample_id001_TSStrtRNA_R1.fastq.gz,sample_id001_TSStrtRNA_R2.fastq.gz	totalrna         blood           VCGS      TSStrtRNA  paired    151
+    Hestia          sample_id002	sample_id002_TSStrmRNA_R1.fastq.gz,sample_id002_TSStrmRNA_R2.fastq.gz	polyarna         muscle          VCGS      TSStrmRNA  paired    151
 
 
 This format is useful for ingesting filenames for the seqr loading pipeline
@@ -119,7 +122,7 @@ class SampleFileMapParser(GenericMetadataParser):
         self,
         search_locations: list[str],
         project: str,
-        default_sample_type='blood',
+        default_sample_type='unknown',
         default_sequencing=DefaultSequencing(
             seq_type='genome', technology='short-read', platform='illumina'
         ),
@@ -136,6 +139,7 @@ class SampleFileMapParser(GenericMetadataParser):
             project=project,
             participant_primary_eid_column=PARTICIPANT_COL_NAME,
             sample_primary_eid_column=SAMPLE_ID_COL_NAME,
+            sample_type_column=SAMPLE_TYPE_COL_NAME,
             reads_column=READS_COL_NAME,
             checksum_column=CHECKSUM_COL_NAME,
             seq_type_column=SEQ_TYPE_COL_NAME,
@@ -176,7 +180,7 @@ class SampleFileMapParser(GenericMetadataParser):
     '--project',
     help='The metamist project to import manifest into',
 )
-@click.option('--default-sample-type', default='blood')
+@click.option('--default-sample-type', default='unknown')
 @click.option('--default-sequencing-type', default='wgs')
 @click.option('--default-sequencing-technology', default='short-read')
 @click.option('--default-sequencing-facility', default=None)
@@ -224,7 +228,7 @@ async def main(  # noqa: PLR0913
     manifests,
     search_path: list[str],
     project,
-    default_sample_type='blood',
+    default_sample_type='unknown',
     default_sequencing_type='genome',
     default_sequencing_technology='short-read',
     default_sequencing_platform='illumina',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -46,7 +46,7 @@ def _get_basic_participant_to_upsert():
             SampleUpsertInternal(
                 external_ids={PRIMARY_EXTERNAL_ORG: 'sample_id001'},
                 meta={},
-                type='blood',
+                type='unknown',
                 sequencing_groups=[
                     SequencingGroupUpsertInternal(
                         type='genome',
@@ -1110,6 +1110,119 @@ class TestParseGenericMetadata(DbIsolatedTest):
             str(ctx.exception),
         )
 
+    @run_as_sync
+    @patch('metamist.parser.generic_parser.query_async')
+    async def test_rows_with_sample_type(self, mock_graphql_query):
+        """Test importing a single row with a sample type column"""
+        mock_graphql_query.side_effect = self.run_graphql_query_async
+
+        rows = [
+            'Individual ID\tSample ID\tFilenames\tType\tSample Type',
+            'Demeter\tsample_id001\tsample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz\tWGS\tblood',
+            'Demeter\tsample_id001\tsample_id001.exome.filename-R1.fastq.gz,sample_id001.exome.filename-R2.fastq.gz\tWES\tBlood',
+            'Apollo\tsample_id002\tsample_id002.filename-R1.fastq.gz\tWGS\tSaliva',
+            'Apollo\tsample_id002\tsample_id002.filename-R2.fastq.gz\tWGS\tsaliva',
+            'Athena\tsample_id003\tsample_id003.filename-R1.fastq.gz\tWGS\tBlood',
+            'Athena\tsample_id003\tsample_id003.filename-R2.fastq.gz\tWGS\tblood',
+            'Apollo\tsample_id004\tsample_id004.filename-R1.fastq.gz\tWGS\tunknown',
+            'Apollo\tsample_id004\tsample_id004.filename-R2.fastq.gz\tWGS\tunknown',
+        ]
+
+        parser = GenericMetadataParser(
+            search_locations=[],
+            participant_primary_eid_column='Individual ID',
+            sample_primary_eid_column='Sample ID',
+            sample_type_column='Sample Type',
+            reads_column='Filenames',
+            seq_type_column='Type',
+            participant_meta_map={},
+            sample_meta_map={},
+            assay_meta_map={},
+            qc_meta_map={},
+            # doesn't matter, we're going to mock the call anyway
+            project=self.project_name,
+        )
+
+        parser.skip_checking_gcs_objects = True
+        parser.filename_map = {
+            'sample_id001.filename-R1.fastq.gz': '/path/to/sample_id001.filename-R1.fastq.gz',
+            'sample_id001.filename-R2.fastq.gz': '/path/to/sample_id001.filename-R2.fastq.gz',
+            'sample_id001.exome.filename-R1.fastq.gz': '/path/to/sample_id001.exome.filename-R1.fastq.gz',
+            'sample_id001.exome.filename-R2.fastq.gz': '/path/to/sample_id001.exome.filename-R2.fastq.gz',
+            'sample_id002.filename-R1.fastq.gz': '/path/to/sample_id002.filename-R1.fastq.gz',
+            'sample_id002.filename-R2.fastq.gz': '/path/to/sample_id002.filename-R2.fastq.gz',
+            'sample_id003.filename-R1.fastq.gz': '/path/to/sample_id003.filename-R1.fastq.gz',
+            'sample_id003.filename-R2.fastq.gz': '/path/to/sample_id003.filename-R2.fastq.gz',
+            'sample_id004.filename-R1.fastq.gz': '/path/to/sample_id004.filename-R1.fastq.gz',
+            'sample_id004.filename-R2.fastq.gz': '/path/to/sample_id004.filename-R2.fastq.gz',
+        }
+
+        # Call generic parser
+        file_contents = '\n'.join(rows)
+        summary, prows = await parser.parse_manifest(
+            StringIO(file_contents), delimiter='\t', dry_run=True
+        )
+
+        participants: list[ParsedParticipant] = prows
+
+        self.assertEqual(3, summary.participants.insert)
+        self.assertEqual(0, summary.participants.update)
+        self.assertEqual(4, summary.samples.insert)
+        self.assertEqual(0, summary.samples.update)
+        self.assertEqual(5, summary.assays.insert)
+        self.assertEqual(0, summary.assays.update)
+        self.assertEqual(0, summary.analyses.insert)
+
+        expected_assay_dict = {
+            'reads': [
+                {
+                    'basename': 'sample_id001.filename-R1.fastq.gz',
+                    'checksum': None,
+                    'class': 'File',
+                    'location': '/path/to/sample_id001.filename-R1.fastq.gz',
+                    'size': None,
+                    'datetime_added': None,
+                },
+                {
+                    'basename': 'sample_id001.filename-R2.fastq.gz',
+                    'checksum': None,
+                    'class': 'File',
+                    'location': '/path/to/sample_id001.filename-R2.fastq.gz',
+                    'size': None,
+                    'datetime_added': None,
+                },
+            ],
+            'reads_type': 'fastq',
+            'sequencing_platform': 'illumina',
+            'sequencing_technology': 'short-read',
+            'sequencing_type': 'genome',
+        }
+        assay = participants[0].samples[0].sequencing_groups[0].assays[0]
+        self.maxDiff = None
+        self.assertDictEqual(expected_assay_dict, assay.meta)
+
+        # Check that both of Demeter's assays are there
+        self.assertEqual(participants[0].primary_external_id, 'Demeter')
+        self.assertEqual(len(participants[0].samples), 1)
+        self.assertEqual(len(participants[0].samples[0].sequencing_groups), 2)
+
+    @run_as_sync
+    @patch('metamist.parser.generic_parser.query_async')
+    async def test_parser_with_default_sample_type(self, mock_graphql_query):
+        """Test importing a single row without a sample type column but with the default sample type set"""
+        pass
+
+    @run_as_sync
+    @patch('metamist.parser.generic_parser.query_async')
+    async def test_parser_with_missing_sample_type(self, mock_graphql_query):
+        """Test importing a single row without a sample type column and no default sample type set"""
+        pass
+
+    @run_as_sync
+    @patch('metamist.parser.generic_parser.query_async')
+    async def test_rows_with_bad_sample_type(self, mock_graphql_query):
+        """Test importing a single row with a bad sample type"""
+        pass
 
 class FastqPairMatcher(unittest.TestCase):
     """Test Fastq pair matching logic explictly"""

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
 
-from metamist.apis import EnumsApi
 from metamist.graphql import configure_sync_client, validate
 from metamist.parser.generic_metadata_parser import (
     DefaultSequencing,
@@ -1296,6 +1295,7 @@ class TestParseGenericMetadata(DbIsolatedTest):
             await parser.parse_manifest(
                 StringIO(file_contents), delimiter='\t', dry_run=True
             )
+
 
 class FastqPairMatcher(unittest.TestCase):
     """Test Fastq pair matching logic explictly"""

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
 
+from metamist.apis import EnumsApi
 from metamist.graphql import configure_sync_client, validate
 from metamist.parser.generic_metadata_parser import (
     DefaultSequencing,
@@ -46,7 +47,7 @@ def _get_basic_participant_to_upsert():
             SampleUpsertInternal(
                 external_ids={PRIMARY_EXTERNAL_ORG: 'sample_id001'},
                 meta={},
-                type='unknown',
+                type='blood',
                 sequencing_groups=[
                     SequencingGroupUpsertInternal(
                         type='genome',
@@ -1119,7 +1120,7 @@ class TestParseGenericMetadata(DbIsolatedTest):
         rows = [
             'Individual ID\tSample ID\tFilenames\tType\tSample Type',
             'Demeter\tsample_id001\tsample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz\tWGS\tblood',
-            'Demeter\tsample_id001\tsample_id001.exome.filename-R1.fastq.gz,sample_id001.exome.filename-R2.fastq.gz\tWES\tBlood',
+            'Demeter\tsample_id001\tsample_id001.exome.filename-R1.fastq.gz,sample_id001.exome.filename-R2.fastq.gz\tWES\tblood',
             'Apollo\tsample_id002\tsample_id002.filename-R1.fastq.gz\tWGS\tSaliva',
             'Apollo\tsample_id002\tsample_id002.filename-R2.fastq.gz\tWGS\tsaliva',
             'Athena\tsample_id003\tsample_id003.filename-R1.fastq.gz\tWGS\tBlood',
@@ -1159,70 +1160,142 @@ class TestParseGenericMetadata(DbIsolatedTest):
 
         # Call generic parser
         file_contents = '\n'.join(rows)
-        summary, prows = await parser.parse_manifest(
+        _, prows = await parser.parse_manifest(
             StringIO(file_contents), delimiter='\t', dry_run=True
         )
 
         participants: list[ParsedParticipant] = prows
 
-        self.assertEqual(3, summary.participants.insert)
-        self.assertEqual(0, summary.participants.update)
-        self.assertEqual(4, summary.samples.insert)
-        self.assertEqual(0, summary.samples.update)
-        self.assertEqual(5, summary.assays.insert)
-        self.assertEqual(0, summary.assays.update)
-        self.assertEqual(0, summary.analyses.insert)
-
-        expected_assay_dict = {
-            'reads': [
-                {
-                    'basename': 'sample_id001.filename-R1.fastq.gz',
-                    'checksum': None,
-                    'class': 'File',
-                    'location': '/path/to/sample_id001.filename-R1.fastq.gz',
-                    'size': None,
-                    'datetime_added': None,
-                },
-                {
-                    'basename': 'sample_id001.filename-R2.fastq.gz',
-                    'checksum': None,
-                    'class': 'File',
-                    'location': '/path/to/sample_id001.filename-R2.fastq.gz',
-                    'size': None,
-                    'datetime_added': None,
-                },
-            ],
-            'reads_type': 'fastq',
-            'sequencing_platform': 'illumina',
-            'sequencing_technology': 'short-read',
-            'sequencing_type': 'genome',
-        }
-        assay = participants[0].samples[0].sequencing_groups[0].assays[0]
-        self.maxDiff = None
-        self.assertDictEqual(expected_assay_dict, assay.meta)
-
-        # Check that both of Demeter's assays are there
-        self.assertEqual(participants[0].primary_external_id, 'Demeter')
-        self.assertEqual(len(participants[0].samples), 1)
-        self.assertEqual(len(participants[0].samples[0].sequencing_groups), 2)
+        # Check that the participant sample types are set correctly
+        self.assertEqual(participants[0].samples[0].sample_type, 'blood')
+        self.assertEqual(participants[1].samples[0].sample_type, 'saliva')
+        self.assertEqual(participants[1].samples[1].sample_type, 'unknown')
+        self.assertEqual(participants[2].samples[0].sample_type, 'blood')
 
     @run_as_sync
     @patch('metamist.parser.generic_parser.query_async')
     async def test_parser_with_default_sample_type(self, mock_graphql_query):
         """Test importing a single row without a sample type column but with the default sample type set"""
-        pass
+        mock_graphql_query.side_effect = self.run_graphql_query_async
+
+        rows = [
+            'Individual ID\tSample ID\tFilenames\tType',
+            'Demeter\tsample_id001\tsample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz\tWGS',
+        ]
+
+        parser = GenericMetadataParser(
+            search_locations=[],
+            participant_primary_eid_column='Individual ID',
+            sample_primary_eid_column='Sample ID',
+            default_sample_type='unknown',
+            reads_column='Filenames',
+            seq_type_column='Type',
+            participant_meta_map={},
+            sample_meta_map={},
+            assay_meta_map={},
+            qc_meta_map={},
+            # doesn't matter, we're going to mock the call anyway
+            project=self.project_name,
+        )
+
+        parser.skip_checking_gcs_objects = True
+        parser.filename_map = {
+            'sample_id001.filename-R1.fastq.gz': '/path/to/sample_id001.filename-R1.fastq.gz',
+            'sample_id001.filename-R2.fastq.gz': '/path/to/sample_id001.filename-R2.fastq.gz',
+        }
+
+        # Call generic parser
+        file_contents = '\n'.join(rows)
+        _, prows = await parser.parse_manifest(
+            StringIO(file_contents), delimiter='\t', dry_run=True
+        )
+
+        participants: list[ParsedParticipant] = prows
+
+        # Check that the participant sample types are set correctly
+        self.assertEqual(participants[0].samples[0].sample_type, 'unknown')
 
     @run_as_sync
     @patch('metamist.parser.generic_parser.query_async')
     async def test_parser_with_missing_sample_type(self, mock_graphql_query):
         """Test importing a single row without a sample type column and no default sample type set"""
-        pass
+        mock_graphql_query.side_effect = self.run_graphql_query_async
+
+        rows = [
+            'Individual ID\tSample ID\tFilenames\tType',
+            'Demeter\tsample_id001\tsample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz\tWGS',
+        ]
+
+        parser = GenericMetadataParser(
+            search_locations=[],
+            participant_primary_eid_column='Individual ID',
+            sample_primary_eid_column='Sample ID',
+            default_sample_type=None,
+            sample_type_column=None,
+            reads_column='Filenames',
+            seq_type_column='Type',
+            participant_meta_map={},
+            sample_meta_map={},
+            assay_meta_map={},
+            qc_meta_map={},
+            # doesn't matter, we're going to mock the call anyway
+            project=self.project_name,
+        )
+
+        parser.skip_checking_gcs_objects = True
+        parser.filename_map = {
+            'sample_id001.filename-R1.fastq.gz': '/path/to/sample_id001.filename-R1.fastq.gz',
+            'sample_id001.filename-R2.fastq.gz': '/path/to/sample_id001.filename-R2.fastq.gz',
+        }
+
+        # Call generic parser, should break as sample type will be None and no default is set
+        file_contents = '\n'.join(rows)
+        with self.assertRaises(ValueError):
+            await parser.parse_manifest(
+                StringIO(file_contents), delimiter='\t', dry_run=True
+            )
 
     @run_as_sync
     @patch('metamist.parser.generic_parser.query_async')
-    async def test_rows_with_bad_sample_type(self, mock_graphql_query):
-        """Test importing a single row with a bad sample type"""
-        pass
+    async def test_rows_with_too_many_sample_types(self, mock_graphql_query):
+        """Test importing rows for a sample with multiple conflicting sample types"""
+        mock_graphql_query.side_effect = self.run_graphql_query_async
+
+        rows = [
+            'Individual ID\tSample ID\tFilenames\tType\tSample Type',
+            'Demeter\tsample_id001\tsample_id001.filename-R1.fastq.gz,sample_id001.filename-R2.fastq.gz\tWGS\tblood',
+            'Demeter\tsample_id001\tsample_id001.filename2-R1.fastq.gz,sample_id001.filename2-R2.fastq.gz\tWGS\tsaliva',
+        ]
+
+        parser = GenericMetadataParser(
+            search_locations=[],
+            participant_primary_eid_column='Individual ID',
+            sample_primary_eid_column='Sample ID',
+            sample_type_column='Sample Type',
+            reads_column='Filenames',
+            seq_type_column='Type',
+            participant_meta_map={},
+            sample_meta_map={},
+            assay_meta_map={},
+            qc_meta_map={},
+            # doesn't matter, we're going to mock the call anyway
+            project=self.project_name,
+        )
+
+        parser.skip_checking_gcs_objects = True
+        parser.filename_map = {
+            'sample_id001.filename-R1.fastq.gz': '/path/to/sample_id001.filename-R1.fastq.gz',
+            'sample_id001.filename-R2.fastq.gz': '/path/to/sample_id001.filename-R2.fastq.gz',
+            'sample_id001.filename2-R1.fastq.gz': '/path/to/sample_id001.filename2-R1.fastq.gz',
+            'sample_id001.filename2-R2.fastq.gz': '/path/to/sample_id001.filename2-R2.fastq.gz',
+        }
+
+        # Call parse_manifest, should break as multiple sample types are defined for the same sample
+        file_contents = '\n'.join(rows)
+        with self.assertRaises(ValueError):
+            await parser.parse_manifest(
+                StringIO(file_contents), delimiter='\t', dry_run=True
+            )
 
 class FastqPairMatcher(unittest.TestCase):
     """Test Fastq pair matching logic explictly"""


### PR DESCRIPTION
Updating the generic parser / generic metadata parser with added flexibility for sample type

- Set default sample type to 'unknown' (previously 'blood' or None)
- Allowing flexible sample type ingestion using a column in the sample file map manifest (like how sequencing type works)
- Forbid `sample_type = None` - users must either provide a populated `Sample Type` column in their manifest and set it when instantiating the parser OR set the `default_sample_type` value when instantiating the parser